### PR TITLE
MS Datasets: c-store and wado-uri introduced + bug fixes

### DIFF
--- a/docker-compose/datasets/Dockerfile
+++ b/docker-compose/datasets/Dockerfile
@@ -12,6 +12,15 @@
 
 FROM openjdk:8-jdk-alpine
 
+# Installation of dcm4che to manage the store-scu into the PACS
+# dcm4che3, used last version 5.21.0 as available on the 2020-02-14
+# https://sourceforge.net/projects/dcm4che/files/dcm4che3/
+RUN wget -O dcm4che-5.21.0-bin.zip http://downloads.sourceforge.net/project/dcm4che/dcm4che3/5.21.0/dcm4che-5.21.0-bin.zip
+RUN unzip dcm4che-5.21.0-bin.zip
+
+# take care of path
+ENV PATH /dcm4che-5.21.0/bin:$PATH
+
 RUN mkdir -pv /var/log/shanoir-ng-logs
 ADD shanoir-ng-datasets.jar shanoir-ng-datasets.jar
 

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/controler/DatasetAcquisitionApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/controler/DatasetAcquisitionApiController.java
@@ -18,6 +18,8 @@ import javax.validation.Valid;
 
 import org.shanoir.ng.importer.dto.ImportJob;
 import org.shanoir.ng.importer.service.ImporterService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -31,14 +33,24 @@ import io.swagger.annotations.ApiParam;
 @Controller
 public class DatasetAcquisitionApiController implements DatasetAcquisitionApi {
 
+	private static final Logger LOG = LoggerFactory.getLogger(DatasetAcquisitionApiController.class);
+	
 	@Autowired
 	private ImporterService importerService;
 
 	public ResponseEntity<Void> createNewDatasetAcquisition(
 			@ApiParam(value = "DatasetAcquisition to create", required = true) @Valid @RequestBody ImportJob importJob) {
-		importerService.setImportJob(importJob);
-		importerService.createAllDatasetAcquisition();
-		importerService.cleanTempFiles(importJob.getWorkFolder());
+		try {
+			long startTime = System.currentTimeMillis();
+			importerService.createAllDatasetAcquisition(importJob);
+		    long endTime = System.currentTimeMillis();
+		    long duration = (endTime - startTime);
+		    LOG.info("Creation of dataset acquisition required " + duration + " millis.");
+		} catch (Exception e) {
+			return new ResponseEntity<Void>(HttpStatus.INTERNAL_SERVER_ERROR);
+		} finally {
+			importerService.cleanTempFiles(importJob.getWorkFolder());			
+		}
 		return new ResponseEntity<Void>(HttpStatus.OK);
 	}
 

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/DatasetAcquisitionContext.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/DatasetAcquisitionContext.java
@@ -52,7 +52,7 @@ public class DatasetAcquisitionContext implements DatasetAcquisitionStrategy {
 	}
 
 	@Override
-	public DatasetAcquisition generateDatasetAcquisitionForSerie(Serie serie, int rank, ImportJob importJob) {
+	public DatasetAcquisition generateDatasetAcquisitionForSerie(Serie serie, int rank, ImportJob importJob) throws Exception {
 		if (datasetAcquisitionStrategy != null) {
 			return datasetAcquisitionStrategy.generateDatasetAcquisitionForSerie(serie, rank, importJob);
 		}

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/DicomPersisterService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/DicomPersisterService.java
@@ -14,6 +14,7 @@
 
 package org.shanoir.ng.importer.service;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,37 +22,77 @@ import org.shanoir.ng.importer.dto.Dataset;
 import org.shanoir.ng.importer.dto.DatasetFile;
 import org.shanoir.ng.importer.dto.ExpressionFormat;
 import org.shanoir.ng.importer.dto.Serie;
+import org.shanoir.ng.shared.exception.ShanoirException;
 import org.shanoir.ng.shared.service.DicomServiceApi;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
 
+/**
+ * The DicomPersisterService sends DICOM images to the PACS for their permanent
+ * storage in the PACS.
+ * 
+ * According to the paper: Comparative performance investigation of DICOM
+ * C-STORE and DICOM HTTP-based requests
+ * https://www.researchgate.net/publication/270659008_Comparative_performance_investigation_of_DICOM_C-STORE_and_DICOM_HTTP-based_requests
+ * the STOW is much more efficient in general than the C-STORE.
+ * 
+ * My tests showed, that sending 160 images with stow-rs took 4 seconds and
+ * sending the same 160 images with c-store took 3 seconds.
+ * 
+ * @author mkain
+ *
+ */
 @Service
 @Scope("prototype")
 public class DicomPersisterService {
 
+	@Value("${dcm4chee-arc.dicom.web}")
+	private boolean dicomWeb;
 
 	@Autowired
 	@Qualifier("stowrs")
-	DicomServiceApi dicomServiceApi;
-	
-	public void persistAllForSerie(Serie serie) {
-		
+	DicomServiceApi stowRsService;
+
+	@Autowired
+	@Qualifier("cstore")
+	DicomServiceApi cStoreService;
+
+	/**
+	 * This method reads the datasets for each serie from the json (String), gets
+	 * the dicom expression format and sends the images to the PACS.
+	 * 
+	 * @param serie
+	 * @throws Exception
+	 */
+	public void persistAllForSerie(Serie serie) throws Exception {
 		if (serie != null) {
-			List<String> dcmFilesToSendToPacs = new ArrayList<String>();
 			for (Dataset dataset : serie.getDatasets()) {
 				for (ExpressionFormat expressionFormat : dataset.getExpressionFormats()) {
 					if (expressionFormat.getType().equals("dcm")) {
-						for (DatasetFile datasetFile : expressionFormat.getDatasetFiles()) {
-							if (datasetFile.getPath() != null && !datasetFile.getPath().isEmpty()) {
-								dcmFilesToSendToPacs.add(datasetFile.getPath());								
+						List<DatasetFile> datasetFiles = expressionFormat.getDatasetFiles();
+						if (datasetFiles != null && !datasetFiles.isEmpty()) {
+							DatasetFile firstDatasetFile = datasetFiles.get(0);
+							if (firstDatasetFile.getPath() != null && !firstDatasetFile.getPath().isEmpty()) {
+								File firstDicomFile = new File(firstDatasetFile.getPath());
+								File directoryWithDicomFiles = firstDicomFile.getParentFile();
+								if (dicomWeb) {
+									stowRsService.sendDicomFilesToPacs(directoryWithDicomFiles);
+								} else {
+									cStoreService.sendDicomFilesToPacs(directoryWithDicomFiles);
+								}								
+							} else {
+								throw new ShanoirException("Send Dicoms to Pacs: DatasetFile with empty path found.");
 							}
+						} else {
+							throw new ShanoirException("Send Dicoms to Pacs: DatasetFiles null or empty.");
 						}
 					}
 				}
 			}
-			dicomServiceApi.storeDcmFiles(dcmFilesToSendToPacs);
 		}
 	}
+
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/strategies/dataset/DatasetStrategy.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/strategies/dataset/DatasetStrategy.java
@@ -36,9 +36,9 @@ import org.shanoir.ng.importer.dto.Serie;
 
 public interface DatasetStrategy<T extends org.shanoir.ng.dataset.model.Dataset> {
 
-	DatasetsWrapper<T> generateDatasetsForSerie(Attributes dicomAttributes, Serie serie, ImportJob importJob);
+	DatasetsWrapper<T> generateDatasetsForSerie(Attributes dicomAttributes, Serie serie, ImportJob importJob) throws Exception;
 
-	T generateSingleDataset(Attributes dicomAttributes, Serie serie, Dataset dataset, int datasetIndex,	ImportJob importJob);
+	T generateSingleDataset(Attributes dicomAttributes, Serie serie, Dataset dataset, int datasetIndex,	ImportJob importJob) throws Exception;
 
 	String computeDatasetName(String name, int index);
 

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/strategies/dataset/MrDatasetStrategy.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/strategies/dataset/MrDatasetStrategy.java
@@ -14,6 +14,7 @@
 
 package org.shanoir.ng.importer.strategies.dataset;
 
+import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -67,7 +68,7 @@ public class MrDatasetStrategy implements DatasetStrategy<MrDataset> {
 	
 	@Override
 	public DatasetsWrapper<MrDataset> generateDatasetsForSerie(Attributes dicomAttributes, Serie serie,
-			ImportJob importJob) {
+			ImportJob importJob) throws Exception {
 		
 		DatasetsWrapper<MrDataset> datasetWrapper = new DatasetsWrapper<MrDataset>();
 		/**
@@ -119,7 +120,7 @@ public class MrDatasetStrategy implements DatasetStrategy<MrDataset> {
 	 */
 	@Override
 	public MrDataset generateSingleDataset(Attributes dicomAttributes, Serie serie, Dataset dataset, int datasetIndex,
-			ImportJob importJob) {
+			ImportJob importJob) throws Exception {
 		MrDataset mrDataset = new MrDataset();
 		mrDataset.setCreationDate(serie.getSeriesDate());
 		mrDataset.setDiffusionGradients(dataset.getDiffusionGradients());

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/strategies/datasetacquisition/DatasetAcquisitionStrategy.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/strategies/datasetacquisition/DatasetAcquisitionStrategy.java
@@ -34,6 +34,6 @@ import org.shanoir.ng.importer.dto.Serie;
 public interface DatasetAcquisitionStrategy {
 	
 	// Create a new dataset acquisition 
-	DatasetAcquisition generateDatasetAcquisitionForSerie(Serie serie, int rank, ImportJob importJob);
+	DatasetAcquisition generateDatasetAcquisitionForSerie(Serie serie, int rank, ImportJob importJob) throws Exception;
 
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/strategies/datasetacquisition/MrDatasetAcquisitionStrategy.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/strategies/datasetacquisition/MrDatasetAcquisitionStrategy.java
@@ -63,7 +63,7 @@ public class MrDatasetAcquisitionStrategy implements DatasetAcquisitionStrategy 
 	DatasetStrategy<MrDataset> mrDatasetStrategy;
 	
 	@Override
-	public DatasetAcquisition generateDatasetAcquisitionForSerie(Serie serie, int rank, ImportJob importJob) {
+	public DatasetAcquisition generateDatasetAcquisitionForSerie(Serie serie, int rank, ImportJob importJob) throws Exception {
 		MrDatasetAcquisition mrDatasetAcquisition = new MrDatasetAcquisition();
 		LOG.info("Generating DatasetAcquisition for   : " +serie.getSequenceName() + " - " + serie.getProtocolName() + " - Rank:" + rank);
 		Attributes dicomAttributes = null;

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/strategies/datasetexpression/DatasetExpressionContext.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/strategies/datasetexpression/DatasetExpressionContext.java
@@ -15,6 +15,8 @@
 package org.shanoir.ng.importer.strategies.datasetexpression;
 
 
+import java.net.MalformedURLException;
+
 import org.shanoir.ng.dataset.model.DatasetExpression;
 import org.shanoir.ng.importer.dto.ExpressionFormat;
 import org.shanoir.ng.importer.dto.ImportJob;
@@ -56,7 +58,7 @@ public class DatasetExpressionContext implements DatasetExpressionStrategy {
 
 	@Override
 	public DatasetExpression generateDatasetExpression(Serie serie, ImportJob importJob,
-			ExpressionFormat expressionFormat) {
+			ExpressionFormat expressionFormat) throws MalformedURLException {
 		if (datasetExpressionStrategy != null) {
 			return datasetExpressionStrategy.generateDatasetExpression(serie, importJob, expressionFormat);
 		}

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/strategies/datasetexpression/DatasetExpressionStrategy.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/strategies/datasetexpression/DatasetExpressionStrategy.java
@@ -14,6 +14,8 @@
 
 package org.shanoir.ng.importer.strategies.datasetexpression;
 
+import java.net.MalformedURLException;
+
 import org.shanoir.ng.dataset.model.DatasetExpression;
 import org.shanoir.ng.importer.dto.ExpressionFormat;
 import org.shanoir.ng.importer.dto.ImportJob;
@@ -21,6 +23,6 @@ import org.shanoir.ng.importer.dto.Serie;
 
 public interface DatasetExpressionStrategy {
 	
-	DatasetExpression generateDatasetExpression(Serie serie, ImportJob importJob, ExpressionFormat expressionFormat);
+	DatasetExpression generateDatasetExpression(Serie serie, ImportJob importJob, ExpressionFormat expressionFormat) throws MalformedURLException;
 
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/strategies/protocol/MrProtocolStrategy.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/strategies/protocol/MrProtocolStrategy.java
@@ -256,7 +256,7 @@ public class MrProtocolStrategy implements ProtocolStrategy {
 	        b.append("\n");
 	    }
 
-	    LOG.info(b.toString());
+	    LOG.debug(b.toString());
         
 		return mrProtocol;
 	}

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/shared/service/CStoreDicomService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/shared/service/CStoreDicomService.java
@@ -1,0 +1,108 @@
+/**
+ * Shanoir NG - Import, manage and share neuroimaging data
+ * Copyright (C) 2009-2019 Inria - https://www.inria.fr/
+ * Contact us on https://project.inria.fr/shanoir/
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+package org.shanoir.ng.shared.service;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.shanoir.ng.shared.exception.ShanoirException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * The class CStoreDicomService calls the command storescu of dcm4che3 on the
+ * command line to send the dicom images to the PACS via c-store. In the
+ * dockerbuild file of the ms datasets /docker-compose/datasets
+ * dcm4che-5.21.0-bin.zip is installed and configured to be available for this.
+ * 
+ * @author mkain
+ *
+ */
+@Component(value = "cstore")
+public class CStoreDicomService implements DicomServiceApi {
+	
+	/** Logger. */
+	private static final Logger LOG = LoggerFactory.getLogger(CStoreDicomService.class);
+
+	private static final String STORESCU = "storescu";
+
+	private static final String C = "-c";
+
+	@Value("${dcm4chee-arc.host}")
+	private String dcm4cheeHost;
+
+	@Value("${dcm4chee-arc.port.dcm}")
+	private String dcm4cheePortDcm;
+
+	@Value("${dcm4chee-arc.dicom.c-store.aet.called}")
+	private String dcm4cheeCStoreAETCalled;
+
+	@Override
+	public void sendDicomFilesToPacs(File directoryWithDicomFiles) throws Exception {
+		if (directoryWithDicomFiles != null && directoryWithDicomFiles.exists()
+				&& directoryWithDicomFiles.isDirectory()) {
+			File[] dicomFiles = directoryWithDicomFiles.listFiles();
+			LOG.info("Start: C-STORE sending " + dicomFiles.length + " dicom files to PACS from folder: "
+					+ directoryWithDicomFiles.getAbsolutePath());
+			List<String> args = new ArrayList<String>();
+			args.add(STORESCU);
+			args.add(C);
+			args.add(dcm4cheeCStoreAETCalled + "@" + dcm4cheeHost + ":" + dcm4cheePortDcm);
+			args.add(directoryWithDicomFiles.getAbsolutePath());
+			execute(args);
+			LOG.info("Finished: C-STORE sending " + dicomFiles.length + " dicom files to PACS from folder: "
+					+ directoryWithDicomFiles.getAbsolutePath());
+		} else {
+			throw new ShanoirException(
+					"sendDicomFilesToPacs called with null, or file: not existing or not a directory.");
+		}
+	}
+
+	/**
+	 * Calls the command line, error occurred if exitCode != 0.
+	 * 
+	 * Uses ProcessBuilder here as Runtime.exec did not work (stopped after sending 49 images),
+	 * very probably related to a buffer problem: many output of the script saturates the default
+	 * output buffer of Runtime.exec, so we have been obliged to use ProcessBuilder here.
+	 * 
+	 * Furthermore the below code is blocking by intention. It could be coded not blocking, BUT
+	 * the problem is when to check for the results: 5, 10, 15 secs?, in any case we want to continue
+	 * when it terminates, so no real gain when using ExecuterService.
+	 * 
+	 * @param args
+	 * @throws Exception
+	 */
+	private void execute(List<String> args) throws Exception {
+		LOG.debug("Calling command: " + args.toString());
+		ProcessBuilder processBuilder = new ProcessBuilder();
+		processBuilder.command(args);
+		Process process = processBuilder.start();
+        BufferedReader reader =
+                new BufferedReader(new InputStreamReader(process.getInputStream()));
+        String line;
+        while ((line = reader.readLine()) != null) {
+            LOG.debug(line);
+        }
+        int exitCode = process.waitFor();
+		if (exitCode != 0)
+			throw new ShanoirException("Send to PACS (c-store) error occured on cmd line.");
+	}
+
+}

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/shared/service/DicomServiceApi.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/shared/service/DicomServiceApi.java
@@ -14,10 +14,10 @@
 
 package org.shanoir.ng.shared.service;
 
-import java.util.List;
+import java.io.File;
 
 public interface DicomServiceApi {
 	
-	void storeDcmFiles(List<String> dcmFilePathlist);
+	void sendDicomFilesToPacs(File directoryWithDicomFiles) throws Exception;
 
 }

--- a/shanoir-ng-datasets/src/main/resources/application.yml
+++ b/shanoir-ng-datasets/src/main/resources/application.yml
@@ -89,15 +89,32 @@ logging:
   level:
     org.springframework.web: ERROR
     org.hibernate: ERROR
-    org.shanoir: WARN
+    org.shanoir: INFO
         
   
 ### ============================================================= ###
-##                  Dicom Server Configuration                    ##
+###                  Dicom Server Configuration                   ###
 ### ============================================================= ###
 dcm4chee-arc:
-  address: http://dcm4chee-arc:8081
-  wado-rs: /dcm4chee-arc/aets/DCM4CHEE/rs/studies
+  # Attention: the below values are used twice: 1) to address the PACS e.g.
+  # to actually send the dicoms (in StowRs- or CStoreDicomService) to the
+  # Shanoir backup PACS and 2) to generate the WADO download URLs in the
+  # class DicomDatasetExpressionStrategy
+  protocol: http://
+  host: dcm4chee-arc
+  port.web: 8081
+  port.dcm: 11112
+  # flag for either using the DicomWeb protocol (REST) or the Dicom protocol
+  # if false: 1) c-store used to send dicom files to PACS and 2) generated
+  # URLs in db are in WADO-URI format
+  # if true: 2) stow-rs used to send dicom files to PACS and 2) generated URLs
+  # in db are in WADO-RS format
+  # default is true as we want to use new protocols in sh-ng
+  dicom.web: false
+  dicom.c-store.aet.called: DCM4CHEE
+  # use "/wado" for dcm4chee2 and "/dcm4chee-arc/aets/DCM4CHEE/wado" for dcm4chee3
+  dicom.wado.uri: /dcm4chee-arc/aets/DCM4CHEE/wado
+  dicom.web.rs: /dcm4chee-arc/aets/DCM4CHEE/rs/studies
 
 ---
 

--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/dcm2nii/DatasetsCreatorAndNIfTIConverterService.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/dcm2nii/DatasetsCreatorAndNIfTIConverterService.java
@@ -724,14 +724,14 @@ public class DatasetsCreatorAndNIfTIConverterService {
 		} else {
 			Dataset dataset = new Dataset();
 			dataset.setName(serie.getSeriesDescription());
+			ExpressionFormat expressionFormat = new ExpressionFormat();
+			expressionFormat.setType("dcm");
+			dataset.getExpressionFormats().add(expressionFormat);
 			for (Image image : serie.getImages()) {
 				dataset.getFlipAngles().add(new Double(image.getFlipAngle()));
 				dataset.getRepetitionTimes().add(new Double(image.getRepetitionTime()));
 				dataset.getInversionTimes().add(new Double(image.getInversionTime()));
 				dataset.setEchoTimes(image.getEchoTimes());
-				ExpressionFormat expressionFormat = new ExpressionFormat();
-				expressionFormat.setType("dcm");
-				dataset.getExpressionFormats().add(expressionFormat);
 				DatasetFile datasetFile = createDatasetFile(image);
 				expressionFormat.getDatasetFiles().add(datasetFile);
 			}

--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/utils/StreamGobbler.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/utils/StreamGobbler.java
@@ -27,7 +27,7 @@ public class StreamGobbler extends Thread {
 	/**
 	 * Logger
 	 */
-	private static final Logger LOG = LoggerFactory.getLogger(ShanoirExec.class);
+	private static final Logger LOG = LoggerFactory.getLogger(StreamGobbler.class);
 
 	/** The is. */
 	private InputStream is;
@@ -57,11 +57,12 @@ public class StreamGobbler extends Thread {
 	 * @see java.lang.Thread#run()
 	 */
 	public void run() {
+		InputStreamReader isr = null;
+		BufferedReader br = null;
 		try {
-			final InputStreamReader isr = new InputStreamReader(is);
-			final BufferedReader br = new BufferedReader(isr);
+			isr = new InputStreamReader(is);
+			br = new BufferedReader(isr);
 			String line = null;
-
 			while ((line = br.readLine()) != null) {
 				if (type.equals("ERROR")) {
 					LOG.error(line);
@@ -74,9 +75,17 @@ public class StreamGobbler extends Thread {
 					stringDisplay += "INFO : " + line + "\n";
 				}
 			}
+			br.close();
 			isr.close();
 		} catch (final IOException ioe) {
 			LOG.error(ioe.getMessage());
+		} finally {
+			try {
+				br.close();
+				isr.close();
+			} catch (IOException e) {
+				LOG.error(e.getMessage());
+			}				
 		}
 	}
 
@@ -98,5 +107,5 @@ public class StreamGobbler extends Thread {
 	public void setStringDisplay(String stringDisplay) {
 		this.stringDisplay = stringDisplay;
 	}
-}
 
+}


### PR DESCRIPTION
* Integrates c-store and wado-uri into ms datasets to assure backward compatibility with
dcm4chee2 (for production Neurinfo we agreed with the admin to keep for the moment
the current dcm4chee2 to reduce change overhead for installation of new version).
The flag „ dcm4chee-arc.dicom.web“ can be used to switch between c-store+wado-uri
and stowrs+wadors.
* By default now dicom images are sent to the pacs with c-store as tests showed, that
160 images with c-store require 3 secs and 160 images with stowrs require 4 secs in average
* Integrates a new exception handling and stops the „silent“ exceptions in ms datasets
* Installs dcm4che-5.21.0 into ms datasets (Dockerfile), to be used on the command line
* Fixes a major bug in DatasetAcquisitionApiController.java (setImportJob on ImporterService):
-> not multi-thread safe and would lead to bad errors in production
* Fixes a major bug in DatasetsCreatorAndNIfTIConverterService.java in ms import:
-> diffusion datasets (doNotSeparateFlag) have been created with one DatasetExpression
for each DatasetFile (big error), now fixed