### PR TITLE
Shanoir-issue#1152 Order facets by number of result (not alphabetically)

### DIFF
--- a/shanoir-ng-front/src/app/solr/criteria/solr.criterion.component.ts
+++ b/shanoir-ng-front/src/app/solr/criteria/solr.criterion.component.ts
@@ -42,7 +42,7 @@ export class SolrCriterionComponent implements OnChanges {
 
     ngOnChanges(changes: SimpleChanges): void {
         if (changes.allFacetPage && this.allFacetPage) {
-            this.sortAllAlphabetically();
+            this.sortAllByNumber();
             this.loaded = true;
         }
         if (changes.currentFacetPage && this.currentFacetPage && this.allFacetPage) {
@@ -52,7 +52,7 @@ export class SolrCriterionComponent implements OnChanges {
     }
 
     update() {
-        //this.sortAll();
+        this.sortAllByNumber();
         this.filter();
         this.displayedFacets = [];
         this.selectedFacets = [];


### PR DESCRIPTION
Facets in SOLR are now ordered by number of results and not alphabetically.
So that, when selecting a study, top subjects actually have results.

This is a quick fix before implementing facets paging.