### PR TITLE
add missing dependencies

### DIFF
--- a/shanoir-ng-front/package-lock.json
+++ b/shanoir-ng-front/package-lock.json
@@ -2966,11 +2966,6 @@
         "color-convert": "^1.9.0"
       }
     },
-    "ansi_up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi_up/-/ansi_up-5.0.0.tgz",
-      "integrity": "sha512-RHw/w3Kb2U3k4XKfl8FXZW9ldxtTBbLNdKO0RboYeU4ReVwRP77M7b/OxiavMGZsBWcDxn/T0QiR+VtLf7mPYw=="
-    },
     "anymatch": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
@@ -6513,6 +6508,23 @@
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "git-describe": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/git-describe/-/git-describe-4.0.4.tgz",
+      "integrity": "sha512-L1X9OO1e4MusB4PzG9LXeXCQifRvyuoHTpuuZ521Qyxn/B0kWHWEOtsT4LsSfSNacZz0h4ZdYDsDG7f+SrA3hg==",
+      "requires": {
+        "lodash": "^4.17.11",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "optional": true
+        }
       }
     },
     "glob": {


### PR DESCRIPTION
When building the production images this file is updated (to add these missing deps), which makes changes in git's working tree, which makes git-describe add the `-dirty` suffix to the version number.