### PR TITLE
Shanoir-issue#1134 Expert user - study edit subjects available

### DIFF
--- a/shanoir-ng-studies/src/main/java/org/shanoir/ng/subject/service/SubjectServiceImpl.java
+++ b/shanoir-ng-studies/src/main/java/org/shanoir/ng/subject/service/SubjectServiceImpl.java
@@ -101,7 +101,7 @@ public class SubjectServiceImpl implements SubjectService {
 	@Override
 	public List<IdName> findNames() {
 		Iterable<Subject> subjects;
-		if (KeycloakUtil.getTokenRoles().contains("ROLE_ADMIN") || KeycloakUtil.getTokenRoles().contains("ROLE_EXPERT")) {
+		if (KeycloakUtil.getTokenRoles().contains("ROLE_ADMIN")) {
 			subjects = subjectRepository.findAll();
 		} else {
 			Long userId = KeycloakUtil.getTokenUserId();


### PR DESCRIPTION
When creating/editing a study as an expert, all subjects are proposed.
Display only subjects the expert 'can see' in other studies. (can be discussed) 

Closes #1134 