### PR TITLE
Shanoir-issue#930 Import email - add examination ID

### DIFF
--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/email/EmailServiceImpl.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/email/EmailServiceImpl.java
@@ -385,6 +385,10 @@ public class EmailServiceImpl implements EmailService {
 			detail.setUrl(this.shanoirServerAddress + "dataset/details/" + dataset.getKey());
 			datasetLinks.add(detail);
 		}
+		
+		DatasetDetail examDetail = new DatasetDetail();
+		examDetail.setName(generatedMail.getExaminationId());
+		examDetail.setUrl(shanoirServerAddress + "examination/details/" + generatedMail.getExaminationId());
 
 		for (User admin : admins) {
 			MimeMessagePreparator messagePreparator = mimeMessage -> {
@@ -399,11 +403,12 @@ public class EmailServiceImpl implements EmailService {
 				variables.put(STUDY_NAME, generatedMail.getStudyName());
 				variables.put(SUBJECT, generatedMail.getSubjectName());
 				variables.put(SERIES, datasetLinks);
-				variables.put(EXAMINATION, shanoirServerAddress + "examination/details/" + generatedMail.getExaminationId());
+				variables.put(EXAMINATION, examDetail);
 				variables.put(EXAM_DATE, generatedMail.getExamDate());
 				variables.put(STUDY_CARD, generatedMail.getStudyCard());
 				variables.put(SERVER_ADDRESS, shanoirServerAddress);
 				final String content = build("notifyStudyAdminDataImported", variables);
+				LOG.error(content);
 				messageHelper.setText(content, true);
 			};
 			// Send the message

--- a/shanoir-ng-users/src/main/resources/templates/notifyStudyAdminDataImported.html
+++ b/shanoir-ng-users/src/main/resources/templates/notifyStudyAdminDataImported.html
@@ -20,7 +20,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
     User <span th:text="${username}"></span> imported data to study <span th:text="${studyName}"></span>.</p>
     <p>Study card: <span th:text="${study_card}"></span><br/>
     Subject: <span th:text="${subject}"></span><br/>
-    <a th:href="${examination}">Examination</a><br/>
+    <a th:href="${examination.url}" th:text="${'Examination ' + examination.name}"></a> <br/>
     Examination Date: <span th:text="${exam_date}"></span></p>
     <p> Datasets: <br/>
     <ul>


### PR DESCRIPTION
@michaelkain I corrected it rapidly if we want to merge it before midday.

Check that the examination ID appears in the generated mail:

<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
<head></head>
<body>
    <p>Dear <span>Julien</span> <span>Louis</span>, <br />
    User <span>jlouis</span> imported data to study <span>DemoStudy</span>.</p>
    <p>Study card: <span>elleafait</span><br />
    Subject: <span>TestMail</span><br />
    <a href="https://shanoir-ng-nginx/shanoir-ng/examination/details/22">Examination 22</a> <br />
    Examination Date: <span>2010-03-04</span></p>
    <p> Datasets: <br />
    <ul>
    <li><a href="https://shanoir-ng-nginx/shanoir-ng/dataset/details/167">tse_vfl_WIP607</a></li>
    <li><a href="https://shanoir-ng-nginx/shanoir-ng/dataset/details/168">tse_vfl_WIP607</a></li>
    <li><a href="https://shanoir-ng-nginx/shanoir-ng/dataset/details/169">tse_vfl_WIP607</a></li>
    <li><a href="https://shanoir-ng-nginx/shanoir-ng/dataset/details/170">tse_vfl_WIP607</a></li>
    <li><a href="https://shanoir-ng-nginx/shanoir-ng/dataset/details/171">tse_vfl_WIP607</a></li>
    <li><a href="https://shanoir-ng-nginx/shanoir-ng/dataset/details/172">localizer 1</a></li>
    <li><a href="https://shanoir-ng-nginx/shanoir-ng/dataset/details/173">localizer 2</a></li>
    <li><a href="https://shanoir-ng-nginx/shanoir-ng/dataset/details/174">localizer 3</a></li>
    </ul>
    </p>
    <p> Please feel free to check data consistency. </p>
    <p>Regards,<br />
    Shanoir administrator</p>
</body>
</html>
