### PR TITLE
oneshot: ensure child process is not killed with SIGPIPE

### DIFF
--- a/utils/oneshot
+++ b/utils/oneshot
@@ -48,6 +48,7 @@ tee "$fifo2" <"$fifo1" &
 
 set +e
 (	set -e
+	trap 'cat >/dev/null &' EXIT
 	for pattern in "${patterns[@]}"
 	do
 		grep -E -q -m1 -- "$pattern"


### PR DESCRIPTION
Keycloak does not appreciate being killed with SIGPIPE. This makes it crash with a segfault when runing a migration task (eg: `SHANOIR_MIGRATION=init`)
```
  ------------------- sending SIGTERM -------------------
/usr/bin/oneshot: line 65:    23 Segmentation fault      exec "$@" > "$fifo1" 2>&1
  ------------------- terminated (exit 0) -------------------
```
with this change, it only receives a SIGTERM, and terminates cleanly:
```
  ------------------- sending SIGTERM -------------------
*** JBossAS process (447) received TERM signal ***
10:20:12,656 INFO  [org.jboss.as] (MSC service thread 1-4) WFLYSRV0050: Keycloak 12.0.3 (WildFly Core 13.0.3.Final) stopped in 174ms
*** JBossAS process (447) received TERM signal ***
  ------------------- terminated (exit 0) -------------------
```
