### PR TITLE
Shanoir-issue#920 update dcm2niix version to 2021-03-17

### DIFF
--- a/docker-compose/import/Dockerfile
+++ b/docker-compose/import/Dockerfile
@@ -49,8 +49,8 @@ RUN apt-get update -qq \
     python
 
 # Compile DCM2NIIX from source
-ENV DCMCOMMIT_VERSION=v1.0.20201102
-ENV DCMCOMMIT=1.0.20201102
+ENV DCMCOMMIT_VERSION=v1.0.20210317
+ENV DCMCOMMIT=1.0.20210317
 
 WORKDIR /usr/local/
 RUN curl -#L  https://github.com/rordenlab/dcm2niix/archive/refs/tags/$DCMCOMMIT_VERSION.zip | bsdtar -xf- -C .


### PR DESCRIPTION
Hot to test:
- Deploy
- Import data with a study card with dcm2niix
- Check that the conversion is correctly done
- You can also connect to the shanoir-ng-import microservice and make
- -dcm2niix --version
to check the software version.