### PR TITLE
Shanoir issue#1294 Add subject therapy/pathology during subject creation

### DIFF
--- a/shanoir-ng-front/src/app/preclinical/animalSubject/edit/animalSubject-form.component.ts
+++ b/shanoir-ng-front/src/app/preclinical/animalSubject/edit/animalSubject-form.component.ts
@@ -270,7 +270,7 @@ export class AnimalSubjectFormComponent extends EntityComponent<PreclinicalSubje
         let subjectForm = this.formBuilder.group({
             'imagedObjectCategory': [this.preclinicalSubject.subject.imagedObjectCategory, [Validators.required]],
             'isAlreadyAnonymized': [],
-            'name': [this.preclinicalSubject.subject.name, [this.registerOnSubmitValidator('unique', 'name')]],
+            'name': [this.preclinicalSubject.subject.name, [Validators.required, this.registerOnSubmitValidator('unique', 'name')]],
             'specie': [this.preclinicalSubject.animalSubject.specie, animal ? [Validators.required] : []],
             'strain': [this.preclinicalSubject.animalSubject.strain, animal ? [Validators.required] : []],
             'biotype': [this.preclinicalSubject.animalSubject.biotype, animal ? [Validators.required] : []],

--- a/shanoir-ng-front/src/app/preclinical/pathologies/pathologyModel/edit/pathologyModel-form.component.html
+++ b/shanoir-ng-front/src/app/preclinical/pathologies/pathologyModel/edit/pathologyModel-form.component.html
@@ -100,6 +100,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 				(save)="save()"
                 (delete) = "delete()"
 				(edit)="goToEdit()"
+				(cancel)="goToView()"
 				(back)="goBack()">
 		</form-footer>
     </form>

--- a/shanoir-ng-front/src/app/preclinical/pathologies/subjectPathology/list/subjectPathology-list.component.ts
+++ b/shanoir-ng-front/src/app/preclinical/pathologies/subjectPathology/list/subjectPathology-list.component.ts
@@ -49,6 +49,10 @@ export class SubjectPathologiesListComponent extends SubjectAbstractListInput<Su
     protected getEntity() {
         return new SubjectPathology();
     }
+
+    protected addEntity(subjectEntity: SubjectPathology) {
+        this.preclinicalSubject.pathologies = this.preclinicalSubject.pathologies.concat(subjectEntity);
+    }
     
     protected getOptions(): any {
         // Specify that we can't view a pathology'

--- a/shanoir-ng-front/src/app/preclinical/shared/subjectEntity-list-input.abstract.ts
+++ b/shanoir-ng-front/src/app/preclinical/shared/subjectEntity-list-input.abstract.ts
@@ -46,6 +46,9 @@ export abstract class SubjectAbstractListInput<T extends Entity>  extends Browse
     protected abstract getEntity();
  
     protected abstract getEntityList();
+    
+    protected abstract addEntity(subjectEntity: T);
+
 
     protected addToCache(key: string, toBeCached: any) {
         if (!this.breadcrumbsService.currentStep.isPrefilled(key))  {
@@ -100,10 +103,13 @@ export abstract class SubjectAbstractListInput<T extends Entity>  extends Browse
                 this.addToCache(this.getEntityName() + "ToUpdate", subjectEntity);
             }
         }
+        if (subjectEntity) {
+            this.addEntity(subjectEntity);
+        }
         this.onEvent.emit("create");
         this.table.refresh();
     }
-    
+
     protected removeSubjectEntity = (item: T) => {
         const index: number = this.getEntityList().indexOf(item);
         if (index !== -1) {

--- a/shanoir-ng-front/src/app/preclinical/therapies/subjectTherapy/list/subjectTherapy-list.component.ts
+++ b/shanoir-ng-front/src/app/preclinical/therapies/subjectTherapy/list/subjectTherapy-list.component.ts
@@ -55,6 +55,10 @@ export class SubjectTherapiesListComponent extends SubjectAbstractListInput<Subj
         return this.preclinicalSubject.therapies;
     }
 
+    protected addEntity(subjectEntity: SubjectTherapy) {
+        this.preclinicalSubject.therapies = this.preclinicalSubject.therapies.concat(subjectEntity);
+    }
+
     protected getOptions(): any {
         // Specify that we can't view a therapy
         return {


### PR DESCRIPTION
Closes #1294
How to test:
- Create a new preclinical subject (either import brucker data or directly go to preclinical-subject/create)
- Add a new pathology and therapy
- They are correctly displayed in the table