### PR TITLE
Fix for GitHub issues: #540 (Pacs import)+#561: import data issue

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/model/mr/MrSequenceVariant.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/model/mr/MrSequenceVariant.java
@@ -20,7 +20,6 @@ package org.shanoir.ng.datasetacquisition.model.mr;
  * @author atouboul
  *
  */
-
 public enum MrSequenceVariant {
 
 	// segmented k-space
@@ -46,6 +45,8 @@ public enum MrSequenceVariant {
 	
 	// no sequence variant
 	NONE(8);
+	
+	private static final String TOF = "TOF";
 	
 	private int id;
 
@@ -87,6 +88,9 @@ public enum MrSequenceVariant {
 	public static MrSequenceVariant getIdByType(final String type) {
 		if (type == null) {
 			return null;
+		}
+		if (TOF.equals(type)) { // see GitHub issue #561
+			return MrSequenceVariant.SS;
 		}
 		return MrSequenceVariant.valueOf(type);
 	}

--- a/shanoir-ng-front/src/app/import/query-pacs/query-pacs.component.html
+++ b/shanoir-ng-front/src/app/import/query-pacs/query-pacs.component.html
@@ -18,9 +18,12 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
     <fieldset class="step">
         <ol>
             <legend>
-                Please fill <strong class="warning">at least one </strong>of the five fields below to query the PACS. Blank is not allowed.
+                Please fill <strong class="warning">at least one</strong> of the five fields below to query the PACS. Blank is not allowed.<br/>
+                If Patient Name, Patient ID or Patient Birth Date is filled, a PatientRoot query is send to the PACS.<br/>
+                You can fill Study Description and Study Date in combination with the three patient values above to affine your search.<br/>
+                If only Study Description or/and Study Date is filled a StudyRoot query is send to the PACS.
             </legend>
-            <p>The maximum number of patients returned being configured as limited, please optimize your query to find relevant results.</p>
+            <p>The maximum number of patients returned is limited to 10, please optimize your query to find relevant results.</p>
             <li>
                 <label>Patient Name</label> 
                 <span class="right-col">

--- a/shanoir-ng-front/src/app/import/select-series/select-series.component.html
+++ b/shanoir-ng-front/src/app/import/select-series/select-series.component.html
@@ -49,7 +49,8 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
                     (buttonClick)="showStudyDetails($event)">
                         <node 
                             *ngFor="let serie of study.series" 
-                            [label]="serie.seriesDescription ? serie.seriesDescription : 'serie n°' + serie.seriesNumber" 
+                            label="{{serie.seriesDescription ? serie.seriesDescription : 'serie n°'
+                            	+ serie.seriesNumber}} {{serie.seriesDate | date: 'dd/MM/yyyy'}}"
                             awesome="fa fa-brain" 
                             hasBox="true" 
                             [(ngModel)]="serie.selected"  
@@ -94,7 +95,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
             </tr>
             <tr class="item">
                 <td class="label">Date</td>
-                <td class="value">{{detailedStudy?.studyDate}}</td>
+                <td class="value">{{detailedStudy?.studyDate | date: 'dd/MM/yyyy'}}</td>
             </tr>
             <tr class="item">
                 <td class="label">Description</td>

--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/dicom/query/QueryPACSService.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/dicom/query/QueryPACSService.java
@@ -156,7 +156,7 @@ public class QueryPACSService {
 			for (int i = 0; i < patientsNbre; i++) {
 				Patient patient = new Patient(attributesPatients.get(i));
 				patients.add(patient);
-				queryStudies(calling, called, patient);
+				queryStudies(calling, called, dicomQuery, patient);
 			}
 			importJob.setPatients(patients);
 		}
@@ -232,11 +232,16 @@ public class QueryPACSService {
 	 * This method queries for studies, creates studies and adds them to patients.
 	 * @param calling
 	 * @param called
+	 * @param dicomQuery 
 	 * @param patient
 	 */
-	private void queryStudies(DicomNode calling, DicomNode called, Patient patient) {
-		DicomParam[] params = { new DicomParam(Tag.PatientID, patient.getPatientID()),
-				new DicomParam(Tag.StudyInstanceUID), new DicomParam(Tag.StudyDate), new DicomParam(Tag.StudyDescription)};
+	private void queryStudies(DicomNode calling, DicomNode called, DicomQuery dicomQuery, Patient patient) {
+		DicomParam[] params = {
+			new DicomParam(Tag.PatientID, patient.getPatientID()),
+			new DicomParam(Tag.StudyInstanceUID),
+			new DicomParam(Tag.StudyDate, dicomQuery.getStudyDate()),
+			new DicomParam(Tag.StudyDescription, dicomQuery.getStudyDescription())
+		};
 		List<Attributes> attributesStudies = queryCFIND(params, QueryRetrieveLevel.STUDY, calling, called);
 		if (attributesStudies != null) {
 			List<Study> studies = new ArrayList<>();
@@ -245,6 +250,7 @@ public class QueryPACSService {
 				studies.add(study);
 				querySeries(calling, called, study);
 			}
+			studies.sort((p1, p2) -> p1.getStudyDate().compareTo(p2.getStudyDate()));
 			patient.setStudies(studies);
 		}
 	}


### PR DESCRIPTION
Prod: import from pacs: use exam date to sort request answer after Pacs query #540
- PatientRootQuery now considers dicom study date and study description as additional criteria
- Dicom study level ordered by study date (-> exam in Shanoir) old to newest
- Dicom tree: displays now the date of the Dicom study (-> exam in Shanoir)
- Wrong date display of Dicom study fixed