### PR TITLE
table refresh on delete bugfix

### DIFF
--- a/shanoir-ng-front/src/app/shared/components/entity/entity-list.browser.component.abstract.ts
+++ b/shanoir-ng-front/src/app/shared/components/entity/entity-list.browser.component.abstract.ts
@@ -41,6 +41,6 @@ export abstract class BrowserPaginEntityListComponent<T extends Entity> extends 
     }
 
     private instanceOfEntity(obj: any): boolean {
-        return obj.id && obj.create && obj.delete && obj.edit;
+        return obj.id && obj.create && obj.delete && obj.update;
     }
 }


### PR DESCRIPTION
table was not refreshing after delete in browser-side paging lists