### PR TITLE
Shanoir issue#511

### DIFF
--- a/docker-compose/import/Dockerfile
+++ b/docker-compose/import/Dockerfile
@@ -69,8 +69,8 @@ RUN install -m 0755 external/dcm2nii/linux/dcm2nii /opt/nifti-converters/dcm2nii
 RUN install -m 0755 external/mcverter/linux/mcverter_* /opt/nifti-converters/
 RUN cp -n           external/mcverter/linux/lib/lib*.so.* /usr/lib/x86_64-linux-gnu/
 
-RUN mkdir dcm2nii_2008-03-31
-RUN mkdir dcm2nii_2014-08-04
+RUN mkdir -m 1777 dcm2nii_2008-03-31
+RUN mkdir -m 1777 dcm2nii_2014-08-04
 
 # install dicom tool clidcm
 RUN mkdir -p /opt/clidcm/libx64

--- a/docker-compose/import/Dockerfile
+++ b/docker-compose/import/Dockerfile
@@ -69,8 +69,8 @@ RUN install -m 0755 external/dcm2nii/linux/dcm2nii /opt/nifti-converters/dcm2nii
 RUN install -m 0755 external/mcverter/linux/mcverter_* /opt/nifti-converters/
 RUN cp -n           external/mcverter/linux/lib/lib*.so.* /usr/lib/x86_64-linux-gnu/
 
-RUN mkdir -m 1777 dcm2nii_2008-03-31
-RUN mkdir -m 1777 dcm2nii_2014-08-04
+RUN mkdir -m 1777 /.dcm2nii_2008-03-31
+RUN mkdir -m 1777 /.dcm2nii_2014-08-04
 
 # install dicom tool clidcm
 RUN mkdir -p /opt/clidcm/libx64


### PR DESCRIPTION
alternative to #514 to avoid storing dcm2nii config files into an external volume (because `/tmp` needs to be mounted)
