### PR TITLE
Shanoir-issue#1129 RabbitMQ timeout for nifti reconversion

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/controler/DatasetApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/controler/DatasetApiController.java
@@ -40,6 +40,7 @@ import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import javax.annotation.PostConstruct;
 import javax.mail.MessagingException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -173,6 +174,12 @@ public class DatasetApiController implements DatasetApi {
 	@org.springframework.beans.factory.annotation.Autowired
 	public DatasetApiController(final HttpServletRequest request) {
 		this.request = request;
+	}
+
+	@PostConstruct
+	private void initialize() {
+		// Set timeout to 1mn (consider nifti reconversion can take some time)
+		this.rabbitTemplate.setReplyTimeout(60000);
 	}
 
 	@Override


### PR DESCRIPTION
- Wait 30sc for nifti reconversion.
How to test:
Deploy on qualif
Detail of 405591 -> reconvert nifti with mcverter
-> The dataset is well downloaded in nifti

Closes #1129 