### PR TITLE
#1476 display import log in file and console

### DIFF
--- a/shanoir-ng-import/src/main/resources/logback-spring.xml
+++ b/shanoir-ng-import/src/main/resources/logback-spring.xml
@@ -52,6 +52,10 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
     <logger name="org.shanoir.ng.importer.ImporterManagerService" level="INFO" additivity="false">
         <appender-ref ref="IMPORTS_FILE_LOG" />
     </logger>
+    <logger name="org.shanoir.ng.importer.ImporterManagerService" level="ERROR" additivity="false">
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="FILE" />
+    </logger>
 
     <logger name="org.dcm4che3" level="WARN" additivity="false">
         <appender-ref ref="FILE" />


### PR DESCRIPTION
When an error happens during import in ImporterManagerService, it is now displayed.

Closes #1476 