### PR TITLE
Fix app.css styles in entrypoint

### DIFF
--- a/docker-compose/nginx/entrypoint
+++ b/docker-compose/nginx/entrypoint
@@ -37,7 +37,7 @@ override_colors()
 			local name="${BASH_REMATCH[1]}"
 			local value="${BASH_REMATCH[2]}"
 
-			sed -i "s/^\( *--color-$name *:\).*/\1 $value;/" /etc/nginx/html/assets/css/common.css /etc/nginx/html/app.css
+			sed -i "s/^\( *--color-$name *:\).*/\1 $value;/" /etc/nginx/html/assets/css/common.css /etc/nginx/html/styles.*.css
 		else
 			error "malformatted color spec in SHANOIR_COLORS: '$spec'  (expected: name:#xxxxxx)"
 		fi


### PR DESCRIPTION
replace app.css to styles.*.css in docker-compose/nginx/entrypoint si…nce angular 10 does not generate app.css but styles.*.css