### PR TITLE
New db fixes

### DIFF
--- a/docker-compose/migration_scripts/Neurinfo/1_users_migration.py
+++ b/docker-compose/migration_scripts/Neurinfo/1_users_migration.py
@@ -15,8 +15,15 @@ cursor = conn.cursor()
 
 
 print("Update users: start")
-query = "UPDATE users SET role_id=3 WHERE role_id=2"
-cursor.execute(query)
+for query in """
+    UPDATE users SET role_id=3 WHERE role_id=2;
+    
+    ALTER TABLE `users` MODIFY `creation_date` date DEFAULT NULL;
+    ALTER TABLE `users` MODIFY `expiration_date` date DEFAULT NULL;
+    ALTER TABLE `users` MODIFY `extension_date` date DEFAULT NULL;
+    ALTER TABLE `users` MODIFY `last_login` date DEFAULT NULL;
+        """.split(";"):
+    cursor.execute(query)
 conn.commit()
 print("Update users: end")
 

--- a/docker-compose/migration_scripts/Neurinfo/1_users_migration.py
+++ b/docker-compose/migration_scripts/Neurinfo/1_users_migration.py
@@ -15,49 +15,17 @@ cursor = conn.cursor()
 
 
 print("Update users: start")
-for query in """
-    UPDATE users SET role_id=3 WHERE role_id=2;
-    
-    ALTER TABLE `users` MODIFY `account_request_demand` bit(1) DEFAULT NULL;
-    ALTER TABLE `users` MODIFY `can_access_to_dicom_association` bit(1) DEFAULT NULL;
-    ALTER TABLE `users` MODIFY `creation_date` date DEFAULT NULL;
-    ALTER TABLE `users` MODIFY `expiration_date` date DEFAULT NULL;
-    ALTER TABLE `users` MODIFY `extension_request_demand` bit(1) DEFAULT NULL;
-    ALTER TABLE `users` MODIFY `extension_date` date DEFAULT NULL;
-    ALTER TABLE `users` MODIFY `first_expiration_notification_sent` bit(1) DEFAULT NULL;
-    ALTER TABLE `users` MODIFY `last_login` date DEFAULT NULL;
-    ALTER TABLE `users` MODIFY `second_expiration_notification_sent` bit(1) DEFAULT NULL
-        """.split(";"):
-    cursor.execute(query)
+query = "UPDATE users SET role_id=3 WHERE role_id=2"
+cursor.execute(query)
 conn.commit()
 print("Update users: end")
 
 
 print("Update roles: start")
-cursor.execute("DELETE FROM role WHERE id=2")
-cursor.execute("ALTER TABLE role DROP `access_level`")
+query = "DELETE FROM role WHERE id=2"
+cursor.execute(query)
 conn.commit()
 print("Update roles: end")
-
-
-print("Add events: start")
-cursor.execute("""
-    CREATE TABLE `events` (
-      `id` bigint(20) NOT NULL,
-      `creation_date` datetime DEFAULT NULL,
-      `event_type` varchar(255) DEFAULT NULL,
-      `last_update` datetime DEFAULT NULL,
-      `message` varchar(255) DEFAULT NULL,
-      `object_id` varchar(255) DEFAULT NULL,
-      `progress` float DEFAULT NULL,
-      `status` int(11) NOT NULL,
-      `user_id` bigint(20) DEFAULT NULL,
-      PRIMARY KEY (`id`),
-      KEY `i_user_type` (`user_id`,`event_type`)
-    ) ENGINE=InnoDB
-""")
-conn.commit()
-print("Add events: end")
 
 
 conn.close()


### PR DESCRIPTION
here is a PR which:
- reverts b400e112931 (as discussed last week)
- but restores the `ALTER TABLE` statements for the date fields in the users table (the qualif users ms is currently not running because these changes are missing)

Also I added several automated mysqldump commands in the deployment script to dump the db schemas. This will allow easy comparisons.
| file |  description |
| ----- | ------------------ |
| /var/log/dk/qualif/dbdump-pre-migration.sql | all databases before migration (as created by the ms) |
| /var/log/dk/qualif/dbdump-post-migration.sql | all databases after migration |
| /var/log/dk/qualif/dbdump-prod-studies.sql  | production users db |
| /var/log/dk/qualif/dbdump-prod-users.sql | production studies db |


