### PR TITLE
fix nginx proxy_buffer size and gateway errors

### DIFF
--- a/docker-compose/nginx/shanoir.template.conf
+++ b/docker-compose/nginx/shanoir.template.conf
@@ -13,9 +13,6 @@ proxy_buffering 	off;
 
 proxy_set_header	Host $http_host;
 # NOTE: X-Forward-For/X-Forwarded-Proto are added by the entrypoint
-	
-# transform 502 errors (bad gateway) into 503 (service unavailable)
-error_page 502 =503 /shanoir-ng/503.html;
 
 #
 # Keycloak


### PR DESCRIPTION
While testing the password recovery procedure i got nginx errors: « `upstream sent too big header while reading response header` » because the keycloak HTTP response (~4200 bytes) would not fit in the
buffer.

Also the `/shanoir-ng/503.html` page does not exist therefore nginx transforms the response into a 404 (which is misleading).
