### PR TITLE
selectable rows in tables

### DIFF
--- a/shanoir-ng-front/src/app/coils/coil-list/coil-list.component.html
+++ b/shanoir-ng-front/src/app/coils/coil-list/coil-list.component.html
@@ -15,8 +15,8 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 <h2 i18n="Manage coils|Title@@coilListTitle">Manage coils</h2>
   
 <shanoir-table #table
-    [getPage]="getPage.bind(this)" 
-    [columnDefs]="columnDefs" 
-    [customActionDefs]="customActionDefs" 
-    (rowClick)="onRowClick($event)">
+        [getPage]="getPage.bind(this)" 
+        [columnDefs]="columnDefs" 
+        [customActionDefs]="customActionDefs" 
+        (rowClick)="onRowClick($event)">
 </shanoir-table>

--- a/shanoir-ng-front/src/app/datasets/dataset-list/dataset-list.component.ts
+++ b/shanoir-ng-front/src/app/datasets/dataset-list/dataset-list.component.ts
@@ -122,5 +122,4 @@ export class DatasetListComponent extends EntityListComponent<Dataset>{
     canDelete(ds: Dataset): boolean {
         return this.canEdit(ds);
     }
-    
 }

--- a/shanoir-ng-front/src/app/shared/checkbox/checkbox.component.css
+++ b/shanoir-ng-front/src/app/shared/checkbox/checkbox.component.css
@@ -25,10 +25,14 @@
 
 div {
     color: var(--color-c);
+    position: absolute;
+    top: 1px;
+    bottom: 1px;
+    left: 1px;
+    right: 1px;
 }
 
 div svg {
-    height: 90%;
+    height: 100%;
     width: 100%;
-    margin-top: 5%;
 }

--- a/shanoir-ng-front/src/app/shared/checkbox/checkbox.component.html
+++ b/shanoir-ng-front/src/app/shared/checkbox/checkbox.component.html
@@ -12,9 +12,9 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 -->
 
-<div *ngIf="ngModel && ngModel == true">
+<div *ngIf="model && model == true">
     <i class="fas fa-check"></i>
 </div>
-<div *ngIf="ngModel == 'indeterminate'">
+<div *ngIf="model == 'indeterminate'">
     <i class="fas fa-ellipsis-h"></i>
 </div>

--- a/shanoir-ng-front/src/app/shared/checkbox/checkbox.component.ts
+++ b/shanoir-ng-front/src/app/shared/checkbox/checkbox.component.ts
@@ -30,8 +30,7 @@ import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 
 export class CheckboxComponent implements ControlValueAccessor { 
     
-    @Input() @HostBinding('class.on') ngModel: boolean | 'indeterminate' = null;
-    @Output() ngModelChange = new EventEmitter();
+    @HostBinding('class.on') model: boolean | 'indeterminate' = false;
     @Output() onChange = new EventEmitter();
     private onTouchedCallback = () => {};
     private onChangeCallback = (_: any) => {};
@@ -42,34 +41,31 @@ export class CheckboxComponent implements ControlValueAccessor {
     @HostListener('click', ['$event']) 
     private onClick() {
         if (this.disabled) return;
-        this.ngModel = !this.ngModel;
-        this.ngModelChange.emit(this.ngModel);
-        this.onChange.emit(this.ngModel);
-        this.onChangeCallback(this.ngModel);
-        this.onTouchedCallback();
+        this.toogle();
     }
 
     @HostListener('keydown', ['$event']) 
     private onKeyPress(event: any) {
         if (this.disabled) return;
         if (' ' == event.key) {
-            this.ngModel = !this.ngModel;
-            this.ngModelChange.emit(this.ngModel);
-            this.onChange.emit(this.ngModel);
-            this.onChangeCallback(this.ngModel);
-            this.onTouchedCallback();
+            this.toogle();
             event.preventDefault();
         }
     }
 
-    ngOnChanges(changes: SimpleChanges) {
-        if (changes['ngModel'] && !changes['ngModel'].firstChange) {
-            this.onChangeCallback(this.ngModel);
+    private toogle() {
+        if (this.model == true || this.model == 'indeterminate') {
+            this.model = false;
+        } else {
+            this.model = true;
         }
+        this.onChange.emit(this.model);
+        this.onChangeCallback(this.model);
+        this.onTouchedCallback();
     }
     
     writeValue(obj: any): void {
-        this.ngModel = obj;
+        this.model = obj;
     }
     
     registerOnChange(fn: any): void {

--- a/shanoir-ng-front/src/app/shared/components/table/table.component.css
+++ b/shanoir-ng-front/src/app/shared/components/table/table.component.css
@@ -16,12 +16,11 @@ th { width: 100%; white-space: normal; }
 		.controls select { width: 150px; margin-right: 5px; }
 		.controls .text-search,
 		.controls .options,
-		.select-ctrl { margin: 0 3px 0 0; padding: 0 0 0 0; }
+		.select-ctrl { margin: 0 3px 0 0; padding: 0 0 0 5px;vertical-align: bottom; }
 			.controls .options .max-results { width: 40px; text-align: right; }
-	.select-ctrl button { padding: 0 5px; }
 	th.sortable { cursor: pointer; position: relative; overflow: initial; }
 		th.sortable .sort-arrow { position: absolute; top: 11px; right: 0; left: 0; color: var(--color-c); opacity: 0.6; top: 6px; font-size: 23px; }
-	th.checkbox-col { width: 21px; }
+	th.checkbox-col { width: 17px; }
 	th.col-date { width: 70px; }
 	th.col-boolean { width: 20px; }
 	th.col-button { width: 20px; }
@@ -47,7 +46,7 @@ td { padding: 0 5px; border: none; white-space: nowrap; overflow: hidden; text-o
 		td span.button .awesome { color: var(--color-b); }
 	td.loading,
 	td.empty { padding: 20px 20px; text-align: center; }
-		
+
 .loader { float: right; border-left: none !important; }
 	.loader img { margin-left: 5px; vertical-align: -1; height: 10px; }
 
@@ -57,7 +56,7 @@ a.link { text-decoration: none; color: inherit; }
 
 .cell-button svg:hover { color: var(--color-a); }
 
-checkbox { height: 15px; width: 15px; }
+checkbox { height: 13px; width: 13px; margin: 1px 0; }
 
 .triangle { position: absolute;  left: 0; right: 0; z-index: 1; }
 .triangle.up { bottom: 100%; }

--- a/shanoir-ng-front/src/app/shared/components/table/table.component.html
+++ b/shanoir-ng-front/src/app/shared/components/table/table.component.html
@@ -15,8 +15,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 <!-- Control bar -->
 <caption class="controls">
     <span *ngIf="selectionAllowed" class="select-ctrl">
-        <button (click)="selectAll()" title="select all"><img [src]="checkAllImageUrl"/></button>
-        <button (click)="unSelectAll()" title="unselect all"><img [src]="uncheckAllImageUrl"/></button>
+        <checkbox [(ngModel)]="selectAll" (ngModelChange)="onSelectAllChange()"></checkbox>
     </span>
     <!-- Text search -->
     <span *ngIf="browserSearch" class="text-search">
@@ -65,7 +64,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
     *ngFor="let item of items; let i = index" 
     [class.odd]="i%2!=0" 
     [class.even]="i%2==0">
-    <td *ngIf="selectionAllowed" class="checkbox-cell"><input type="checkbox" [(ngModel)]="item.isSelectedInTable" /></td>
+    <td *ngIf="selectionAllowed" class="checkbox-cell"><checkbox (ngModelChange)="onSelectChange(item, $event)" [ngModel]="isSelected(item)"></checkbox></td>
     <!-- if it is a problem to modify an item, we could bind a number[] to the table component from the parent componnent -->
     <td 
         *ngFor="let col of columnDefs" 

--- a/shanoir-ng-front/src/app/shared/components/table/table.component.ts
+++ b/shanoir-ng-front/src/app/shared/components/table/table.component.ts
@@ -280,7 +280,21 @@ export class TableComponent implements OnInit {
 
     onSelectAllChange() {
         if (this.selectAll == true) {
-            this.getPage(new Pageable(1, this.page.totalElements)).then(page => {
+            let pageableAll: Pageable;
+            if (this.filter) {
+                pageableAll = new FilterablePageable(
+                    1, 
+                    this.page.totalElements,
+                    null,
+                    this.filter
+                );
+            } else {
+                pageableAll = new Pageable(
+                    1, 
+                    this.page.totalElements
+                );
+            }
+            this.getPage(pageableAll).then(page => {
                 this.selection = new Map();
                 page.content.forEach(elt => this.selection.set(elt.id, elt));
             });

--- a/shanoir-ng-front/src/app/shared/components/tree/tree-node.component.ts
+++ b/shanoir-ng-front/src/app/shared/components/tree/tree-node.component.ts
@@ -152,7 +152,7 @@ export class TreeNodeComponent implements ControlValueAccessor {
     };
 
     setBox(value: boolean | 'indeterminate') {
-        if (this.boxElt) this.boxElt.ngModel = value;
+        if (this.boxElt) this.boxElt.model = value;
         this.writeValue(value != null && value);
     }
 


### PR DESCRIPTION
**Usage :**

Add ` [selectionAllowed]="true"` to the `<shanoir-table>` tag and then catch selected rows with the `(selectionChange)` event.

**Exemple :** 

* in html

```
<shanoir-table #table
        [getPage]="getPage.bind(this)" 
        [columnDefs]="columnDefs" 
        [customActionDefs]="customActionDefs" 
        (rowClick)="onRowClick($event)"
        [browserSearch]="false"
        [selectionAllowed]="true"
        (selectionChange)="onSelectedChange($event)">
</shanoir-table>

```
* in component

```
onSelectedChange(selected: Dataset[]) {
	console.log(selected);
}
```

**Warning :**

When clicking 'select all' on a backend paging entities table, a request will fetch every single entity ( getAll() ). Else, how could we know what is selected? We probably will set a limit.
