### PR TITLE
Shanoir issue#563 - Dicomifier not working

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -204,7 +204,7 @@ services:
   #
   preclinical-bruker2dicom:
     container_name: "${SHANOIR_PREFIX}preclinical-bruker2dicom"
-    image: jcomedouteau/dicomifier.ws
+    image: jcomedouteau/dicomifier.ws:1.0
     command: ["python3", "/opt/dicomifier.ws/run.py"]
     volumes:
       - "logs:/var/log/shanoir-ng-logs"


### PR DESCRIPTION
I updated DockerHub image for dicomifier.ws to tag 1.0 so that it is updated with the new image i loaded.

=> This new image uses 0.0.0.0 instead of 127.0.0.1 to be seen from shanoir-network.