### PR TITLE
shanoir-issue#1344 disallow dataset table sorting: study / subject

### DIFF
--- a/shanoir-ng-front/src/app/datasets/dataset-list/dataset-list.component.ts
+++ b/shanoir-ng-front/src/app/datasets/dataset-list/dataset-list.component.ts
@@ -68,10 +68,12 @@ export class DatasetListComponent extends EntityListComponent<Dataset>{
             {headerName: "Name", field: "name", orderBy: ["updatedMetadata.name", "originMetadata.name", "id"]},
             {headerName: "Type", field: "type", width: "50px", suppressSorting: true},
             {headerName: "Subject", field: "subject.name",
-				route: (ds: Dataset) =>  '/subject/details/' + ds.subject.id
+				route: (ds: Dataset) =>  '/subject/details/' + ds.subject.id,
+                suppressSorting: true
 			},
             {headerName: "Study", field: "study.name",
-				route: (ds: Dataset) => '/study/details/' + ds.study.id
+				route: (ds: Dataset) => '/study/details/' + ds.study.id,
+                suppressSorting: true
 			},
             {headerName: "Creation date", field: "creationDate", type: "date", cellRenderer: (params: any) => dateRenderer(params.data.creationDate)},
             {headerName: "Comment", field: "originMetadata.comment"},


### PR DESCRIPTION
Closes #1344 

Datasets cannot be sorted by subject name or study name anymore.