### PR TITLE
increase keycloak access lifetime to 15 minutes

### DIFF
--- a/docker-compose/keycloak/cfg/shanoir-ng-realm.json
+++ b/docker-compose/keycloak/cfg/shanoir-ng-realm.json
@@ -6,7 +6,7 @@
   "notBefore": 0,
   "revokeRefreshToken": false,
   "refreshTokenMaxReuse": 0,
-  "accessTokenLifespan": 300,
+  "accessTokenLifespan": 900,
   "accessTokenLifespanForImplicitFlow": 900,
   "ssoSessionIdleTimeout": 1800,
   "ssoSessionMaxLifespan": 36000,


### PR DESCRIPTION
so that long uploads are not affected