### PR TITLE
update existing user_study on study update

### DIFF
--- a/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/StudyServiceImpl.java
+++ b/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/StudyServiceImpl.java
@@ -376,6 +376,14 @@ public class StudyServiceImpl implements StudyService {
 				// Add link study/user
 				studyUser.setStudyId(studyDb.getId());
 				studyDb.getStudyUserList().add(studyUser);
+			} else {
+				for (final StudyUser studyUserDb : studyUserDbList) {
+					if (studyUserDb.getId() == studyUser.getId()) {
+						studyUserDb.setReceiveAnonymizationReport(studyUserDb.isReceiveAnonymizationReport());
+						studyUserDb.setReceiveNewImportReport(studyUser.isReceiveNewImportReport());
+						studyUserDb.setStudyUserType(studyUser.getStudyUserType());
+					}
+				}
 			}
 		}
 		for (final StudyUser studyUserDb : studyUserDbList) {


### PR DESCRIPTION
Fixes #59 
I set @michaelkain  as reviewer because he said that the creation of a new study-user might be buggy as well. But I think this is an old behaviour that has been fixed some time ago. Here I just fixed the update of an existing study-user (e.g. when changing a study-user from IS_RESPONSIBLE to CAN_SEE_AND...)