### PR TITLE
spring-boot-2.6.6: final adaptations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,7 +197,7 @@ services:
     networks:
       - shanoir_ng_network
     ports:
-     - "9909:9909"
+     - "9905:9905"
      - "9915:9915"
     depends_on:
       - "database"

--- a/docker-compose/nginx/shanoir.template.conf
+++ b/docker-compose/nginx/shanoir.template.conf
@@ -48,4 +48,4 @@ location /shanoir-ng/studies/	{ proxy_pass http://SHANOIR_PREFIXstudies:9902/;	}
 location /shanoir-ng/import/	{ proxy_pass http://SHANOIR_PREFIXimport:9903/;	}
 location /shanoir-ng/dicomweb/	{ proxy_pass http://SHANOIR_PREFIXimport:9903/;	}
 location /shanoir-ng/datasets/	{ proxy_pass http://SHANOIR_PREFIXdatasets:9904/;	}
-location /shanoir-ng/preclinical/ { proxy_pass http://SHANOIR_PREFIXpreclinical:9909/;	}
+location /shanoir-ng/preclinical/ { proxy_pass http://SHANOIR_PREFIXpreclinical:9905/;	}

--- a/shanoir-ng-datasets/src/main/resources/application.yml
+++ b/shanoir-ng-datasets/src/main/resources/application.yml
@@ -25,10 +25,9 @@ spring:
     username: datasets
     password: password
     driver-class-name: com.mysql.cj.jdbc.Driver
-    initialization-mode: never
-    data: classpath:/scripts/import.sql
   jpa:
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+    defer-datasource-initialization: true
     generate-ddl: false # default, but prefer to set it explicitly (bootstrap.sh)
     hibernate:
       # Hibernate ddl auto (create, create-drop, update, validate)
@@ -40,15 +39,15 @@ spring:
           charset: UTF-8
         hbm2ddl:
           import_files_sql_extractor: org.hibernate.tool.hbm2ddl.MultipleLinesSqlCommandExtractor
-    defer-datasource-initialization: true
   main:
     allow-circular-references: true
-  sql:
-    init.mode: never
-    init.data-locations: classpath:/scripts/import.sql
   mvc:
     pathmatch:
       matching-strategy: ANT_PATH_MATCHER
+  sql:
+    init:
+      data-locations: classpath:/scripts/import.sql
+      mode: never
 ##### Others #####
   jackson:
     mapper:
@@ -139,12 +138,11 @@ dcm4chee-arc:
 # DO NOT COMMIT VALUES MODIFICATIONS #
 ######################################
 server:
-  port: 9924
+  port: 9914
 spring:
   config.activate.on-profile: dev
   datasource:
     url: jdbc:mysql://localhost:3307/datasets?useLegacyDatetimeCode=false&serverTimezone=Europe/Paris&characterEncoding=utf-8&useSSL=false
-    initialization-mode: always
   jpa:
     generate-ddl: true
     hibernate:
@@ -152,16 +150,16 @@ spring:
       ddl-auto: create
     # Show or not log for each sql query
     show-sql: true
-    defer-datasource-initialization: true
-  rabbitmq:
-    host: localhost
   main:
     allow-circular-references: true
-  sql:
-    init.mode: always
   mvc:
     pathmatch:
       matching-strategy: ANT_PATH_MATCHER
+  rabbitmq:
+    host: localhost
+  sql:
+    init:
+      mode: always
 front.server:
   address: https://shanoir-ng-nginx/shanoir-ng/
   url: https://shanoir-ng-nginx
@@ -191,19 +189,14 @@ spring:
   main:
     allow-bean-definition-overriding: true
     allow-circular-references: true
-  sql:
-    init.mode: always
-    init.data-locations: classpath:/scripts/test-data-h2.sql
   datasource:
     url: jdbc:h2:mem:SHANOIR_NG_DATASET;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;DATABASE_TO_UPPER=false
     username: sa
     password: 
     driver-class-name: org.h2.Driver
-    initialization-mode: always
-    data: classpath:/scripts/test-data-h2.sql
   jpa:
-    defer-datasource-initialization: true
     database-platform: org.hibernate.dialect.H2Dialect
+    defer-datasource-initialization: true
     generate-ddl: true
     hibernate:
       # Hibernate ddl auto (create, create-drop, update, validate)
@@ -213,3 +206,7 @@ spring:
   mvc:
     pathmatch:
       matching-strategy: ANT_PATH_MATCHER
+  sql:
+    init:
+      data-locations: classpath:/scripts/test-data-h2.sql
+      mode: always

--- a/shanoir-ng-import/src/main/resources/application.yml
+++ b/shanoir-ng-import/src/main/resources/application.yml
@@ -25,13 +25,10 @@ spring:
     username: import
     password: password
     driver-class-name: com.mysql.cj.jdbc.Driver
-    initialization-mode: never
-    data: classpath:/scripts/import.sql
   jpa:
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+    defer-datasource-initialization: true
     generate-ddl: false # default, but prefer to set it explicitly (bootstrap.sh)
-# keep the below for Spring Boot 2.5:
-#    defer-datasource-initialization: true
     hibernate:
       # Hibernate ddl auto (create, create-drop, update, validate)
       ddl-auto: validate
@@ -42,21 +39,15 @@ spring:
           charset: UTF-8
         hbm2ddl:
           import_files_sql_extractor: org.hibernate.tool.hbm2ddl.MultipleLinesSqlCommandExtractor
-    defer-datasource-initialization: true
   main:
     allow-circular-references: true
-  sql:
-    init:
-      mode: never
-      data-locations: classpath:/scripts/import.sql
   mvc:
     pathmatch:
       matching-strategy: ANT_PATH_MATCHER
-# keep the below for Spring Boot 2.5:
-#  sql:
-#    init:
-#      enabled: true
-#      data-locations: classpath:/scripts/import.sql
+  sql:
+    init:
+      data-locations: classpath:/scripts/import.sql
+      mode: never
 ##### Others #####
   jackson:
     mapper:
@@ -158,17 +149,13 @@ shanoir:
 # DO NOT COMMIT VALUES MODIFICATIONS #
 ######################################
 server:
-  port: 9923
+  port: 9913
 spring:
   config.activate.on-profile: dev
-  sql:
-    init.mode: always
   datasource:
     url: jdbc:mysql://localhost:3307/import?useLegacyDatetimeCode=false&serverTimezone=Europe/Paris&characterEncoding=utf-8&allowPublicKeyRetrieval=true&useSSL=false
-    initialization-mode: always
   jpa:
     generate-ddl: true
-    defer-datasource-initialization: true
     hibernate:
       # Hibernate ddl auto (create, create-drop, update, validate)
       ddl-auto: create
@@ -180,6 +167,9 @@ spring:
   mvc:
     pathmatch:
       matching-strategy: ANT_PATH_MATCHER
+  sql:
+    init:
+      mode: always
 front.server:
   address: https://shanoir-ng-nginx/shanoir-ng/
   url: https://shanoir-ng-nginx
@@ -233,19 +223,14 @@ spring:
   main:
     allow-bean-definition-overriding: true
     allow-circular-references: true
-  sql:
-    init.mode: always
-    init.data-locations: classpath:/scripts/test-data-h2.sql
   datasource:
     url: jdbc:h2:mem:SHANOIR_NG_IMPORT;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;DATABASE_TO_UPPER=false
     username: sa
     password: 
     driver-class-name: org.h2.Driver
-    initialization-mode: always
-    data: classpath:/scripts/test-data-h2.sql
   jpa:
-    defer-datasource-initialization: true
     database-platform: org.hibernate.dialect.H2Dialect
+    defer-datasource-initialization: true
     generate-ddl: true
     hibernate:
       # Hibernate ddl auto (create, create-drop, update, validate)
@@ -254,10 +239,10 @@ spring:
   mvc:
     pathmatch:
       matching-strategy: ANT_PATH_MATCHER
-# keep for Spring Boot 2.5
-#  sql:
-#    init:
-#      data-locations: classpath:/scripts/test-data-h2.sql
+  sql:
+    init:
+      data-locations: classpath:/scripts/test-data-h2.sql
+      mode: always
 logging:
   file:
     name: /tmp/shanoir-ng-import.log

--- a/shanoir-ng-preclinical/src/main/resources/application.yml
+++ b/shanoir-ng-preclinical/src/main/resources/application.yml
@@ -14,7 +14,7 @@
 # Default profile is production      #
 ######################################
 server:
-  port: 9909
+  port: 9905
   error:
     whitelabel:
       enabled: false
@@ -25,11 +25,9 @@ spring:
     username: preclinical
     password: password
     driver-class-name: com.mysql.cj.jdbc.Driver
-    initialization-mode: never
-    data: classpath:/scripts/import.sql
   jpa:
-    defer-datasource-initialization: true
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+    defer-datasource-initialization: true
     generate-ddl: false # default, but prefer to set it explicitly (bootstrap.sh)
     hibernate:
       # Hibernate ddl auto (create, create-drop, update, validate)
@@ -48,8 +46,8 @@ spring:
       matching-strategy: ANT_PATH_MATCHER
   sql:
     init:
-      mode: never
       data-locations: classpath:/scripts/import.sql
+      mode: never
 ##### Others #####
   jackson:
     mapper:
@@ -119,18 +117,12 @@ spring:
   main:
     allow-bean-definition-overriding: true
     allow-circular-references: true
-  sql:
-    init.mode: always
-    init.data-locations: classpath:/scripts/test-data-preclinical-h2.sql
   datasource:
     url: jdbc:h2:mem:SHANOIR_NG_PRECLINICAL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;DATABASE_TO_UPPER=false
     username: sa
     password: 
     driver-class-name: org.h2.Driver
-    initialization-mode: always
-    data: classpath:/scripts/test-data-preclinical-h2.sql
   jpa:
-    defer-datasource-initialization: true
     database-platform: org.hibernate.dialect.H2Dialect
     generate-ddl: true
     hibernate:
@@ -139,7 +131,10 @@ spring:
   mvc:
     pathmatch:
       matching-strategy: ANT_PATH_MATCHER
-
+  sql:
+    init:
+      data-locations: classpath:/scripts/test-data-preclinical-h2.sql
+      mode: always
 logging:
   file:
     name: /tmp/shanoir-ng-import.log
@@ -148,10 +143,10 @@ logging:
 ######################################
 # DO NOT COMMIT VALUES MODIFICATIONS #
 ######################################
+server:
+  port: 9915
 spring:
   config.activate.on-profile: dev
-  datasource:
-    initialization-mode: always
   jpa:
     defer-datasource-initialization: true
     generate-ddl: true
@@ -160,13 +155,15 @@ spring:
       ddl-auto: create
     # Show or not log for each sql query
     show-sql: true
-  autoconfigure.exclude: org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration  sql:    init:      mode: always
+  autoconfigure.exclude: org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
   main:
     allow-circular-references: true
   mvc:
     pathmatch:
       matching-strategy: ANT_PATH_MATCHER
-
+  sql:
+    init:
+      mode: always
 # logging configuration
 logging:
   file:

--- a/shanoir-ng-studies/src/main/resources/application.yml
+++ b/shanoir-ng-studies/src/main/resources/application.yml
@@ -25,11 +25,9 @@ spring:
     username: studies
     password: password
     driver-class-name: com.mysql.cj.jdbc.Driver
-    initialization-mode: never
-    data: classpath:/scripts/import.sql
   jpa:
-    defer-datasource-initialization: true
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+    defer-datasource-initialization: true
     generate-ddl: false # default, but prefer to set it explicitly (bootstrap.sh)
     hibernate:
       # Hibernate ddl auto (create, create-drop, update, validate)
@@ -48,8 +46,8 @@ spring:
       matching-strategy: ANT_PATH_MATCHER
   sql:
     init:
-      mode: never
       data-locations: classpath:/scripts/import.sql
+      mode: never
 ##### Others #####
   jackson:
     mapper:
@@ -114,14 +112,12 @@ logging:
 # DO NOT COMMIT VALUES MODIFICATIONS #
 ######################################
 server:
-  port: 9922
+  port: 9912
 spring:
   config.activate.on-profile: dev
   datasource:
     url: jdbc:mysql://localhost:3307/studies?useLegacyDatetimeCode=false&serverTimezone=Europe/Paris&characterEncoding=utf-8&useSSL=false
-    initialization-mode: always
   jpa:
-    defer-datasource-initialization: true
     generate-ddl: true
     hibernate:
       # Hibernate ddl auto (create, create-drop, update, validate)
@@ -131,7 +127,8 @@ spring:
   rabbitmq:
     host: localhost
   sql:
-    init.mode: always
+    init:
+      mode: always
   main:
     allow-circular-references: true
   mvc:
@@ -164,9 +161,6 @@ logging:
 ---
 spring:
   config.activate.on-profile: test
-  sql: 
-    init.mode: always
-    init.data-locations: classpath:/scripts/test-data-h2.sql
   main:
     allow-bean-definition-overriding: true
     allow-circular-references: true
@@ -175,12 +169,10 @@ spring:
     username: sa
     password:
     driver-class-name: org.h2.Driver
-    initialization-mode: always
-    data: classpath:/scripts/test-data-h2.sql
   jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
     defer-datasource-initialization: true
     generate-ddl: true
-    database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       # Hibernate ddl auto (create, create-drop, update, validate)
       ddl-auto: create-drop
@@ -188,4 +180,7 @@ spring:
   mvc:
     pathmatch:
       matching-strategy: ANT_PATH_MATCHER
-
+  sql: 
+    init:
+      data-locations: classpath:/scripts/test-data-h2.sql
+      mode: always

--- a/shanoir-ng-users/src/main/resources/application.yml
+++ b/shanoir-ng-users/src/main/resources/application.yml
@@ -27,11 +27,9 @@ spring:
     username: users
     password: password
     driver-class-name: com.mysql.cj.jdbc.Driver
-    initialization-mode: never
-    data: classpath:/scripts/import.sql
   jpa:
-    defer-datasource-initialization: true
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+    defer-datasource-initialization: true
     generate-ddl: false # default, but prefer to set it explicitly (bootstrap.sh)
     hibernate:
       # Hibernate ddl auto (create, create-drop, update, validate)
@@ -48,8 +46,10 @@ spring:
   mvc:
     pathmatch:
       matching-strategy: ANT_PATH_MATCHER
-  sql.init.mode: never
-  sql.init.data-locations: classpath:/scripts/import.sql
+  sql:
+    init:
+      data-locations: classpath:/scripts/import.sql
+      mode: never
 ##### Others #####
   jackson:
     mapper:
@@ -112,10 +112,12 @@ logging:
 ######################################
 # DO NOT COMMIT VALUES MODIFICATIONS #
 ######################################
+server:
+  port: 9911
 spring:
   config.activate.on-profile: dev
   datasource:
-    initialization-mode: always
+    url: jdbc:mysql://localhost:3307/users?useLegacyDatetimeCode=false&serverTimezone=Europe/Paris&characterEncoding=utf-8&useSSL=false
   jpa:
     generate-ddl: true
     hibernate:
@@ -123,14 +125,15 @@ spring:
       ddl-auto: create
     # Show or not log for each sql query
     show-sql: true
-    defer-datasource-initialization: true
   main:
     allow-circular-references: true
-  sql.init.mode: always
   mvc:
     pathmatch:
       matching-strategy: ANT_PATH_MATCHER
-
+  sql:
+    init:
+      data-locations: classpath:/scripts/import.sql
+      mode: always
 # logging configuration
 logging:
   file:
@@ -143,8 +146,6 @@ logging:
 ---
 spring:
   config.activate.on-profile: test
-  sql.init.mode: always
-  sql.init.data-locations: classpath:/scripts/test-data-h2.sql
   main:
     allow-bean-definition-overriding: true
     allow-circular-references: true
@@ -153,11 +154,9 @@ spring:
     username: sa
     password: 
     driver-class-name: org.h2.Driver
-    initialization-mode: always
-    data: classpath:/scripts/test-data-h2.sql
   jpa:
-    defer-datasource-initialization: true
     database-platform: org.hibernate.dialect.H2Dialect
+    defer-datasource-initialization: true
     generate-ddl: true
     hibernate:
       # Hibernate ddl auto (create, create-drop, update, validate)
@@ -167,6 +166,10 @@ spring:
     port: 3025
     protocol: smtp
   autoconfigure.exclude: org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
+  sql:
+    init:
+      data-locations: classpath:/scripts/test-data-h2.sql
+      mode: always
 front:
   server:
     url: https://shanoir-ng-nginx

--- a/utils/entrypoint_common
+++ b/utils/entrypoint_common
@@ -141,12 +141,12 @@ handle_microservice_migration()
 {
 	case "$SHANOIR_MIGRATION" in
 		dev)
-			env_setdefault	spring.datasource.initialization-mode	never
+			env_setdefault	spring.sql.init.mode	never
 			env_setdefault	spring.jpa.generate-ddl	true
 			env_setdefault	spring.jpa.hibernate.ddl-auto	update
 			;;
 		init)
-			env_setdefault	spring.datasource.initialization-mode	always
+			env_setdefault	spring.sql.init.mode	always
 			env_setdefault	spring.jpa.generate-ddl	true
 			env_setdefault	spring.jpa.hibernate.ddl-auto	create
 
@@ -158,7 +158,7 @@ handle_microservice_migration()
 			env_setdefault	"logging.level.org.shanoir"			INFO
 			;;
 		never|auto)
-			env_setdefault	spring.datasource.initialization-mode	never
+			env_setdefault	spring.sql.init.mode	never
 			env_setdefault	spring.jpa.generate-ddl	false
 			env_setdefault	spring.jpa.hibernate.ddl-auto	validate
 			;;


### PR DESCRIPTION
- application.yml of all 5 microservices cleaned from old spring properties
- preclinical microservice changed to port 9905, to unify port schema for all ms
- utils/entrypoint_common adapted to spring boot 2.6.6 and sql.init.mode change