### PR TITLE
Shanoir-issue#574 (actually #674)  special character in search bar

### DIFF
--- a/shanoir-ng-front/src/app/solr/solr.search.component.ts
+++ b/shanoir-ng-front/src/app/solr/solr.search.component.ts
@@ -56,7 +56,7 @@ export class SolrSearchComponent{
     }
     
     buildForm(): FormGroup {
-        const searchBarRegex = '^((studyName|subjectName|datasetName|examinationComment|datasetTypes|datasetNatures)[:][*]?[a-zA-Z0-9\\s_\W]+[*]?[;])+$';
+        const searchBarRegex = '^((studyName|subjectName|datasetName|examinationComment|datasetTypes|datasetNatures)[:][*]?[a-zA-Z0-9\\s_\W\.\!\@\#\$\%\^\&\*\(\)\_\+\-\=]+[*]?[;])+$';
         let formGroup = this.formBuilder.group({
             'keywords': [this.keyword, Validators.pattern(searchBarRegex)],
             'studyName': [this.solrRequest.studyName],


### PR DESCRIPTION
- Only add special char for the moment (prepare for later update => Fix
schema not using SolrConfig.schemaCreationSupport, add center and add
"all" field to search on all fields.)