### PR TITLE
fix solr bug (can't use several keywords)

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/solr/repository/SolrRepositoryImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/solr/repository/SolrRepositoryImpl.java
@@ -298,8 +298,9 @@ public class SolrRepositoryImpl implements SolrRepositoryCustom {
 
 	private void addSearchInAllClause(SolrQuery query, String searchStr) {
 		if (searchStr != null && !searchStr.isEmpty()) {
-			String[] searchTerms = ClientUtils.escapeQueryChars(searchStr).trim().split(" ");		
+			String[] searchTerms = searchStr.trim().split(" ");		
 			for (String term : searchTerms) {
+				term = ClientUtils.escapeQueryChars(term);
 				List<String> termInFieldFormattedStrList = new ArrayList<>();
 				for (String field : TEXTUAL_FACET_LIST) {
 					StringBuilder termInField = new StringBuilder()


### PR DESCRIPTION
Any spaces in Solr free search where escaped and it made the search return no results. This is fixed here.

Now there is a question. Currently, a free search with several words separated by spaces search for datasets that have at least one of those keywords in any of it's field. 

* use case : studyA studyB gives datasets from studyA and datasets from studyB

But would it be better if it gave datasets that contains every term ?

* use case : 3d t1 subjectA , here the user wants 3d t1 from the sujectA, not every dataset from the database that mention '3d'

For instance in amazon it's a mix of both logic : at top of the results it's the second solution, then there are suggestions that ignore one or more terms.
In my opinion we should go for the second solution. Let's discuss it at the daily.