### PR TITLE
Shanoir-issue#1176 User account request, initialize not null values

### DIFF
--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/accountrequest/controller/AccountRequestApiController.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/accountrequest/controller/AccountRequestApiController.java
@@ -45,6 +45,9 @@ public class AccountRequestApiController extends AbstractUserRequestApiControlle
 
 		user.setExpirationDate(null);
 		user.setAccountRequestDemand(true);
+		user.setFirstExpirationNotificationSent(Boolean.FALSE);
+		user.setSecondExpirationNotificationSent(Boolean.FALSE);
+		user.setExtensionRequestDemand(Boolean.FALSE);
 
 		validate(user, result);
 		

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/user/controller/UserApiController.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/user/controller/UserApiController.java
@@ -140,6 +140,9 @@ public class UserApiController extends AbstractUserRequestApiController implemen
 		if (user.getUsername() == null && user.getFirstName() != null && user.getLastName() != null) {
 			generateUsername(user);
 		}
+		user.setFirstExpirationNotificationSent(Boolean.FALSE);
+		user.setSecondExpirationNotificationSent(Boolean.FALSE);
+		user.setExtensionRequestDemand(Boolean.FALSE);
 		
 		user.setCreationDate(LocalDate.now()); // Set creation date on creation, which is now
 		validateIgnoreBlankUsername(user, result);


### PR DESCRIPTION
Account creation now fails. Some not null values are not well initialized.
How to test:
- Try to create an account -> No error message (other than "mail server communication failed" that happens after).

