### PR TITLE
Shanoir issue#1118 Expiration date update resets expiration notification

### DIFF
--- a/docker-compose/database/db-changes/users/0001_user_expiration_notification.sql
+++ b/docker-compose/database/db-changes/users/0001_user_expiration_notification.sql
@@ -1,3 +1,9 @@
+UPDATE users SET first_expiration_notification_sent = false WHERE first_expiration_notification_sent IS null;
+UPDATE users SET second_expiration_notification_sent = false WHERE second_expiration_notification_sent IS null;
+
+ALTER TABLE users MODIFY first_expiration_notification_sent bit(1) NOT NULL DEFAULT b'0';
+ALTER TABLE users MODIFY second_expiration_notification_sent bit(1) NOT NULL DEFAULT b'0';
+
 UPDATE users SET first_expiration_notification_sent = false, second_expiration_notification_sent = false
 WHERE first_expiration_notification_sent = true
 AND second_expiration_notification_sent = true

--- a/docker-compose/database/db-changes/users/0001_user_expiration_notification.sql
+++ b/docker-compose/database/db-changes/users/0001_user_expiration_notification.sql
@@ -1,6 +1,8 @@
+UPDATE users SET extension_request_demand = false WHERE extension_request_demand IS null;
 UPDATE users SET first_expiration_notification_sent = false WHERE first_expiration_notification_sent IS null;
 UPDATE users SET second_expiration_notification_sent = false WHERE second_expiration_notification_sent IS null;
 
+ALTER TABLE users MODIFY extension_request_demand bit(1) NOT NULL DEFAULT b'0';
 ALTER TABLE users MODIFY first_expiration_notification_sent bit(1) NOT NULL DEFAULT b'0';
 ALTER TABLE users MODIFY second_expiration_notification_sent bit(1) NOT NULL DEFAULT b'0';
 

--- a/docker-compose/database/db-changes/users/0001_user_expiration_notification.sql
+++ b/docker-compose/database/db-changes/users/0001_user_expiration_notification.sql
@@ -1,0 +1,4 @@
+UPDATE users SET first_expiration_notification_sent = false, second_expiration_notification_sent = false
+WHERE first_expiration_notification_sent = true
+AND second_expiration_notification_sent = true
+AND expiration_date > now();

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/user/model/User.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/user/model/User.java
@@ -91,6 +91,7 @@ public class User extends HalEntity implements UserDetails {
 	private Boolean extensionRequestDemand;
 	
 	@VisibleOnlyBy(roles = { "ROLE_ADMIN" })
+	@NotNull
 	private Boolean firstExpirationNotificationSent;
 	
 	@NotBlank
@@ -111,6 +112,7 @@ public class User extends HalEntity implements UserDetails {
 	private Role role;
 	
 	@VisibleOnlyBy(roles = { "ROLE_ADMIN" })
+	@NotNull
 	private Boolean secondExpirationNotificationSent;
 
 	@NotBlank

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/user/model/User.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/user/model/User.java
@@ -88,6 +88,7 @@ public class User extends HalEntity implements UserDetails {
 	private ExtensionRequestInfo extensionRequestInfo;
 
 	@VisibleOnlyBy(roles = { "ROLE_ADMIN" })
+	@NotNull
 	private Boolean extensionRequestDemand;
 	
 	@VisibleOnlyBy(roles = { "ROLE_ADMIN" })

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/user/service/UserServiceImpl.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/user/service/UserServiceImpl.java
@@ -317,7 +317,7 @@ public class UserServiceImpl implements UserService {
 		userDb.setCanAccessToDicomAssociation(user.isCanAccessToDicomAssociation() != null && user.isCanAccessToDicomAssociation());
 		userDb.setEmail(user.getEmail());
 		// If expiration date was updated, reset expiration notifications.
-		if ((userDb.getExpirationDate() == null ^ userDb.getExpirationDate() == null) || !userDb.getExpirationDate().isEqual(user.getExpirationDate())) {
+		if ((userDb.getExpirationDate() == null || userDb.getExpirationDate() == null) || !userDb.getExpirationDate().isEqual(user.getExpirationDate())) {
 			userDb.setFirstExpirationNotificationSent(Boolean.FALSE);
 			userDb.setSecondExpirationNotificationSent(Boolean.FALSE);
 		}

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/user/service/UserServiceImpl.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/user/service/UserServiceImpl.java
@@ -317,7 +317,7 @@ public class UserServiceImpl implements UserService {
 		userDb.setCanAccessToDicomAssociation(user.isCanAccessToDicomAssociation() != null && user.isCanAccessToDicomAssociation());
 		userDb.setEmail(user.getEmail());
 		// If expiration date was updated, reset expiration notifications.
-		if (userDb.getExpirationDate() == null || !userDb.getExpirationDate().isEqual(user.getExpirationDate())) {
+		if ((userDb.getExpirationDate() == null ^ userDb.getExpirationDate() == null) || !userDb.getExpirationDate().isEqual(user.getExpirationDate())) {
 			userDb.setFirstExpirationNotificationSent(Boolean.FALSE);
 			userDb.setSecondExpirationNotificationSent(Boolean.FALSE);
 		}

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/user/service/UserServiceImpl.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/user/service/UserServiceImpl.java
@@ -317,7 +317,7 @@ public class UserServiceImpl implements UserService {
 		userDb.setCanAccessToDicomAssociation(user.isCanAccessToDicomAssociation() != null && user.isCanAccessToDicomAssociation());
 		userDb.setEmail(user.getEmail());
 		// If expiration date was updated, reset expiration notifications.
-		if ((userDb.getExpirationDate() == null || userDb.getExpirationDate() == null) || !userDb.getExpirationDate().isEqual(user.getExpirationDate())) {
+		if (userDb.getExpirationDate() == null || user.getExpirationDate() == null || !userDb.getExpirationDate().isEqual(user.getExpirationDate())) {
 			userDb.setFirstExpirationNotificationSent(Boolean.FALSE);
 			userDb.setSecondExpirationNotificationSent(Boolean.FALSE);
 		}

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/user/service/UserServiceImpl.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/user/service/UserServiceImpl.java
@@ -316,6 +316,11 @@ public class UserServiceImpl implements UserService {
 	private User updateUserValues(final User userDb, final User user) {
 		userDb.setCanAccessToDicomAssociation(user.isCanAccessToDicomAssociation() != null && user.isCanAccessToDicomAssociation());
 		userDb.setEmail(user.getEmail());
+		// If expiration date was updated, reset expiration notifications.
+		if (userDb.getExpirationDate().isEqual(user.getExpirationDate())) {
+			userDb.setFirstExpirationNotificationSent(Boolean.FALSE);
+			userDb.setSecondExpirationNotificationSent(Boolean.FALSE);
+		}
 		userDb.setExpirationDate(user.getExpirationDate());
 		userDb.setFirstName(user.getFirstName());
 		userDb.setLastName(user.getLastName());

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/user/service/UserServiceImpl.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/user/service/UserServiceImpl.java
@@ -317,7 +317,7 @@ public class UserServiceImpl implements UserService {
 		userDb.setCanAccessToDicomAssociation(user.isCanAccessToDicomAssociation() != null && user.isCanAccessToDicomAssociation());
 		userDb.setEmail(user.getEmail());
 		// If expiration date was updated, reset expiration notifications.
-		if (userDb.getExpirationDate().isEqual(user.getExpirationDate())) {
+		if (userDb.getExpirationDate() == null || !userDb.getExpirationDate().isEqual(user.getExpirationDate())) {
 			userDb.setFirstExpirationNotificationSent(Boolean.FALSE);
 			userDb.setSecondExpirationNotificationSent(Boolean.FALSE);
 		}


### PR DESCRIPTION
When updating a user and changing its expiration date, expiration mail triggers were never reset. So changed users (26 on prod) would never receive these expiration messages.
Update database so that all users can now receive correctly expiration notifications.
Now when an expiration date is changed, we reset these triggers.

How to test:
- Force a user in DB with the triggers to true as if mails had already been sent:
`update users set first_expiration_notification_sent = true, second_expiration_notification_sent = true where id = 1;`
- Update this user by changing its expiration date
- Now these two boolean are reset to false.

Closes #1118 