### PR TITLE
upgrade to dcm4chee 5.27.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -237,7 +237,7 @@ services:
   # https://github.com/dcm4che-dockerfiles/dcm4chee-arc-psql/blob/master/docker-compose.yml
   ldap:
     container_name: "${SHANOIR_PREFIX}ldap"
-    image: dcm4che/slapd-dcm4chee:2.6.2-26.1
+    image: dcm4che/slapd-dcm4chee:2.6.2-27.0
     logging:
       driver: json-file
       options:
@@ -252,7 +252,7 @@ services:
       - "dcm4chee-sldap-data:/etc/openldap/slapd.d"
   dcm4chee-database:
     container_name: "${SHANOIR_PREFIX}dcm4chee-database"
-    image: dcm4che/postgres-dcm4chee:14.2-26
+    image: dcm4che/postgres-dcm4chee:14.4-27
     logging:
       driver: json-file
       options:
@@ -266,7 +266,7 @@ services:
       - "dcm4chee-database-data:/var/lib/postgresql/data"
   dcm4chee-arc:
     container_name: "${SHANOIR_PREFIX}dcm4chee-arc"
-    image: dcm4che/dcm4chee-arc-psql:5.26.1
+    image: dcm4che/dcm4chee-arc-psql:5.27.0
     logging:
       driver: json-file
       options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -233,9 +233,11 @@ services:
       - "8983:8983"
   # Backup PACS microservice: dcm4chee 5 arc-light
   #
+  # The config for the dcm4chee containers is derived from this template:
+  # https://github.com/dcm4che-dockerfiles/dcm4chee-arc-psql/blob/master/docker-compose.yml
   ldap:
     container_name: "${SHANOIR_PREFIX}ldap"
-    image: dcm4che/slapd-dcm4chee:2.4.44-13.0
+    image: dcm4che/slapd-dcm4chee:2.6.2-26.1
     logging:
       driver: json-file
       options:
@@ -246,11 +248,11 @@ services:
       - "389:389"
     env_file: ./docker-compose/dcm4chee/variables.env
     volumes:
-      - "dcm4chee-ldap-data:/var/lib/ldap"
-      - "dcm4chee-sldap-data:/etc/ldap/slapd.d"
+      - "dcm4chee-ldap-data:/var/lib/openldap/openldap-data"
+      - "dcm4chee-sldap-data:/etc/openldap/slapd.d"
   dcm4chee-database:
     container_name: "${SHANOIR_PREFIX}dcm4chee-database"
-    image: dcm4che/postgres-dcm4chee:10.0-13
+    image: dcm4che/postgres-dcm4chee:14.2-26
     logging:
       driver: json-file
       options:
@@ -264,7 +266,7 @@ services:
       - "dcm4chee-database-data:/var/lib/postgresql/data"
   dcm4chee-arc:
     container_name: "${SHANOIR_PREFIX}dcm4chee-arc"
-    image: dcm4che/dcm4chee-arc-psql:5.13.0
+    image: dcm4che/dcm4chee-arc-psql:5.26.1
     logging:
       driver: json-file
       options:
@@ -280,7 +282,7 @@ services:
     env_file: ./docker-compose/dcm4chee/variables.env
     environment:
       POSTGRES_HOST: "${SHANOIR_PREFIX}dcm4chee-database"
-      WILDFLY_CHOWN: /opt/wildfly/standalone /storage
+      WILDFLY_CHOWN: /storage
       WILDFLY_WAIT_FOR: "${SHANOIR_PREFIX}ldap:389 ${SHANOIR_PREFIX}dcm4chee-database:5432"
     depends_on:
       - "ldap"


### PR DESCRIPTION
Note that the postgresql upgrade is not automatic (need to make a full dump and import of the base). In the dev environment you can just destroy the relevant volumes.