### PR TITLE
fix the version displayed on the front

### DIFF
--- a/shanoir-ng-front/src/version.ts
+++ b/shanoir-ng-front/src/version.ts
@@ -4,8 +4,8 @@ const { resolve, relative } = require('path');
 const { writeFileSync } = require('fs-extra');
 
 const gitInfo = gitDescribeSync({
-    dirtyMark: false,
-    dirtySemver: false
+    match: 'NG_v[0-9]*',
+    longSemver: true
 });
 
 gitInfo.version = version;


### PR DESCRIPTION
- match the current tag format (NG_vxxxx)
- always display the git commit (longSemver=true)
- restore the '-dirty' mark (showed when the git repo is not clean)