### PR TITLE
New imports.log

### DIFF
--- a/docker-compose/datasets/Dockerfile
+++ b/docker-compose/datasets/Dockerfile
@@ -47,6 +47,6 @@ ADD shanoir-ng-datasets.jar shanoir-ng-datasets.jar
 COPY entrypoint entrypoint_common oneshot /bin/
 
 # Use the below line for remote debugging and to active dev profile
-# ENTRYPOINT ["/bin/entrypoint", "java", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=9914,suspend=y", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-Dspring.profiles.active=dev", "-jar", "/shanoir-ng-datasets.jar"]
+# ENTRYPOINT ["/bin/entrypoint", "java", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=0.0.0.0:9914,suspend=y", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-Dspring.profiles.active=dev", "-jar", "/shanoir-ng-datasets.jar"]
 
 ENTRYPOINT ["/bin/entrypoint", "java", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-jar", "/shanoir-ng-datasets.jar"]

--- a/docker-compose/import/Dockerfile
+++ b/docker-compose/import/Dockerfile
@@ -114,5 +114,5 @@ ADD shanoir-ng-import.jar shanoir-ng-import.jar
 COPY entrypoint entrypoint_common oneshot /bin/
 
 # Use the below line for remote debugging and to active dev profile
-#ENTRYPOINT ["/bin/entrypoint", "java", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=9913,suspend=y", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-Dspring.profiles.active=dev", "-jar", "/shanoir-ng-import.jar"]
+#ENTRYPOINT ["/bin/entrypoint", "java", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=0.0.0.0:9913,suspend=y", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-Dspring.profiles.active=dev", "-jar", "/shanoir-ng-import.jar"]
 ENTRYPOINT ["/bin/entrypoint", "java", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-jar", "/shanoir-ng-import.jar"]

--- a/docker-compose/preclinical/Dockerfile
+++ b/docker-compose/preclinical/Dockerfile
@@ -17,6 +17,6 @@ ADD shanoir-ng-preclinical.jar shanoir-ng-preclinical.jar
 COPY entrypoint entrypoint_common oneshot /bin/
 
 # Use the below line for remote debugging
-#ENTRYPOINT ["/bin/entrypoint", "java", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=9915,suspend=y", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-Dspring.profiles.active=dev", "-jar", "/shanoir-ng-preclinical.jar"]
+#ENTRYPOINT ["/bin/entrypoint", "java", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=0.0.0.0:9915,suspend=y", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-Dspring.profiles.active=dev", "-jar", "/shanoir-ng-preclinical.jar"]
 
 ENTRYPOINT ["/bin/entrypoint", "java","-Xmx6g", "-Xms1g",  "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-jar", "/shanoir-ng-preclinical.jar"]

--- a/docker-compose/studies/Dockerfile
+++ b/docker-compose/studies/Dockerfile
@@ -29,6 +29,6 @@ ADD shanoir-ng-studies.jar shanoir-ng-studies.jar
 COPY entrypoint entrypoint_common oneshot /bin/
 
 # Use the below line for remote debugging and to active dev profile
-#ENTRYPOINT ["/bin/entrypoint", "java", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=9912,suspend=y", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-Dspring.profiles.active=dev", "-jar", "/shanoir-ng-studies.jar"]
+#ENTRYPOINT ["/bin/entrypoint", "java", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=0.0.0.0:9912,suspend=y", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-Dspring.profiles.active=dev", "-jar", "/shanoir-ng-studies.jar"]
 
 ENTRYPOINT ["/bin/entrypoint", "java", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-jar", "/shanoir-ng-studies.jar"]

--- a/docker-compose/users/Dockerfile
+++ b/docker-compose/users/Dockerfile
@@ -28,7 +28,7 @@ ADD shanoir-ng-users.jar shanoir-ng-users.jar
 COPY entrypoint entrypoint_common oneshot /bin/
 
 # Use the below line for remote debugging and development profile purpose
-#ENTRYPOINT ["/bin/entrypoint", "java", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=9911,suspend=y", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-Dspring.profiles.active=dev", "-jar", "/shanoir-ng-users.jar", "--syncAllUsersToKeycloak=true"]
+#ENTRYPOINT ["/bin/entrypoint", "java", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=0.0.0.0:9911,suspend=y", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-Dspring.profiles.active=dev", "-jar", "/shanoir-ng-users.jar", "--syncAllUsersToKeycloak=true"]
 
 ENV	\
 	kc.admin.client.client.id="admin-cli"	\

--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/ImporterApiController.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/ImporterApiController.java
@@ -242,6 +242,7 @@ public class ImporterApiController implements ImporterApi {
 					throws RestServiceException {
 		File userImportDir = ImportUtils.getUserImportDir(importDir);
 		final Long userId = KeycloakUtil.getTokenUserId();
+		importJob.setUserId(userId);
 		String tempDirId = importJob.getWorkFolder();
 		final File importJobDir = new File(userImportDir, tempDirId);
 		if (importJobDir.exists()) {
@@ -250,6 +251,7 @@ public class ImporterApiController implements ImporterApi {
 				importJob.setAnonymisationProfileToUse("Profile Neurinfo");
 			}
 			removeUnselectedSeries(importJob);
+			LOG.info("Starting import job for userId: {} with import job folder: {}", userId, importJob.getWorkFolder());
 			importerManagerService.manageImportJob(userId, KeycloakUtil.getKeycloakHeader(), importJob);
 			return new ResponseEntity<>(HttpStatus.OK);
 		} else {

--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/dcm2nii/DatasetsCreatorAndNIfTIConverterService.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/dcm2nii/DatasetsCreatorAndNIfTIConverterService.java
@@ -530,22 +530,16 @@ public class DatasetsCreatorAndNIfTIConverterService {
 	 * @throws NoSuchFieldException
 	 */
 	private NIfTIConverter datasetToNiftiConversionLauncher(Dataset dataset, File directory, Serie serie, Long converterId, boolean isConvertAs4D, boolean isConvertWithClidcm) throws NoSuchFieldException, SecurityException {
-
 		// search for the existing files in the destination folder
-
-		LOG.info("convertToNifti : create nifti files for the dataset : {}", dataset.getName());
 		if (conversionLogs != null && !"".equals(conversionLogs)) {
 			conversionLogs += "\n";
 		} else {
 			conversionLogs = "";
 		}
-
-
 		NIfTIConverter converter = findById(converterId);
 		convertToNiftiExec(converter, directory.getPath(), directory.getPath(), isConvertAs4D);
-		LOG.info("conversionLogs : {}", conversionLogs);
+		LOG.debug("conversionLogs : {}", conversionLogs);
 		return converter;
-
 	}
 
 
@@ -554,7 +548,6 @@ public class DatasetsCreatorAndNIfTIConverterService {
 	 * 
 	 * @return List of nifti files
 	 */
-
 	private List<File> niftiFileSorting(List<File> existingFiles, File directory, File serieIDFolderFile) {
 		// If one of the output files is a prop file, there has been an error
 		List<File> niftiFileResult = null;
@@ -564,7 +557,7 @@ public class DatasetsCreatorAndNIfTIConverterService {
 			if (!containsPropFile(niiFiles)) {
 				for (File niiFile : niiFiles) {
 					outputFiles.get(serieIDFolderFile.getName()).add(niiFile.getAbsolutePath());
-					LOG.info("Path niiFile : {}", niiFile.getAbsolutePath());
+					LOG.debug("Path niiFile : {}", niiFile.getAbsolutePath());
 				}
 			}
 		} else {
@@ -574,7 +567,7 @@ public class DatasetsCreatorAndNIfTIConverterService {
 				niftiFileResult = niiFileList;
 				for (File niiFile : niiFileList) {
 					niiPathList.add(niiFile.getAbsolutePath());
-					LOG.info("Path niiFile : {}", niiFile.getAbsolutePath());
+					LOG.debug("Path niiFile : {}", niiFile.getAbsolutePath());
 				}
 				outputFiles.put(serieIDFolderFile.getName(), niiPathList);
 			}
@@ -619,7 +612,7 @@ public class DatasetsCreatorAndNIfTIConverterService {
 	}
 
 	/**
-	 * This method generates the nifti files of serie  in proper datasets for an entire serie.
+	 * This method generates the nifti files of a serie in proper datasets for an entire serie.
 	 * It also constructs the associated Nifti ExpressionFormat and DatasetFiles within the Dataset object.
 	 * Finally it also constructs the Bvec and BVal values needed for Diffusion and store them in a a list of Diffusion Gradient which is hold by the dataset itself.
 	 *
@@ -649,7 +642,7 @@ public class DatasetsCreatorAndNIfTIConverterService {
 				for (Dataset dataset : serie.getDatasets()) {
 					File directory = new File(serieIDFolderFile + File.separator + DATASET_STR + index);
 					if (directory.isDirectory()) {
-						LOG.info("convertToNifti : create nifti files for the dataset {} in directory : {}", dataset.getName(), directory.getName());
+						LOG.debug("convertToNifti : create nifti files for the dataset {} in directory : {}", dataset.getName(), directory.getName());
 						final List<File> existingFiles = Arrays.asList(directory.listFiles());
 						NIfTIConverter converter = null;
 						try {
@@ -666,7 +659,7 @@ public class DatasetsCreatorAndNIfTIConverterService {
 				// Need to construct nifti files for only one dataset in current serie
 				Dataset dataset = serie.getDatasets().get(0);
 				if (serieIDFolderFile.isDirectory()) {
-					LOG.info("convertToNifti : create nifti files for the dataset {} in directory : {}", dataset.getName(), serieIDFolderFile.getName());
+					LOG.debug("convertToNifti : create nifti files for the dataset {} in directory : {}", dataset.getName(), serieIDFolderFile.getName());
 					final List<File> existingFiles = Arrays.asList(serieIDFolderFile.listFiles());
 					NIfTIConverter converter = null;
 					try {
@@ -675,7 +668,6 @@ public class DatasetsCreatorAndNIfTIConverterService {
 						LOG.error(e.getMessage());
 					}
 					List<File> niftiGeneratedFiles = converter.isDicomifier() ? niftiFileSortingDicom2Nifti(existingFiles, serieIDFolderFile, dataset) : niftiFileSorting(existingFiles, serieIDFolderFile, serieIDFolderFile);
-
 					constructNiftiExpressionAndDatasetFiles(converter, dataset, serie, niftiGeneratedFiles);
 				}
 			}

--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/dicom/ImagesCreatorAndDicomFileAnalyzerService.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/dicom/ImagesCreatorAndDicomFileAnalyzerService.java
@@ -211,7 +211,7 @@ public class ImagesCreatorAndDicomFileAnalyzerService {
 				images.add(image);
 			}
 		} catch (IOException e) {
-			LOG.error("Error during DICOM file process", e);
+			LOG.error("Error during DICOM file process.", e);
 		}
 	}
 	
@@ -224,7 +224,7 @@ public class ImagesCreatorAndDicomFileAnalyzerService {
 	 */
 	private void processDicomFileForFirstInstance(File dicomFile, Serie serie, Patient patient) {
 		try (DicomInputStream dIS = new DicomInputStream(dicomFile)) {
-			LOG.warn("Process first DICOM file of serie {} path {}", serie.getSeriesInstanceUID() + " " + serie.getSeriesDescription(), dicomFile.getAbsolutePath());
+			LOG.debug("Process first DICOM file of serie {} path {}", serie.getSeriesInstanceUID() + " " + serie.getSeriesDescription(), dicomFile.getAbsolutePath());
 			Attributes attributes = dIS.readDataset(-1, -1);
 			checkPatientData(patient, attributes);
 			checkSerieData(serie, attributes);
@@ -258,7 +258,7 @@ public class ImagesCreatorAndDicomFileAnalyzerService {
 			}
 			image.setImageOrientationPatient(imageOrientationPatient);
 		} else {
-			LOG.warn("imageOrientationPatientArray in dcm file null: {}", image.getPath());
+			LOG.debug("imageOrientationPatientArray in dcm file null: {}", image.getPath());
 		}
 		// repetition time
 		image.setRepetitionTime(attributes.getDouble(Tag.RepetitionTime, 0));

--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/model/ImportJob.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/model/ImportJob.java
@@ -198,5 +198,38 @@ public class ImportJob implements Serializable {
 	public void setUserId(Long userId) {
 		this.userId = userId;
 	}
+
+	@Override
+	public String toString() {
+		String importType;
+		if (fromDicomZip) {
+			importType = "ZIP";
+		} else if (fromShanoirUploader) {
+			importType = "SHUP";
+		} else if (fromPacs) {
+			importType = "PACS";
+		} else {
+			importType = "UNSUPPORTED";
+		}
+		int numberOfSeries = 0;
+		String modality = "unknown";
+		boolean enhanced = false;
+		if (patients != null && !patients.isEmpty()) {
+			Patient patient = patients.get(0);
+			if (patient.getStudies() != null && !patient.getStudies().isEmpty()) {
+				Study study = patient.getStudies().get(0);
+				if (study.getSeries() != null && !study.getSeries().isEmpty()) {
+					numberOfSeries = study.getSeries().size(); // only selected series remain at the stage of the logging call
+					Serie serie = study.getSeries().get(0);
+					modality = serie.getModality();
+					enhanced = serie.getIsEnhanced();
+				}
+			}
+		}
+		return 	"userId=" + userId + ",studyName=" + studyName + ",studyCardId=" + studyCardId + ",type=" + importType +
+				",workFolder=" + workFolder + ",pseudoProfile=" + anonymisationProfileToUse + ",modality=" + modality + ",enhanced=" + enhanced +
+				",subjectName=" + subjectName + ",examId=" + examinationId  + ",converterId=" + converterId + ",numberOfSeries=" + numberOfSeries;
+	}
+	
 }
 

--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/model/ImportJob.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/model/ImportJob.java
@@ -17,6 +17,7 @@ package org.shanoir.ng.importer.model;
 import java.io.Serializable;
 import java.util.List;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.shanoir.ng.shared.event.ShanoirEvent;
 
 /**
@@ -214,11 +215,11 @@ public class ImportJob implements Serializable {
 		int numberOfSeries = 0;
 		String modality = "unknown";
 		boolean enhanced = false;
-		if (patients != null && !patients.isEmpty()) {
+		if (CollectionUtils.isNotEmpty(patients)) {
 			Patient patient = patients.get(0);
-			if (patient.getStudies() != null && !patient.getStudies().isEmpty()) {
+			if (CollectionUtils.isNotEmpty(patient.getStudies())) {
 				Study study = patient.getStudies().get(0);
-				if (study.getSeries() != null && !study.getSeries().isEmpty()) {
+				if (CollectionUtils.isNotEmpty(study.getSeries())) {
 					numberOfSeries = study.getSeries().size(); // only selected series remain at the stage of the logging call
 					Serie serie = study.getSeries().get(0);
 					modality = serie.getModality();

--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/utils/ShanoirExec.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/utils/ShanoirExec.java
@@ -66,7 +66,7 @@ public class ShanoirExec {
 	 */
 	public String clidcmExec(final String inputFolder, final String clidcmPath, final String outputFolder) {
 		LOG.debug("clidcmExec : Begin");
-		LOG.info("clidcmExec : {}", clidcmPath);
+		LOG.debug("clidcmExec : {}", clidcmPath);
 
 		String[] cmd = new String[4];
 		cmd[0] = clidcmPath;
@@ -133,7 +133,7 @@ public class ShanoirExec {
 	 */
 	public String dcm2niiExec(final String inputFolder, final String dcm2niiPath, final String outputFolder, boolean is4D) {
 		LOG.debug("dcm2niiExec : Begin");
-		LOG.info("dcm2niiExec : {}", dcm2niiPath);
+		LOG.debug("dcm2niiExec : {}", dcm2niiPath);
 
 		String[] cmd = null;
 
@@ -252,7 +252,7 @@ public class ShanoirExec {
 			}
 		}
 
-		LOG.info("CMD DCM2NII {}", Arrays.asList(cmd));
+		LOG.debug("CMD DCM2NII {}", Arrays.asList(cmd));
 
 		final String result = exec(cmd);
 
@@ -274,7 +274,7 @@ public class ShanoirExec {
 	 */
 	public String mcverterExec(final String inputFolder, final String mcverterPath, final String outputFolder, boolean is4D) {
 		LOG.debug("mcverterExec : Begin");
-		LOG.info("mcverterExec : {}", mcverterPath);
+		LOG.debug("mcverterExec : {}", mcverterPath);
 
 		String[] cmd = null;
 		if(is4D){
@@ -395,7 +395,7 @@ public class ShanoirExec {
 			result += outputGobbler.getStringDisplay();
 		}
 
-		LOG.info("mcverterVersionExec = {}", result);
+		LOG.debug("mcverterVersionExec = {}", result);
 		LOG.debug("mcverterVersionExec : End");
 		return result;
 
@@ -413,11 +413,11 @@ public class ShanoirExec {
 	 */
 	public String dcm2niiVersionExec(final String dcm2niiPath) {
 		LOG.debug("dcm2niiVersionExec : Begin");
-		LOG.info("dcm2niiVersionExec : {}", dcm2niiPath);
+		LOG.debug("dcm2niiVersionExec : {}", dcm2niiPath);
 		String[] cmd = new String[1];
 		cmd[0] = dcm2niiPath;
 		final String result = exec(cmd);
-		LOG.info("dcm2niiVersionExec : {}", result);
+		LOG.debug("dcm2niiVersionExec : {}", result);
 		LOG.debug("dcm2niiVersionExec : End");
 		return result;
 	}
@@ -462,7 +462,7 @@ public class ShanoirExec {
 		cmdLine.append(outputFolder);
 		cmd[2] = cmdLine.toString();
 
-		LOG.info("CMD DICOM2NIFTI {}", Arrays.asList(cmd));
+		LOG.debug("CMD DICOM2NIFTI {}", Arrays.asList(cmd));
 
 		final String result = exec(cmd);
 
@@ -483,7 +483,7 @@ public class ShanoirExec {
 	 */
 	public String dcmdjpeg(final String dcmdjpegPath, final String inputFile, final String outputFile) {
 		LOG.debug("dcmdjpeg : Begin");
-		LOG.info("dcmdjpeg : {}", dcmdjpegPath);
+		LOG.debug("dcmdjpeg : {}", dcmdjpegPath);
 
 		String[] cmd = new String[3];
 		cmd[0] = dcmdjpegPath;

--- a/shanoir-ng-import/src/main/resources/logback-spring.xml
+++ b/shanoir-ng-import/src/main/resources/logback-spring.xml
@@ -53,6 +53,10 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
         <appender-ref ref="IMPORTS_FILE_LOG" />
     </logger>
 
+    <logger name="org.dcm4che3" level="WARN" additivity="false">
+        <appender-ref ref="FILE" />
+    </logger>
+
     <root level="INFO">
         <appender-ref ref="FILE" />
         <appender-ref ref="CONSOLE" />

--- a/shanoir-ng-import/src/main/resources/logback-spring.xml
+++ b/shanoir-ng-import/src/main/resources/logback-spring.xml
@@ -21,24 +21,38 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
     <include resource="org/springframework/boot/logging/logback/file-appender.xml" />
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder><pattern>${CONSOLE_LOG_PATTERN}</pattern></encoder>
-
+        <encoder>
+        	<pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter"> 
             <level>${SHANOIR_CONSOLE_LOG_LEVEL}</level>
         </filter>
     </appender>
 
-    <appender name="EVENT_FILE_LOG" class="ch.qos.logback.core.FileAppender">
+    <appender name="EVENTS_FILE_LOG" class="ch.qos.logback.core.FileAppender">
         <file>/var/log/shanoir-ng-logs/shanoir-events.log</file>
         <append>true</append>
         <encoder>
-            <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd_HH:mm:ss.SSS} [%thread] %-5level %logger{35} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    
+    <appender name="IMPORTS_FILE_LOG" class="ch.qos.logback.core.FileAppender">
+        <file>/var/log/shanoir-ng-logs/shanoir-imports.log</file>
+        <append>true</append>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd_HH:mm:ss.SSS} - %msg%n</pattern>
         </encoder>
     </appender>
 
     <logger name="org.shanoir.ng.shared.event" level="INFO" additivity="false">
-        <appender-ref ref="EVENT_FILE_LOG" />
+        <appender-ref ref="EVENTS_FILE_LOG" />
     </logger>
+    
+    <logger name="org.shanoir.ng.importer.ImporterManagerService" level="INFO" additivity="false">
+        <appender-ref ref="IMPORTS_FILE_LOG" />
+    </logger>
+
     <root level="INFO">
         <appender-ref ref="FILE" />
         <appender-ref ref="CONSOLE" />


### PR DESCRIPTION
- shanoir-imports.log introduced, slight modification on shanoir-events.log format
- one line of CSV style log, per import started: evaluate especially the percentage of DICOM Enhanced used during the imports
- shanoir-ng-import.log optimised: nifti conversion removed + warnings reduced
- better debug with remote application: change in all Dockerfile (for dev only)