### PR TITLE
fix the detection of existing migrations

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: fetch the master branch
+      run: git fetch --no-tags --no-recurse-submodules --depth=1 origin +refs/heads/master:refs/remotes/origin/master
     - name: check migration names
       run: cd docker-compose/database && ./check_migration_names.py
     - name: Set up JDK 11

--- a/docker-compose/database/check_migration_names.py
+++ b/docker-compose/database/check_migration_names.py
@@ -18,7 +18,7 @@ for path in pathlib.Path("db-changes").glob("*"):
         print(f"{30*'#'} {db} {45*'#'}"[:79])
 
         # get the existing migrations from the RELEASE_BRANCH
-        proc = subprocess.run(["git", "ls-tree", f"{RELEASE_BRANCH}/develop:db-changes/{db}"],
+        proc = subprocess.run(["git", "ls-tree", RELEASE_BRANCH], cwd=f"db-changes/{db}",
                 encoding="utf-8", capture_output=True, errors="replace")
         if proc.returncode == 0:
             released_migrations = set(line.split("\t", 1)[1] for line in proc.stdout.splitlines())
@@ -47,7 +47,7 @@ for path in pathlib.Path("db-changes").glob("*"):
 
 print("#"*79)
 if errors:
-    print(f"{errors} errors (migrations must be ordered after all migrations in {RELEASE_BRANCH})")
+    print(f"{errors} errors (new migrations must have a greater sequence number than all existing migrations in {RELEASE_BRANCH})")
     sys.exit(1)
 else:
     print ("success")


### PR DESCRIPTION
The "check migration names" stage in the ci pipeline fails to detect existing migrations in the master branch. They appear as `(none)` in https://github.com/fli-iam/shanoir-ng/actions/runs/3046116136/jobs/4908518031

With proper detection this script would have caught the bugs that had to be fixed in ca84e9502b and d25400f693.


Note: #1407 has to be merged before this PR (otherwise this fix will make it fail the test)
