### PR TITLE
shanoir-issue#1425-processing-circular-dependency - resolve

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/controler/DatasetApi.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/controler/DatasetApi.java
@@ -270,5 +270,16 @@ public interface DatasetApi {
 			@RequestParam(value = "subjectNameInRegExp", required = false) String subjectNameInRegExp,
 			@ApiParam(value = "Subject name excluding regular expression", required=false) @Valid
 			@RequestParam(value = "subjectNameOutRegExp", required = false) String subjectNameOutRegExp) throws RestServiceException, IOException;
+
+	@ApiOperation(value = "", notes = "If exists, returns the datasets corresponding to the given ids", response = List.class, tags = {})
+	@ApiResponses(value = { @ApiResponse(code = 200, message = "found dataset", response = Dataset.class),
+			@ApiResponse(code = 401, message = "unauthorized", response = Void.class),
+			@ApiResponse(code = 403, message = "forbidden", response = Void.class),
+			@ApiResponse(code = 404, message = "no study found", response = Void.class),
+			@ApiResponse(code = 500, message = "unexpected error", response = ErrorModel.class) })
+	@GetMapping(value = "/allById", produces = { "application/json" })
+	@PreAuthorize("hasRole('ADMIN') or (hasAnyRole('EXPERT', 'USER') and @datasetSecurityService.hasRightOnEveryDataset(#datasetIds, 'CAN_SEE_ALL'))")
+	ResponseEntity<List<DatasetDTO>> findDatasetsByIds(
+			@RequestParam(value = "datasetIds", required = true) List<Long> datasetIds);
 		
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/controler/DatasetApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/controler/DatasetApiController.java
@@ -257,6 +257,16 @@ public class DatasetApiController implements DatasetApi {
 	}
 
 	@Override
+	public ResponseEntity<List<DatasetDTO>> findDatasetsByIds(
+			@RequestParam(value = "datasetIds", required = true) List<Long> datasetIds) {
+		List<Dataset> datasets = datasetService.findByIdIn(datasetIds);
+		if (datasets.isEmpty()) {
+			return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+		}
+		return new ResponseEntity<List<DatasetDTO>>(datasetMapper.datasetToDatasetDTO(datasets), HttpStatus.OK); 
+	}
+
+	@Override
 	public ResponseEntity<List<DatasetDTO>> findDatasetsByAcquisitionId(@ApiParam(value = "id of the subject", required = true) @PathVariable("acquisitionId") Long acquisitionId) {
 		List<Dataset> datasets = datasetService.findByAcquisition(acquisitionId);
 		if (datasets.isEmpty()) {

--- a/shanoir-ng-front/src/app/carmin/shared/carmin-dataset-processing.service.ts
+++ b/shanoir-ng-front/src/app/carmin/shared/carmin-dataset-processing.service.ts
@@ -31,10 +31,6 @@ export class CarminDatasetProcessingService extends EntityService<CarminDatasetP
 
     getEntityInstance() { return new CarminDatasetProcessing(); }
 
-    public saveNewCarminDatasetProcessing(carminDatasetProcessing: CarminDatasetProcessing): Observable<Object> {
-        return this.httpClient.post<Object>(this.API_URL, carminDatasetProcessing);
-    }
-
     public getAllCarminDatasetProcessings(): Observable<CarminDatasetProcessing[]>{
         return this.httpClient.get<CarminDatasetProcessing[]>(`${this.API_URL}/carminDatasetProcessings`);
     }
@@ -44,3 +40,4 @@ export class CarminDatasetProcessingService extends EntityService<CarminDatasetP
     }
 
 }
+ 

--- a/shanoir-ng-front/src/app/datasets/shared/dataset.service.ts
+++ b/shanoir-ng-front/src/app/datasets/shared/dataset.service.ts
@@ -89,7 +89,13 @@ export class DatasetService extends EntityService<Dataset> implements OnDestroy 
                 .toPromise()
                 .then(dtos => this.datasetDTOService.toEntityList(dtos));
     }
-    
+
+    getByIds(ids: Set<number>): Promise<Dataset[]> {
+        return this.http.get<DatasetDTO[]>(AppUtils.BACKEND_API_DATASET_URL + '/allById')
+            .toPromise()
+            .then(dtos => this.datasetDTOService.toEntityList(Array.from(dtos)));
+    }
+
     progressBarFunc(event: HttpEvent<any>, progressBar: LoadingBarComponent): void {
        switch (event.type) {
             case HttpEventType.Sent:

--- a/shanoir-ng-front/src/app/processing/execution/execution.component.ts
+++ b/shanoir-ng-front/src/app/processing/execution/execution.component.ts
@@ -46,17 +46,11 @@ export class ExecutionComponent implements OnInit {
     )
     this.processingService.selectedDatasets.subscribe(
       (datasets: Set<number>) => {
-        let selectedDatasets = new Set<Dataset>();
-        datasets.forEach(
-          id => {
-            this.datasetService.get(id).then((dataset: Dataset) => {
-              selectedDatasets.add(dataset);
-            })
-          }
-        )
-        this.selectedDatasets = selectedDatasets;
-      }
-    )
+        this.datasetService.getByIds(datasets).then(
+            result => {
+                this.selectedDatasets = new Set(result);
+            });
+        });
     this.keycloakService.getToken().then(
       (token: String) => {
         this.token = token;
@@ -133,7 +127,7 @@ export class ExecutionComponent implements OnInit {
         carminDatasetProcessing.datasetProcessingType = DatasetProcessingType.SEGMENTATION; // TODO : this should be selected by the user.
         carminDatasetProcessing.inputDatasets = Array.from(this.selectedDatasets);
 
-        this.carminDatasetProcessing.saveNewCarminDatasetProcessing(carminDatasetProcessing).subscribe(
+        this.carminDatasetProcessing.create(carminDatasetProcessing).then(
           (response: CarminDatasetProcessing) => {
             this.router.navigate([`/dataset-processing/details/${response.id}`]);
           },


### PR DESCRIPTION
Dear @KhalilKes,

I created this pull request to correct the problem you encountered during carmin dataset processing creation.
I could not test locally, as we havn't VIP on our servers.

The problem was:
1) To load selected datasets, you were doing one call by dataset ID, this is not a great solution for communication and database performance, this should be avoided as much as possible.
2) Each of this call returned a dataset and not a datasetDTO -> these carry all the stuff that was provoking the circular dependency problem

What I did:
- Created a new method in the back to load all datasets from a list of IDs
- This method returns datasetDTOs and not datasets

Closes #1425 

Please note that I could not test it, could you please try it locally so that we can adapt my solution ?
Thanks,
Jean-Côme