### PR TITLE
Shanoir-issue#923 Extension request can be asked after first mail

### DIFF
--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/extensionrequest/controller/ExtensionRequestApiController.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/extensionrequest/controller/ExtensionRequestApiController.java
@@ -44,7 +44,8 @@ public class ExtensionRequestApiController extends AbstractUserRequestApiControl
 	public ResponseEntity<Void> requestExtension(@RequestBody final ExtensionRequestInfo requestInfo) {
 		try {
 			User userToExtend = getUserService().findByEmailForExtension(requestInfo.getEmail()).orElseThrow(() -> new EntityNotFoundException(requestInfo.getEmail()));
-			if (userToExtend.isEnabled()) {
+			// Check that the user is well disabled or that at least the first notification email was sent, see #923
+			if (userToExtend.isEnabled() && (userToExtend.isFirstExpirationNotificationSent() == null || !userToExtend.isFirstExpirationNotificationSent().booleanValue())) {
 				throw new ShanoirException("This user is not disabled, please enter an email of a disabled account. If you forgot your password, please return to login page and follow the adapted link.");
 			}
 			if (userToExtend.isExtensionRequestDemand().booleanValue()) {


### PR DESCRIPTION
How to test
- Grab an activated user
- Try to ask extension request => fail
- Update this user to set the "first_expiration_notification_sent" to true in DB
- Re ask for an account extension
- The account extension is well sent.