### PR TITLE
Tree fixes

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/security/DatasetSecurityService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/security/DatasetSecurityService.java
@@ -25,6 +25,7 @@ import org.shanoir.ng.dataset.dto.DatasetDTO;
 import org.shanoir.ng.dataset.model.Dataset;
 import org.shanoir.ng.dataset.repository.DatasetRepository;
 import org.shanoir.ng.datasetacquisition.dto.DatasetAcquisitionDTO;
+import org.shanoir.ng.datasetacquisition.dto.ExaminationDatasetAcquisitionDTO;
 import org.shanoir.ng.datasetacquisition.model.DatasetAcquisition;
 import org.shanoir.ng.datasetacquisition.repository.DatasetAcquisitionRepository;
 import org.shanoir.ng.examination.dto.ExaminationDTO;
@@ -491,6 +492,46 @@ public class DatasetSecurityService {
     	});
     	Set<Long> checkedIds = commService.hasRightOnStudies(studyIds, rightStr);
     	list.removeIf((DatasetAcquisition dsa) -> !checkedIds.contains(dsa.getExamination().getStudyId()));
+    	return true;
+    }
+    
+    /**
+     * Filter dataset acquisitions checking the connected user has the right on those.
+     * 
+     * @param page the page
+     * @param rightStr the right
+     * @return true
+     */
+    public boolean filterDatasetAcquisitionDTOList(List<DatasetAcquisitionDTO> list, String rightStr) {
+    	if (list == null) {
+			return true;
+		}
+    	Set<Long> studyIds = new HashSet<Long>();
+    	list.forEach((DatasetAcquisitionDTO dsa) -> {
+    		studyIds.add(dsa.getExamination().getStudyId());
+    	});
+    	Set<Long> checkedIds = commService.hasRightOnStudies(studyIds, rightStr);
+    	list.removeIf((DatasetAcquisitionDTO dsa) -> !checkedIds.contains(dsa.getExamination().getStudyId()));
+    	return true;
+    } 
+    
+    /**
+     * Filter dataset acquisitions checking the connected user has the right on those.
+     * 
+     * @param page the page
+     * @param rightStr the right
+     * @return true
+     */
+    public boolean filterExaminationDatasetAcquisitionDTOList(List<ExaminationDatasetAcquisitionDTO> list, String rightStr) {
+    	if (list == null) {
+			return true;
+		}
+    	Set<Long> studyIds = new HashSet<Long>();
+    	list.forEach((ExaminationDatasetAcquisitionDTO edsa) -> {
+    		studyIds.add(edsa.getStudyId());
+    	});
+    	Set<Long> checkedIds = commService.hasRightOnStudies(studyIds, rightStr);
+    	list.removeIf((ExaminationDatasetAcquisitionDTO edsa) -> !checkedIds.contains(edsa.getStudyId()));
     	return true;
     }
     

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/controler/DatasetAcquisitionApi.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/controler/DatasetAcquisitionApi.java
@@ -86,7 +86,7 @@ public interface DatasetAcquisitionApi {
 			@ApiResponse(code = 500, message = "unexpected error", response = ErrorModel.class) })
 	@RequestMapping(value = "/datasetacquisition/byStudyCard/{studyCardId}", produces = { "application/json" }, method = RequestMethod.GET)
 	@PreAuthorize("hasAnyRole('ADMIN', 'EXPERT', 'USER')")
-	@PostAuthorize("hasRole('ADMIN') or @datasetSecurityService.filterDatasetAcquisitionList(returnObject.getBody(), 'CAN_SEE_ALL')")
+	@PostAuthorize("hasRole('ADMIN') or @datasetSecurityService.filterDatasetAcquisitionDTOList(returnObject.getBody(), 'CAN_SEE_ALL')")
 	ResponseEntity<List<DatasetAcquisitionDTO>> findByStudyCard(
 			@ApiParam(value = "id of the study card", required = true) @PathVariable("studyCardId") Long studyCardId);
 	
@@ -122,7 +122,7 @@ public interface DatasetAcquisitionApi {
 			@ApiResponse(code = 500, message = "unexpected error", response = ErrorModel.class) })
 	@RequestMapping(value = "/datasetacquisition/examination/{examinationId}", produces = { "application/json" }, method = RequestMethod.GET)
 	@PreAuthorize("hasAnyRole('ADMIN', 'EXPERT', 'USER')")
-	@PostAuthorize("hasRole('ADMIN') or @datasetSecurityService.filterDatasetAcquisitionList(returnObject.getBody(), 'CAN_SEE_ALL')")
+	@PostAuthorize("hasRole('ADMIN') or @datasetSecurityService.filterExaminationDatasetAcquisitionDTOList(returnObject.getBody(), 'CAN_SEE_ALL')")
 	ResponseEntity<List<ExaminationDatasetAcquisitionDTO>> findDatasetAcquisitionByExaminationId(
 			@ApiParam(value = "id of the examination", required = true) @PathVariable("examinationId") Long examinationId);
 	

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/dto/ExaminationDatasetAcquisitionDTO.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/dto/ExaminationDatasetAcquisitionDTO.java
@@ -30,6 +30,9 @@ public class ExaminationDatasetAcquisitionDTO extends IdName {
 	private String type;
 
 	private List<DatasetAndProcessingsDTO> datasets;
+	
+	private Long studyId;
+	
 
 	public String getType() {
 		return type;
@@ -53,4 +56,12 @@ public class ExaminationDatasetAcquisitionDTO extends IdName {
 		this.datasets = datasets;
 	}
 
+	public Long getStudyId() {
+		return studyId;
+	}
+
+	public void setStudyId(Long studyId) {
+		this.studyId = studyId;
+	}
+	
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/dto/mapper/ExaminationDatasetAcquisitionDecorator.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/dto/mapper/ExaminationDatasetAcquisitionDecorator.java
@@ -30,7 +30,7 @@ import org.springframework.util.StringUtils;
  *
  */
 public abstract class ExaminationDatasetAcquisitionDecorator implements ExaminationDatasetAcquisitionMapper {
-
+	
 	@Autowired
 	private ExaminationDatasetAcquisitionMapper delegate;
 
@@ -53,6 +53,7 @@ public abstract class ExaminationDatasetAcquisitionDecorator implements Examinat
 		final ExaminationDatasetAcquisitionDTO datasetAcquisitionDTO = delegate
 				.datasetAcquisitionToExaminationDatasetAcquisitionDTO(datasetAcquisition);
 		datasetAcquisitionDTO.setName(getExaminationDatasetAcquisitionDTOName(datasetAcquisition));
+		datasetAcquisitionDTO.setStudyId(datasetAcquisition.getExamination().getStudyId());
 
 		return datasetAcquisitionDTO;
 	}
@@ -102,9 +103,8 @@ public abstract class ExaminationDatasetAcquisitionDecorator implements Examinat
 				result.append(" rank=").append(datasetAcquisition.getRank());
 			}
 		}
-		// TODO: retrieve dataset acquisition type
-		final String type = "";
-
+		
+		final String type = datasetAcquisition.getType();
 		return result.append(" (").append(type).append(")").toString();
 	}
 

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/datasetacquisition/DatasetAcquisitionMapperTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/datasetacquisition/DatasetAcquisitionMapperTest.java
@@ -25,6 +25,7 @@ import org.shanoir.ng.datasetacquisition.dto.ExaminationDatasetAcquisitionDTO;
 import org.shanoir.ng.datasetacquisition.dto.mapper.ExaminationDatasetAcquisitionMapper;
 import org.shanoir.ng.datasetacquisition.model.DatasetAcquisition;
 import org.shanoir.ng.datasetacquisition.model.mr.MrDatasetAcquisition;
+import org.shanoir.ng.examination.model.Examination;
 import org.shanoir.ng.utils.ModelsUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -44,8 +45,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class DatasetAcquisitionMapperTest {
 
 	private static final Long DATASET_ACQUISITION_ID = 1L;
-	private static final String DATASET_ACQUISITION_WIHTOUT_DATASET_NAME = "id=1 ()";
-	private static final String DATASET_ACQUISITION_WIHT_DATASET_NAME = ModelsUtil.DATASET_NAME + " ()";
+	private static final String DATASET_ACQUISITION_WIHTOUT_DATASET_NAME = "id=1 (Mr)";
+	private static final String DATASET_ACQUISITION_WIHT_DATASET_NAME = ModelsUtil.DATASET_NAME + " (Mr)";
 
 	@Autowired
 	private ExaminationDatasetAcquisitionMapper datasetAcquisitionMapper;
@@ -76,6 +77,8 @@ public class DatasetAcquisitionMapperTest {
 		final DatasetAcquisition datasetAcquisition = new MrDatasetAcquisition();
 		datasetAcquisition.setId(DATASET_ACQUISITION_ID);
 		datasetAcquisition.setDatasets(new ArrayList<>());
+		datasetAcquisition.setExamination(new Examination());
+		datasetAcquisition.getExamination().setStudyId(1L);
 		return datasetAcquisition;
 	}
 

--- a/shanoir-ng-front/src/app/datasets/download/dataset-download.component.html
+++ b/shanoir-ng-front/src/app/datasets/download/dataset-download.component.html
@@ -17,7 +17,7 @@
         </ng-container>
     </div>
     <div class="footer">
-        <button *ngIf="!inError" type="button" (click)="download()" >OK</button>
+        <button *ngIf="!inError" type="button" (click)="download()" [disabled]="!type">OK</button>
         <button type="button" (click)="cancel()">Cancel</button>
     </div>
 </div>

--- a/shanoir-ng-front/src/app/datasets/download/dataset-download.component.ts
+++ b/shanoir-ng-front/src/app/datasets/download/dataset-download.component.ts
@@ -41,7 +41,7 @@ export class DatasetDownloadComponent {
     @Input() datasetIds: number[] = [];
     @Input() studyId: number;
     protected useBids: boolean = false;
-    protected type = {value: 'nii', label: 'Nifti'};
+    protected type: 'nii' | 'dcm' = 'nii';
     protected inError: boolean = false;
     protected errorMessage: string;
     protected loading: boolean = false;
@@ -76,12 +76,12 @@ export class DatasetDownloadComponent {
         // Call service method to download datasets
         this.loading = true;
         if (this.mode == 'selected') {
-            this.datasetService.downloadDatasets(this.datasetIds, this.type.value).then(() => this.loading = false);
+            this.datasetService.downloadDatasets(this.datasetIds, this.type).then(() => this.loading = false);
         } else if (this.mode == 'all') {
             if (this.useBids) {
                 this.studyService.exportBIDSByStudyId(this.studyId).then(() => this.loading = false);
             } else {
-                this.datasetService.downloadDatasetsByStudy(this.studyId, this.type.value).then(() => this.loading = false);
+                this.datasetService.downloadDatasetsByStudy(this.studyId, this.type).then(() => this.loading = false);
             }
         } 
         this.downloadDialog.hide();

--- a/shanoir-ng-front/src/app/datasets/tree/dataset-node.component.html
+++ b/shanoir-ng-front/src/app/datasets/tree/dataset-node.component.html
@@ -15,7 +15,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 <node
         *ngIf="node"
         [class.selected]="this.menuOpened"
-        [label]="node.label + ' / ' + menuOpened" 
+        [label]="node.label"
         awesome="fas fa-camera" 
         [(opened)]="node.open"
         (labelClick)="toggleMenu()"

--- a/shanoir-ng-front/src/app/examinations/shared/examination.pipe.ts
+++ b/shanoir-ng-front/src/app/examinations/shared/examination.pipe.ts
@@ -22,7 +22,7 @@ export class ExaminationPipe implements PipeTransform {
 
     transform(examination: Examination | SubjectExamination) {
         if (examination) {
-            return   new Date(examination.examinationDate).toLocaleDateString()  + " , ENCÉPHALIQUE  ( id = " + examination.id + " ) ";
+            return new Date(examination.examinationDate).toLocaleDateString()  + " , ENCÉPHALIQUE  ( id = " + examination.id + " ) ";
         }
         return "";
     }

--- a/shanoir-ng-front/src/app/examinations/tree/examination-node.component.html
+++ b/shanoir-ng-front/src/app/examinations/tree/examination-node.component.html
@@ -16,7 +16,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
         *ngIf="node"
         [class.selected]="this.menuOpened"
         [label]="node.label" 
-        awesome="fas fa-diagnoses" 
+        awesome="fas fa-stethoscope" 
         [(opened)]="node.open"
         (labelClick)="menuOpened = !menuOpened"
         (firstOpen)="firstOpen()"

--- a/shanoir-ng-front/src/app/shared/components/dropdown-menu/menu-item/menu-item.component.html
+++ b/shanoir-ng-front/src/app/shared/components/dropdown-menu/menu-item/menu-item.component.html
@@ -16,7 +16,6 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
     [class.opened]="init && opened" 
     [class.closed]="!opened" 
     [class.animate]="overflow"
-    (click)="click.emit()"
     >
     <!-- [class.disabled]="!hasChildren && boolVar == undefined && (!link || link=='')" -->
     <span 

--- a/shanoir-ng-front/src/app/shared/components/dropdown-menu/menu-item/menu-item.component.ts
+++ b/shanoir-ng-front/src/app/shared/components/dropdown-menu/menu-item/menu-item.component.ts
@@ -31,7 +31,6 @@ export class MenuItemComponent {
     @Input() link: string;
     @Input() boolVar: boolean;
     @Input() awesome: string;
-    @Output() click: EventEmitter<void> = new EventEmitter();;
     @ContentChildren(forwardRef(() => MenuItemComponent)) itemMenus: QueryList<MenuItemComponent>;
 
     public opened: boolean = false;
@@ -115,13 +114,7 @@ export class MenuItemComponent {
         if (this.opened) this.close();
         else this.open();
     }
-
-    public onClick() {
-        if (this.link != undefined || this.boolVar == undefined) {
-            this.cascadingClose();
-        }
-    }
-
+    
     public cascadingClose() {
         if (this.parent) this.parent.cascadingClose();
     }

--- a/shanoir-ng-front/src/app/study-cards/tree/study-card-node.component.ts
+++ b/shanoir-ng-front/src/app/study-cards/tree/study-card-node.component.ts
@@ -46,6 +46,6 @@ export class StudyCardNodeComponent implements OnChanges {
     }
 
     showDetails() {
-        this.router.navigate(['/study-cards/details/' + this.node.id]);
+        this.router.navigate(['/study-card/details/' + this.node.id]);
     }
 }

--- a/shanoir-ng-front/src/app/subjects/tree/subject-node.component.ts
+++ b/shanoir-ng-front/src/app/subjects/tree/subject-node.component.ts
@@ -99,6 +99,7 @@ export class SubjectNodeComponent implements OnChanges {
     }
     
     private mapAcquisitionNode(dsAcq: DatasetAcquisition): DatasetAcquisitionNode {
+        console.log(dsAcq.name);
         return new DatasetAcquisitionNode(
             dsAcq.id,
             dsAcq.name,

--- a/shanoir-ng-front/src/app/subjects/tree/subject-node.component.ts
+++ b/shanoir-ng-front/src/app/subjects/tree/subject-node.component.ts
@@ -99,7 +99,6 @@ export class SubjectNodeComponent implements OnChanges {
     }
     
     private mapAcquisitionNode(dsAcq: DatasetAcquisition): DatasetAcquisitionNode {
-        console.log(dsAcq.name);
         return new DatasetAcquisitionNode(
             dsAcq.id,
             dsAcq.name,


### PR DESCRIPTION
see https://github.com/fli-iam/shanoir-ng/issues/646

* / false behind each dataset (serie dicom), e.g. 3dTof 1 / false ... :ok: 
* View studycard detail from study tree => error ... :ok:  
* 3D T2 FS () behind each exam (actually behind dataset acquisitions) ... :ok:
* As expert, from examination no access to dataset list in tree ... :ok: 
*  issue: icon in menu for examination is not the same as in tree ... :ok: 
* When downloading from dataset detail in study-tree => download launched twice. Due to element cliocked in ? ... :ok: 
* user type User, all rights in study, study details (studyId 178) - click on 001 patient and try to download dicom of first dataset -> error (first mail) ... :ok: 
* user type User, all rights in study, study details (studyId 178) - selected 3 datasets of patient 001, click on selected datasets -> error to choose dataset type (see my 2nd mail) ... :ok: 
