### PR TITLE
reduce the exposed surface of the keycloak UI/API

### DIFF
--- a/docker-compose/nginx/shanoir.template.conf
+++ b/docker-compose/nginx/shanoir.template.conf
@@ -17,13 +17,20 @@ proxy_set_header	Host $http_host;
 #
 # Keycloak
 #
-# forward (reverse-proxy) all requests for /auth/* to the Keycloak server
 location /auth/ {
-	proxy_pass	http://SHANOIR_PREFIXkeycloak:8080/auth/;
-	# protect admin web interface from outside access
-	location = /auth/admin/ {
-		return 404;
+	# Forward requests to the keycloak server
+	#
+	# This whitelist covers only the locations needed by ordinary users
+	# 	- /auth/js/
+	# 	- /auth/resources/
+	# 	- /auth/realms/shanoir-ng/
+	location ~ ^/auth/(js|resources|realms/shanoir-ng)/
+	{
+		proxy_pass http://SHANOIR_PREFIXkeycloak:8080;
 	}
+
+	# Disallow all other locations (master realm, admin, ...)
+	return 404;
 }
 
 #


### PR DESCRIPTION
This new setup blocks all locations by default and only allows the
minimal set needed by the users.