### PR TITLE
Shanoir issue#1070 subject name limitation + download

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/controler/DatasetApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/controler/DatasetApiController.java
@@ -327,6 +327,9 @@ public class DatasetApiController implements DatasetApi {
 			if (subjectOpt.isPresent()) {
 				subjectName = subjectOpt.get().getName();
 			}
+			if (subjectName.contains("/")) {
+				subjectName = subjectName.replaceAll("/", "_");
+			}
 
 			if (DCM.equals(format)) {
 				getDatasetFilePathURLs(dataset, pathURLs, DatasetExpressionFormat.DICOM);
@@ -475,6 +478,9 @@ public class DatasetApiController implements DatasetApi {
 				}
 				// Create a new folder organized by subject / examination
 				String subjectName = subjectRepo.findById(dataset.getSubjectId()).orElse(null).getName();
+				if (subjectName.contains("/")) {
+					subjectName = subjectName.replaceAll("/", "_");
+				}
 				String studyName = studyRepo.findById(dataset.getStudyId()).orElse(null).getName();
 
 				Examination exam = dataset.getDatasetAcquisition().getExamination();

--- a/shanoir-ng-front/src/app/examinations/examination/examination.component.ts
+++ b/shanoir-ng-front/src/app/examinations/examination/examination.component.ts
@@ -57,6 +57,7 @@ export class ExaminationComponent extends EntityComponent<Examination> {
     hasAdministrateRight: boolean = false;
     hasImportRight: boolean = false;
     hasDownloadRight: boolean = false;
+    pattern: string = '[^:|<>&\/]+';
 
     datasetIds: Promise<number[]> = new Promise((resolve, reject) => {});
     datasetIdsLoaded: boolean = false;
@@ -136,7 +137,7 @@ export class ExaminationComponent extends EntityComponent<Examination> {
             'subject': [{value: this.examination.subject, disabled: this.inImport}],
             'center': [{value: this.examination.center, disabled: this.inImport}, Validators.required],
             'examinationDate': [this.examination.examinationDate, [Validators.required, DatepickerComponent.validator]],
-            'comment': [this.examination.comment],
+            'comment': [this.examination.comment, Validators.pattern(this.pattern)],
             'note': [this.examination.note],
             'subjectWeight': [this.examination.subjectWeight]
         });

--- a/shanoir-ng-front/src/app/subjects/subject/subject.component.html
+++ b/shanoir-ng-front/src/app/subjects/subject/subject.component.html
@@ -91,6 +91,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
                                 <label *ngIf="hasError('name', ['required'])" class="form-validation-alert" i18n="Subject detail|Name required error@@subjectDetailNameRequiredError">Common Name is required !</label>
                                 <label *ngIf="hasError('name', ['minlength', 'maxlength'])" class="form-validation-alert" i18n="Subject detail|Name Length error@@subjectDetailNameLengthError">Length must be between 2 and 64 !</label>
                                 <label *ngIf="hasError('name', ['unique'])" class="form-validation-alert" i18n="Subject detail|Name unique error@@subjectDetailNameUniqueError">This name is already taken !</label>
+                                <label *ngIf="hasError('name', ['pattern'])" class="form-validation-alert" i18n="Subject detail|Name chars error@@subjectDetailNameCharsError">Forbidden characters</label>
                             </ng-template>
                         </span>
 					</li>

--- a/shanoir-ng-front/src/app/subjects/subject/subject.component.ts
+++ b/shanoir-ng-front/src/app/subjects/subject/subject.component.ts
@@ -44,7 +44,7 @@ export class SubjectComponent extends EntityComponent<Subject> implements OnInit
     isAlreadyAnonymized: boolean;
     firstName: string = "";
     lastName: string = "";
-    pattern: string = '^[ a-zA-Z0-9.!#$%°&’*+=?^_`{|}~-]*';
+    pattern: string = '[^:|<>&\/]+';
     private nameValidators = [Validators.required, Validators.minLength(2), Validators.maxLength(64), Validators.pattern(this.pattern)];
     forceStudy: Study = null;
 

--- a/shanoir-ng-front/src/app/subjects/subject/subject.component.ts
+++ b/shanoir-ng-front/src/app/subjects/subject/subject.component.ts
@@ -44,7 +44,8 @@ export class SubjectComponent extends EntityComponent<Subject> implements OnInit
     isAlreadyAnonymized: boolean;
     firstName: string = "";
     lastName: string = "";
-    private nameValidators = [Validators.required, Validators.minLength(2), Validators.maxLength(64)];
+    pattern: string = '^[ a-zA-Z0-9.!#$%°&’*+=?^_`{|}~-]*';
+    private nameValidators = [Validators.required, Validators.minLength(2), Validators.maxLength(64), Validators.pattern(this.pattern)];
     forceStudy: Study = null;
 
     catOptions: Option<ImagedObjectCategory>[] = [


### PR DESCRIPTION
How to test:
- Before launching test, import data, create a subject with a name with a slash.
--> Data are not accessible anymore
- After deploy
--> Dataset download is now possible
--> It is now impossible to create a new subject with a name with a '/' in it. (and other specific chars)

Closes #1070 