### PR TITLE
shanoir-issue#1412 Shanoir-uploader - bug when equip number null

### DIFF
--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/action/ImportDialogOpener.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/action/ImportDialogOpener.java
@@ -140,6 +140,7 @@ public class ImportDialogOpener {
 											String manufacturerModelNameSC = acquisitionEquipment.getManufacturerModel().getName();
 											if (manufacturerSC.compareToIgnoreCase(manufacturer) == 0
 													&& manufacturerModelNameSC.compareToIgnoreCase(manufacturerModelName) == 0
+													&& acquisitionEquipment.getSerialNumber() != null
 													&& acquisitionEquipment.getSerialNumber().compareToIgnoreCase(deviceSerialNumber) == 0) {
 												studyCard.setCompatible(true);
 												compatibleStudyCard = true;


### PR DESCRIPTION
Closes #1412 

How to test:
- Create an equipment with no serial number
- Create a study card with this equipment
- Try to upload data on this study using shanoir uploader
--> There should be no error.