### PR TITLE
Shanoir-issue#1156 Delete events older than 1 year.

### DIFF
--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/events/ShanoirEventsService.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/events/ShanoirEventsService.java
@@ -51,8 +51,8 @@ public class ShanoirEventsService {
 	@Scheduled(fixedDelay = DateUtils.MILLIS_PER_DAY)
 	private void deletePeriodically( ) {
 		Date now = new Date();
-		Long nowMinusSevenDays = now.getTime() - DateUtils.MILLIS_PER_DAY * 180;
-		repository.deleteByLastUpdateBefore(new Date(nowMinusSevenDays));
+		Long nowMinusOneYear = now.getTime() - DateUtils.MILLIS_PER_DAY * 361;
+		repository.deleteByLastUpdateBefore(new Date(nowMinusOneYear));
 	}
 
 	/**


### PR DESCRIPTION
Shanoir events are now stored for 1 year.
Closes #1156 