### PR TITLE
fix SHANOIR_COLORS not working with angular 10

### DIFF
--- a/docker-compose/nginx/entrypoint
+++ b/docker-compose/nginx/entrypoint
@@ -37,7 +37,9 @@ override_colors()
 			local name="${BASH_REMATCH[1]}"
 			local value="${BASH_REMATCH[2]}"
 
-			sed -i "s/^\( *--color-$name *:\).*/\1 $value;/" /etc/nginx/html/assets/css/common.css /etc/nginx/html/styles.*.css
+			sed -i "s/^\( *--color-$name *:\)[^;]*/\1 $value;/ ;
+				s/;\( *--color-$name *:\)[^;]*/;\1 $value;/g
+				" /etc/nginx/html/assets/css/common.css /etc/nginx/html/styles.*.css
 		else
 			error "malformatted color spec in SHANOIR_COLORS: '$spec'  (expected: name:#xxxxxx)"
 		fi


### PR DESCRIPTION
Since the migration to angular 10, the css are minified. The regex
overriding the colors from the `SHANOIR_COLORS` env var had to be updated.