### PR TITLE
ShanoirUploader v6.0.2: extensions for sh-ng

### DIFF
--- a/shanoir-ng-studies/src/main/java/org/shanoir/ng/subject/repository/SubjectRepository.java
+++ b/shanoir-ng-studies/src/main/java/org/shanoir/ng/subject/repository/SubjectRepository.java
@@ -21,8 +21,17 @@ import org.springframework.data.repository.query.Param;
 
 /**
  * Repository for Subject.
+ * 
+ * mkain: For the method findSubjectFromCenterCode I would have preferred to use
+ * JPQL or Spring Data Jpa with method names. Both did not work for me: 1) JPQL
+ * does not support "limit 1". With JPQL I would have to use Pageable to implement
+ * the same, but as I want to give back one subject, I see no sense in asking the
+ * caller to work with PageRequest(0,1), what looks strange too. 2) With Spring
+ * Data Jpa I was not able to combine findFirstByOrderDesc and StartsWith, that
+ * is why I am using nativeQuery here.
  *
  * @author msimon
+ * @author mkain
  */
 public interface SubjectRepository extends CrudRepository<Subject, Long>, SubjectRepositoryCustom {
 
@@ -44,7 +53,7 @@ public interface SubjectRepository extends CrudRepository<Subject, Long>, Subjec
 	 */
 	Subject findByIdentifier(String identifier);
 	
-	
-	@Query("SELECT s FROM Subject s WHERE s.name LIKE CONCAT(:centerCode,'%','%','%','%')")
-	public Subject findFromCenterCode(@Param("centerCode") String centerCode);
+	@Query(value = "SELECT * FROM subject WHERE name LIKE :centerCode ORDER BY name DESC LIMIT 1", nativeQuery = true)
+	Subject findSubjectFromCenterCode(@Param("centerCode") String centerCode);
+
 }

--- a/shanoir-ng-studies/src/main/java/org/shanoir/ng/subject/service/SubjectServiceImpl.java
+++ b/shanoir-ng-studies/src/main/java/org/shanoir/ng/subject/service/SubjectServiceImpl.java
@@ -30,6 +30,7 @@ import org.shanoir.ng.subjectstudy.repository.SubjectStudyRepository;
 import org.shanoir.ng.utils.ListDependencyUpdate;
 import org.shanoir.ng.utils.Utils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 /**
@@ -40,6 +41,10 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class SubjectServiceImpl implements SubjectService {
+
+	private static final String FORMAT_CENTER_CODE = "000";
+
+	private static final String FORMAT_SUBJECT_CODE = "0000";
 
 	@Autowired
 	private SubjectRepository subjectRepository;
@@ -108,7 +113,8 @@ public class SubjectServiceImpl implements SubjectService {
 				subjectStudy.setSubject(subject);
 			}			
 		}
-		DecimalFormat formatterCenter = new DecimalFormat("000");
+		// the first 3 numbers are the center code, search for highest existing subject with center code
+		DecimalFormat formatterCenter = new DecimalFormat(FORMAT_CENTER_CODE);
 		String commonNameCenter = formatterCenter.format(centerId);
 		int maxCommonNameNumber = 0;
 		Subject subjectOfsepCommonNameMaxFoundByCenter = findSubjectFromCenterCode(commonNameCenter);
@@ -117,7 +123,7 @@ public class SubjectServiceImpl implements SubjectService {
 			maxCommonNameNumber = Integer.parseInt(maxNameToIncrement);
 		}
 		maxCommonNameNumber += 1;
-		DecimalFormat formatterSubject = new DecimalFormat("0000");
+		DecimalFormat formatterSubject = new DecimalFormat(FORMAT_SUBJECT_CODE);
 		String subjectName = commonNameCenter + formatterSubject.format(maxCommonNameNumber);
 		subject.setName(subjectName);
 		return subjectRepository.save(subject);
@@ -193,6 +199,7 @@ public class SubjectServiceImpl implements SubjectService {
 		if (centerCode == null || "".equals(centerCode)) {
 			return null;
 		}
-		return subjectRepository.findFromCenterCode(centerCode);
+		return subjectRepository.findSubjectFromCenterCode(centerCode + "%");
 	}
+
 }

--- a/shanoir-ng-studies/src/test/java/org/shanoir/ng/subject/SubjectApiSecurityTest.java
+++ b/shanoir-ng-studies/src/test/java/org/shanoir/ng/subject/SubjectApiSecurityTest.java
@@ -45,6 +45,7 @@ import org.shanoir.ng.utils.usermock.WithMockKeycloakUser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.context.ActiveProfiles;
@@ -176,7 +177,7 @@ public class SubjectApiSecurityTest {
 		given(repository.findOne(1L)).willReturn(subjectMockNoRights);
 		given(repository.findByIdentifier("identifier")).willReturn(subjectMockNoRights);
 		given(repository.findSubjectWithSubjectStudyById(1L)).willReturn(subjectMockNoRights);
-		given(repository.findFromCenterCode("centerCode")).willReturn(subjectMockNoRights);
+		given(repository.findSubjectFromCenterCode("centerCode%")).willReturn(subjectMockNoRights);
 		assertAccessDenied(api::findSubjectById, ENTITY_ID);
 		assertAccessDenied(api::findSubjectByIdentifier, "identifier");
 		
@@ -200,7 +201,7 @@ public class SubjectApiSecurityTest {
 		given(repository.findOne(1L)).willReturn(subjectMockWrongRights);
 		given(repository.findByIdentifier("identifier")).willReturn(subjectMockWrongRights);
 		given(repository.findSubjectWithSubjectStudyById(1L)).willReturn(subjectMockWrongRights);
-		given(repository.findFromCenterCode("centerCode")).willReturn(subjectMockWrongRights);
+		given(repository.findSubjectFromCenterCode("centerCode%")).willReturn(subjectMockWrongRights);
 		given(repository.findAll()).willReturn(Arrays.asList(subjectMockWrongRights));
 		assertAccessDenied(api::findSubjectById, ENTITY_ID);
 		assertAccessDenied(api::findSubjectByIdentifier, "identifier");
@@ -225,7 +226,7 @@ public class SubjectApiSecurityTest {
 		given(repository.findOne(1L)).willReturn(subjectMockRightRights);
 		given(repository.findByIdentifier("identifier")).willReturn(subjectMockRightRights);
 		given(repository.findSubjectWithSubjectStudyById(1L)).willReturn(subjectMockRightRights);
-		given(repository.findFromCenterCode("centerCode")).willReturn(subjectMockRightRights);
+		given(repository.findSubjectFromCenterCode("centerCode%")).willReturn(subjectMockRightRights);
 		assertAccessAuthorized(api::findSubjectById, ENTITY_ID);
 		assertAccessAuthorized(api::findSubjectByIdentifier, "identifier");
 		

--- a/shanoir-ng-studies/src/test/java/org/shanoir/ng/subject/SubjectServiceSecurityTest.java
+++ b/shanoir-ng-studies/src/test/java/org/shanoir/ng/subject/SubjectServiceSecurityTest.java
@@ -39,6 +39,7 @@ import org.shanoir.ng.utils.usermock.WithMockKeycloakUser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.context.ActiveProfiles;
@@ -167,7 +168,7 @@ public class SubjectServiceSecurityTest {
 		given(repository.findOne(1L)).willReturn(subjectMockNoRights);
 		given(repository.findByIdentifier("identifier")).willReturn(subjectMockNoRights);
 		given(repository.findSubjectWithSubjectStudyById(1L)).willReturn(subjectMockNoRights);
-		given(repository.findFromCenterCode("centerCode")).willReturn(subjectMockNoRights);
+		given(repository.findSubjectFromCenterCode("centerCode%")).willReturn(subjectMockNoRights);
 		assertAccessDenied(service::findByData, NAME);
 		assertAccessDenied(service::findById, 1L);
 		assertAccessDenied(service::findByIdentifier, "identifier");
@@ -180,7 +181,7 @@ public class SubjectServiceSecurityTest {
 		given(repository.findOne(1L)).willReturn(subjectMockWrongRights);
 		given(repository.findByIdentifier("identifier")).willReturn(subjectMockWrongRights);
 		given(repository.findSubjectWithSubjectStudyById(1L)).willReturn(subjectMockWrongRights);
-		given(repository.findFromCenterCode("centerCode")).willReturn(subjectMockWrongRights);
+		given(repository.findSubjectFromCenterCode("centerCode%")).willReturn(subjectMockWrongRights);
 		assertAccessDenied(service::findByData, NAME);
 		assertAccessDenied(service::findById, 1L);
 		assertAccessDenied(service::findByIdentifier, "identifier");
@@ -193,7 +194,7 @@ public class SubjectServiceSecurityTest {
 		given(repository.findOne(1L)).willReturn(subjectMockRightRights);
 		given(repository.findByIdentifier("identifier")).willReturn(subjectMockRightRights);
 		given(repository.findSubjectWithSubjectStudyById(1L)).willReturn(subjectMockRightRights);
-		given(repository.findFromCenterCode("centerCode")).willReturn(subjectMockRightRights);
+		given(repository.findSubjectFromCenterCode("centerCode%")).willReturn(subjectMockRightRights);
 		assertAccessAuthorized(service::findByData, NAME);
 		assertAccessAuthorized(service::findById, 1L);
 		assertAccessAuthorized(service::findByIdentifier, "identifier");

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/action/ImportDialogOpener.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/action/ImportDialogOpener.java
@@ -67,7 +67,7 @@ public class ImportDialogOpener {
 				// first, search subject in shanoir server and then init the both listeners
 				SubjectDTO subjectDTO = getSubject(uploadJob);
 				ImportStudyAndStudyCardCBItemListener importStudyAndStudyCardCBIL = new ImportStudyAndStudyCardCBItemListener(this.mainWindow, subjectDTO);
-				ImportFinishActionListener importFinishAL = new ImportFinishActionListener(this.mainWindow, uploadJob, uploadFolder, subjectDTO);
+				ImportFinishActionListener importFinishAL = new ImportFinishActionListener(this.mainWindow, uploadJob, uploadFolder, subjectDTO, importStudyAndStudyCardCBIL);
 				importDialog = new ImportDialog(this.mainWindow,
 						ShUpConfig.resourceBundle.getString("shanoir.uploader.preImportDialog.title"), true, resourceBundle,
 						importStudyAndStudyCardCBIL, importFinishAL);

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/action/ImportDialogOpenerNG.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/action/ImportDialogOpenerNG.java
@@ -22,7 +22,6 @@ import org.shanoir.uploader.model.rest.ImagedObjectCategory;
 import org.shanoir.uploader.model.rest.Study;
 import org.shanoir.uploader.model.rest.StudyCard;
 import org.shanoir.uploader.model.rest.Subject;
-import org.shanoir.uploader.model.rest.SubjectStudy;
 import org.shanoir.uploader.model.rest.SubjectType;
 import org.shanoir.uploader.service.rest.ShanoirUploaderServiceClientNG;
 
@@ -52,29 +51,24 @@ public class ImportDialogOpenerNG {
 	}
 
 	public void openImportDialog(UploadJob uploadJob, File uploadFolder) {
-		// login again, in case session has been expired
-//		if (shanoirUploaderServiceClient.login()) {
-			try {
-				Subject subjectDTO = getSubject(uploadJob);
-				ImportStudyAndStudyCardCBItemListenerNG importStudyAndStudyCardCBIL = new ImportStudyAndStudyCardCBItemListenerNG(this.mainWindow);
-				ImportFinishActionListenerNG importFinishAL = new ImportFinishActionListenerNG(this.mainWindow, uploadJob, uploadFolder, subjectDTO);
-				importDialog = new ImportDialog(this.mainWindow,
-						ShUpConfig.resourceBundle.getString("shanoir.uploader.preImportDialog.title"), true, resourceBundle,
-						importStudyAndStudyCardCBIL, importFinishAL);
-				updateImportDialogForSubject(subjectDTO); // this has to be done after init of dialog
-				List<Study> studiesWithStudyCards = getStudiesWithStudyCards(uploadJob);
-				updateImportDialogForStudyAndStudyCard(studiesWithStudyCards);
-				List<Examination> examinationDTOs = getExaminations(subjectDTO);
-				updateImportDialogForExaminations(examinationDTOs, uploadJob);
-				updateImportDialogForMRICenter(uploadJob);
-			} catch (Exception e) {
-				logger.error(e.getMessage(), e);
-				return;
-			}
-			importDialog.setVisible(true);
-//		} else {
-//			return;
-//		}
+		try {
+			Subject subject = getSubject(uploadJob);
+			ImportStudyAndStudyCardCBItemListenerNG importStudyAndStudyCardCBILNG = new ImportStudyAndStudyCardCBItemListenerNG(this.mainWindow, subject);
+			ImportFinishActionListenerNG importFinishALNG = new ImportFinishActionListenerNG(this.mainWindow, uploadJob, uploadFolder, subject, importStudyAndStudyCardCBILNG);
+			importDialog = new ImportDialog(this.mainWindow,
+					ShUpConfig.resourceBundle.getString("shanoir.uploader.preImportDialog.title"), true, resourceBundle,
+					importStudyAndStudyCardCBILNG, importFinishALNG);
+			updateImportDialogForSubject(subject); // this has to be done after init of dialog
+			List<Study> studiesWithStudyCards = getStudiesWithStudyCards(uploadJob);
+			updateImportDialogForStudyAndStudyCard(studiesWithStudyCards);
+			List<Examination> examinationDTOs = getExaminations(subject);
+			updateImportDialogForExaminations(examinationDTOs, uploadJob);
+			updateImportDialogForMRICenter(uploadJob);
+		} catch (Exception e) {
+			logger.error(e.getMessage(), e);
+			return;
+		}
+		importDialog.setVisible(true);
 	}
 	
 	/**
@@ -110,25 +104,29 @@ public class ImportDialogOpenerNG {
 		String manufacturerModelName = firstSerie.getMriInformation().getManufacturersModelName();
 		String deviceSerialNumber = firstSerie.getMriInformation().getDeviceSerialNumber();
 		List<Study> studies = shanoirUploaderServiceClientNG.findStudiesNamesAndCenters();
-		for (Iterator iterator = studies.iterator(); iterator.hasNext();) {
-			Study study = (Study) iterator.next();
-			study.setCompatible(new Boolean(false));
-			Long studyId = study.getId();
-			IdList idList = new IdList();
-			idList.getIdList().add(studyId);
-			List<StudyCard> studyCards = shanoirUploaderServiceClientNG.findStudyCardsByStudyIds(idList);
-			// fill missing infos coming from other microservice studies here:
-			if (studyCards != null) {
-				for (Iterator itStudyCards = studyCards.iterator(); itStudyCards.hasNext();) {
-					StudyCard studyCard = (StudyCard) itStudyCards.next();
-					Long acquisitionEquipmentId = studyCard.getAcquisitionEquipmentId();
-					AcquisitionEquipment acquisitionEquipment = shanoirUploaderServiceClientNG.findAcquisitionEquipmentById(acquisitionEquipmentId);
-					studyCard.setAcquisitionEquipment(acquisitionEquipment);
+		if (studies != null) {
+			for (Iterator iterator = studies.iterator(); iterator.hasNext();) {
+				Study study = (Study) iterator.next();
+				study.setCompatible(new Boolean(false));
+				Long studyId = study.getId();
+				IdList idList = new IdList();
+				idList.getIdList().add(studyId);
+				List<StudyCard> studyCards = shanoirUploaderServiceClientNG.findStudyCardsByStudyIds(idList);
+				// fill missing infos coming from other microservice studies here:
+				if (studyCards != null) {
+					for (Iterator itStudyCards = studyCards.iterator(); itStudyCards.hasNext();) {
+						StudyCard studyCard = (StudyCard) itStudyCards.next();
+						Long acquisitionEquipmentId = studyCard.getAcquisitionEquipmentId();
+						AcquisitionEquipment acquisitionEquipment = shanoirUploaderServiceClientNG.findAcquisitionEquipmentById(acquisitionEquipmentId);
+						studyCard.setAcquisitionEquipment(acquisitionEquipment);
+					}
 				}
+				study.setStudyCards(studyCards);
 			}
-			study.setStudyCards(studyCards);
+			return studies;
+		} else {
+			return null;
 		}
-		return studies;
 	}
 
 	/**
@@ -137,7 +135,7 @@ public class ImportDialogOpenerNG {
 	private void updateImportDialogForStudyAndStudyCard(List<Study> studiesWithStudyCards) {
 		importDialog.studyCB.removeAllItems();
 		importDialog.studyCardCB.removeAllItems();
-		if (!studiesWithStudyCards.isEmpty()) {
+		if (studiesWithStudyCards != null && !studiesWithStudyCards.isEmpty()) {
 			boolean firstCompatibleStudyFound = false;
 			for (Study study : studiesWithStudyCards) {
 				importDialog.studyCB.addItem(study);
@@ -185,7 +183,7 @@ public class ImportDialogOpenerNG {
 		return foundSubject;
 	}
 
-	private void updateImportDialogForSubject(Subject subjectDTO) {
+	private void updateImportDialogForSubject(Subject subject) {
 		/**
 		 * Insert subject specific items into combo boxes from model classes.
 		 * Should be there nevertheless if subject exists or not.
@@ -205,46 +203,23 @@ public class ImportDialogOpenerNG {
 			importDialog.subjectTypeCB.addItem(SubjectType.values()[i]);
 		}
 		// Existing subject found with identifier:
-		if (subjectDTO != null) {
+		if (subject != null) {
 			// Manage subject values here:
-			importDialog.subjectTextField.setText(subjectDTO.getName());
+			importDialog.subjectTextField.setText(subject.getName());
 			importDialog.subjectTextField.setBackground(Color.LIGHT_GRAY);
 			importDialog.subjectTextField.setEnabled(false);
 			importDialog.subjectTextField.setEditable(false);
 			importDialog.subjectTextField.setValueSet(true);
-			importDialog.subjectImageObjectCategoryCB.setSelectedItem(subjectDTO.getImagedObjectCategory());
+			importDialog.subjectImageObjectCategoryCB.setSelectedItem(subject.getImagedObjectCategory());
 			importDialog.subjectImageObjectCategoryCB.setEnabled(false);
 			importDialog.subjectLanguageHemisphericDominanceCB
-					.setSelectedItem(subjectDTO.getLanguageHemisphericDominance());
+					.setSelectedItem(subject.getLanguageHemisphericDominance());
 			importDialog.subjectLanguageHemisphericDominanceCB.setEnabled(false);
 			importDialog.subjectManualHemisphericDominanceCB
-					.setSelectedItem(subjectDTO.getManualHemisphericDominance());
+					.setSelectedItem(subject.getManualHemisphericDominance());
 			importDialog.subjectManualHemisphericDominanceCB.setEnabled(false);
 			importDialog.subjectPersonalCommentTextArea.setBackground(Color.LIGHT_GRAY);
 			importDialog.subjectPersonalCommentTextArea.setEditable(false);
-			// Manage subject_study values here:
-			List<SubjectStudy> subjectStudyList = subjectDTO.getSubjectStudyList();
-			for (Iterator iterator = subjectStudyList.iterator(); iterator.hasNext();) {
-				SubjectStudy subjectStudyDTO = (SubjectStudy) iterator.next();
-				importDialog.subjectIsPhysicallyInvolvedCB.setSelected(subjectStudyDTO.isPhysicallyInvolved());
-				importDialog.subjectIsPhysicallyInvolvedCB.setEnabled(false);
-				importDialog.subjectTypeCB.setSelectedItem(subjectStudyDTO.getSubjectType());
-				importDialog.subjectTypeCB.setEnabled(false);
-				break; // use the first relation here to display some info
-				/**
-				 * At this time we have found a subject on using the identifier.
-				 * This subject could be in multiple studies, or not, even in a
-				 * study not available to the importing user.
-				 * The subject could be in the future study, the user chooses to
-				 * import into, but could also be in another study. So we display
-				 * the first info we have here, as in the current implementation
-				 * the user can not change and modify anything on using ShUp.
-				 * When we import for the subject and the subject is not yet in
-				 * the selected study, we add it automatically to this study on
-				 * using the same values as in the other study. This could be
-				 * extended later.
-				 */
-			}
 		// No existing subject found with identifier:
 		} else {
 			// Common name
@@ -270,9 +245,6 @@ public class ImportDialogOpenerNG {
 			importDialog.subjectPersonalCommentTextArea.setText("");
 			importDialog.subjectPersonalCommentTextArea.setBackground(Color.WHITE);
 			importDialog.subjectPersonalCommentTextArea.setEditable(true);
-			importDialog.subjectIsPhysicallyInvolvedCB.setEnabled(true);
-			importDialog.subjectIsPhysicallyInvolvedCB.setSelected(true);
-			importDialog.subjectTypeCB.setSelectedItem(SubjectType.values()[2]);
 		}
 	}
 

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/action/ImportFinishActionListener.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/action/ImportFinishActionListener.java
@@ -48,12 +48,16 @@ public class ImportFinishActionListener implements ActionListener {
 	private org.shanoir.uploader.model.dto.SubjectDTO subjectDTO;
 	
 	private ShanoirUploaderServiceClient shanoirUploaderServiceClient;
+	
+	private ImportStudyAndStudyCardCBItemListener importStudyAndStudyCardCBIL;
 
-	public ImportFinishActionListener(final MainWindow mainWindow, UploadJob uploadJob, File uploadFolder, org.shanoir.uploader.model.dto.SubjectDTO subjectDTO) {
+	public ImportFinishActionListener(final MainWindow mainWindow, UploadJob uploadJob, File uploadFolder, org.shanoir.uploader.model.dto.SubjectDTO subjectDTO,
+			ImportStudyAndStudyCardCBItemListener importStudyAndStudyCardCBIL) {
 		this.mainWindow = mainWindow;
 		this.uploadJob = uploadJob;
 		this.uploadFolder = uploadFolder;
 		this.subjectDTO = subjectDTO;
+		this.importStudyAndStudyCardCBIL = importStudyAndStudyCardCBIL;
 		this.shanoirUploaderServiceClient = ShUpOnloadConfig.getShanoirUploaderServiceClient();
 	}
 
@@ -154,7 +158,7 @@ public class ImportFinishActionListener implements ActionListener {
 	}
 
 	private void handleSubjectStudy(final Study study, final Long subjectId) {
-		if (mainWindow.importDialog.subjectStudyDTO == null) {
+		if (importStudyAndStudyCardCBIL.getSubjectStudyDTO() == null) {
 			SubjectStudyDTO subjectStudyDTO = new SubjectStudyDTO();
 			subjectStudyDTO.setStudyId(study.getId());
 			subjectStudyDTO.setSubjectId(subjectId);

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/action/ImportStudyAndStudyCardCBItemListener.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/action/ImportStudyAndStudyCardCBItemListener.java
@@ -29,6 +29,8 @@ public class ImportStudyAndStudyCardCBItemListener implements ItemListener {
 	private MainWindow mainWindow;
 	
 	private SubjectDTO subjectDTO;
+	
+	private SubjectStudyDTO subjectStudyDTO;
 
 	public ImportStudyAndStudyCardCBItemListener(MainWindow mainWindow, SubjectDTO subjectDTO) {
 		this.mainWindow = mainWindow;
@@ -90,7 +92,7 @@ public class ImportStudyAndStudyCardCBItemListener implements ItemListener {
 						mainWindow.importDialog.subjectIsPhysicallyInvolvedCB.setEnabled(false);
 						mainWindow.importDialog.subjectTypeCB.setSelectedItem(subjectStudyDTO.getSubjectType());
 						mainWindow.importDialog.subjectTypeCB.setEnabled(false);
-						mainWindow.importDialog.subjectStudyDTO = subjectStudyDTO;
+						this.subjectStudyDTO = subjectStudyDTO;
 						return;
 					}
 				}
@@ -101,7 +103,15 @@ public class ImportStudyAndStudyCardCBItemListener implements ItemListener {
 		mainWindow.importDialog.subjectIsPhysicallyInvolvedCB.setSelected(true);
 		mainWindow.importDialog.subjectTypeCB.setEnabled(true);
 		mainWindow.importDialog.subjectTypeCB.setSelectedItem(ImportDialogOpener.subjectTypeValues[1]);
-		mainWindow.importDialog.subjectStudyDTO = null;
+		this.subjectStudyDTO = null;
+	}
+
+	public SubjectStudyDTO getSubjectStudyDTO() {
+		return subjectStudyDTO;
+	}
+
+	public void setSubjectStudyDTO(SubjectStudyDTO subjectStudyDTO) {
+		this.subjectStudyDTO = subjectStudyDTO;
 	}
 	
 }

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/action/ImportStudyAndStudyCardCBItemListenerNG.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/action/ImportStudyAndStudyCardCBItemListenerNG.java
@@ -2,26 +2,30 @@ package org.shanoir.uploader.action;
 
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
+import java.util.Iterator;
 import java.util.List;
 
-import org.apache.log4j.Logger;
 import org.shanoir.uploader.gui.MainWindow;
 import org.shanoir.uploader.gui.customcomponent.JComboBoxMandatory;
 import org.shanoir.uploader.model.rest.AcquisitionEquipment;
-import org.shanoir.uploader.model.rest.Center;
 import org.shanoir.uploader.model.rest.IdName;
-import org.shanoir.uploader.model.rest.Investigator;
 import org.shanoir.uploader.model.rest.Study;
 import org.shanoir.uploader.model.rest.StudyCard;
+import org.shanoir.uploader.model.rest.Subject;
+import org.shanoir.uploader.model.rest.SubjectStudy;
+import org.shanoir.uploader.model.rest.SubjectType;
 
 public class ImportStudyAndStudyCardCBItemListenerNG implements ItemListener {
 
-	private static Logger logger = Logger.getLogger(ImportStudyAndStudyCardCBItemListenerNG.class);
-
 	private MainWindow mainWindow;
+	
+	private Subject subject;
+	
+	private SubjectStudy subjectStudy;
 
-	public ImportStudyAndStudyCardCBItemListenerNG(MainWindow mainWindow) {
+	public ImportStudyAndStudyCardCBItemListenerNG(MainWindow mainWindow, Subject subject) {
 		this.mainWindow = mainWindow;
+		this.subject = subject;
 	}
 
 	public void itemStateChanged(ItemEvent e) {
@@ -29,12 +33,8 @@ public class ImportStudyAndStudyCardCBItemListenerNG implements ItemListener {
 		if (state == ItemEvent.SELECTED) {
 			if (e.getSource().equals(mainWindow.importDialog.studyCB)) {
 				Study study = (Study) e.getItem();
-				mainWindow.importDialog.studyCardCB.removeAllItems();
-				if (study.getStudyCards() != null) {
-					for (StudyCard studyCard : study.getStudyCards()) {
-						mainWindow.importDialog.studyCardCB.addItem(studyCard);
-					}
-				}
+				updateStudyCards(study);
+				updateSubjectStudy(study);
 			}
 			// the selection of the StudyCard and its center defines
 			// the center for new created examinations
@@ -53,4 +53,48 @@ public class ImportStudyAndStudyCardCBItemListenerNG implements ItemListener {
 		} // ignore otherwise
 	}
 
+	private void updateStudyCards(Study study) {
+		mainWindow.importDialog.studyCardCB.removeAllItems();
+		if (study.getStudyCards() != null) {
+			for (StudyCard studyCard : study.getStudyCards()) {
+				mainWindow.importDialog.studyCardCB.addItem(studyCard);
+			}
+		}
+	}
+
+	private void updateSubjectStudy(Study study) {
+		if (this.subject != null) {
+			// Check if RelSubjectStudy exists for selected study
+			List<SubjectStudy> subjectStudyList = subject.getSubjectStudyList();
+			if (subjectStudyList != null) {
+				for (Iterator iterator = subjectStudyList.iterator(); iterator.hasNext();) {
+					SubjectStudy subjectStudy = (SubjectStudy) iterator.next();
+					// subject is already in study: display values in GUI and stop editing
+					if (subjectStudy.getStudy().getId() == study.getId()) {
+						mainWindow.importDialog.subjectIsPhysicallyInvolvedCB.setSelected(subjectStudy.isPhysicallyInvolved());
+						mainWindow.importDialog.subjectIsPhysicallyInvolvedCB.setEnabled(false);
+						mainWindow.importDialog.subjectTypeCB.setSelectedItem(subjectStudy.getSubjectType());
+						mainWindow.importDialog.subjectTypeCB.setEnabled(false);
+						this.subjectStudy = subjectStudy;
+						return;
+					}
+				}
+			}
+		}
+		// subject is not in study, enable editing and display defaults
+		mainWindow.importDialog.subjectIsPhysicallyInvolvedCB.setEnabled(true);
+		mainWindow.importDialog.subjectIsPhysicallyInvolvedCB.setSelected(true);
+		mainWindow.importDialog.subjectTypeCB.setEnabled(true);
+		mainWindow.importDialog.subjectTypeCB.setSelectedItem(SubjectType.values()[1]);
+		this.subjectStudy = null;
+	}
+
+	public SubjectStudy getSubjectStudy() {
+		return subjectStudy;
+	}
+
+	public void setSubjectStudy(SubjectStudy subjectStudy) {
+		this.subjectStudy = subjectStudy;
+	}
+	
 }

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/gui/ImportDialog.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/gui/ImportDialog.java
@@ -31,7 +31,6 @@ import org.shanoir.uploader.action.CancelButtonActionListener;
 import org.shanoir.uploader.action.ImportCreateNewExamCBItemListener;
 import org.shanoir.uploader.gui.customcomponent.JComboBoxMandatory;
 import org.shanoir.uploader.gui.customcomponent.JTextFieldMandatory;
-import org.shanoir.uploader.model.dto.SubjectStudyDTO;
 
 /**
  * This is the view class for the Study, StudyCard, Subject and MR Examination
@@ -117,7 +116,6 @@ public class ImportDialog extends JDialog {
 	public JSeparator separatorMrExamination;
 	
 	public MainWindow mainWindow;
-	public SubjectStudyDTO subjectStudyDTO;
 	
 	/**
 	 * On injecting both listeners the ImportDialog becomes invisible of

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/service/rest/HttpService.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/service/rest/HttpService.java
@@ -4,6 +4,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -40,6 +41,20 @@ public class HttpService {
 			StringEntity requestEntity = new StringEntity(json, ContentType.APPLICATION_JSON);
 			httpPost.setEntity(requestEntity);
 			HttpResponse	 response = httpClient.execute(httpPost);
+			return response;
+		} catch (Exception e) {
+			LOG.error(e.getMessage(), e);
+		}
+		return null;
+	}
+
+	public HttpResponse put(String url, String json) {
+		try {
+			HttpPut httpPut = new HttpPut(url);
+			httpPut.addHeader("Authorization", "Bearer " + ShUpOnloadConfig.getKeycloakInstalled().getTokenString());
+			StringEntity requestEntity = new StringEntity(json, ContentType.APPLICATION_JSON);
+			httpPut.setEntity(requestEntity);
+			HttpResponse	 response = httpClient.execute(httpPut);
 			return response;
 		} catch (Exception e) {
 			LOG.error(e.getMessage(), e);

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/service/rest/ShanoirUploaderServiceClientNG.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/service/rest/ShanoirUploaderServiceClientNG.java
@@ -174,16 +174,16 @@ public class ShanoirUploaderServiceClientNG {
 	 * @param studyId
 	 * @param studyCardId
 	 * @param modeSubjectCommonName
-	 * @param subjectDTO
+	 * @param subject
 	 * @return boolean true, if success
 	 */
 	public Subject createSubject(
-			final Subject subjectDTO,
+			final Subject subject,
 			final boolean modeSubjectCommonNameManual,
 			final Long centerId) {
 		try {
 			ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
-			String json = ow.writeValueAsString(subjectDTO);
+			String json = ow.writeValueAsString(subject);
 			HttpResponse response;
 			if (modeSubjectCommonNameManual) {
 				response = httpService.post(this.serviceURLSubjectsCreate, json);
@@ -194,6 +194,30 @@ public class ShanoirUploaderServiceClientNG {
 			if (code == 200) {
 				Subject subjectDTOCreated = Util.getMappedObject(response, Subject.class);
 				return subjectDTOCreated;
+			}
+		} catch (JsonProcessingException e) {
+			logger.error(e.getMessage(), e);
+		}
+		return null;
+	}
+	
+	/**
+	 * This method updates a subject on the server and therefore updates
+	 * the rel_subject_study list too.
+	 * 
+	 * @param subject
+	 * @return
+	 */
+	public Subject createSubjectStudy(
+			final Subject subject) {
+		try {
+			ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+			String json = ow.writeValueAsString(subject);
+			HttpResponse response = httpService.put(this.serviceURLSubjectsCreate + "/" + subject.getId(), json);
+			int code = response.getStatusLine().getStatusCode();
+			if (code == 200) {
+				Subject subjectCreated = Util.getMappedObject(response, Subject.class);
+				return subjectCreated;
 			}
 		} catch (JsonProcessingException e) {
 			logger.error(e.getMessage(), e);


### PR DESCRIPTION
* Big feature extension: automatic token refresh with Keycloak, so ShUp can be used and kept open all time now
Especially important for testing and usage
* Bug fix for: create RelSubjectStudy if existing subject in other study (e.g. situation of patient moves) for REST connection
with Shanoir-NG
* Bug fix for: Caused by: javax.persistence.NonUniqueResultException: result returns more than one elements
at org.shanoir.ng.subject.service.SubjectServiceImpl.findSubjectFromCenterCode(SubjectServiceImpl.java:196)
at org.shanoir.ng.subject.service.SubjectServiceImpl.createAutoIncrement(SubjectServiceImpl.java:114)