### PR TITLE
shanoir-issue#1120 Clear BIDS logs - Override file creation

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/exporter/service/BIDSServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/exporter/service/BIDSServiceImpl.java
@@ -414,6 +414,7 @@ public class BIDSServiceImpl implements BIDSService {
 			Path pathToGo = Paths.get(dataFolder.getAbsolutePath() + File.separator + srcFile.getName());
 			try {
 				// Use link to avoid file duplication
+				deleteIfExists(pathToGo.toAbsolutePath().toString());
 				Files.createLink(pathToGo, srcFile.toPath());
 				
 				// Add the file to the scans.tsv reference
@@ -430,6 +431,13 @@ public class BIDSServiceImpl implements BIDSService {
 			} catch (IOException exception) {
 				LOG.error("File could not be created: {}", srcFile.getAbsolutePath(), exception);
 			}
+		}
+	}
+
+	private void deleteIfExists(String filePath) {
+		File file = new File(filePath);
+		if(file.exists()) {
+			file.delete();
 		}
 	}
 

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/exporter/service/BIDSServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/exporter/service/BIDSServiceImpl.java
@@ -425,10 +425,10 @@ public class BIDSServiceImpl implements BIDSService {
 					.append(NEW_LINE);
 
 				// TODO: center_id / comment / weigth / other examination things ?
-				Files.write(Paths.get(scansTsvFile.getAbsolutePath()), buffer.toString().getBytes(), StandardOpenOption.APPEND);
+				Files.write(Paths.get(scansTsvFile.getAbsolutePath()), buffer.toString().getBytes());
 
 			} catch (IOException exception) {
-				LOG.error("File could not be treated: {}", srcFile.getAbsolutePath(), exception);
+				LOG.error("File could not be created: {}", srcFile.getAbsolutePath(), exception);
 			}
 		}
 	}


### PR DESCRIPTION
Clear datasets log file.

When BIDS create iterate over the datasets, it copies the files from nifti file to BIDS folder.
When some of these file already exists, at the moment, an error is set and the logs are flooded.
With this correction, we override the file (which is quite logic to keep the last imported file)

How to test:
- Import some dicom with a given study, subject, examination
- Re-import the exact same file with same study, same subject, same examination -> The logs are no more flooded and the BIDS folder is up to date.
Closes #1120 