### PR TITLE
use the AS_RECEIVED aet by default in Q/R operations

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dicom/web/service/DICOMWebService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dicom/web/service/DICOMWebService.java
@@ -280,7 +280,7 @@ public class DICOMWebService {
 			instanceId = this.extractInstanceUID(url, null);
 			studyId = this.extractStudyUID(url, null);
 			serieId = this.extractSeriesUIDUID(url, null);
-			// http://localhost:8081/dcm4chee-arc/aets/DCM4CHEE/rs/studies//series//instances//reject/113001%5EDCM
+			// http://localhost:8081/dcm4chee-arc/aets/AS_RECEIVED/rs/studies//series//instances//reject/113001%5EDCM
 			rejectURL = url.substring(0, url.indexOf("wado?")) + "rs/studies/" + studyId + "/series/" + serieId
 					+ "/instances/" + instanceId + REJECT_SUFFIX;
 			deleteUrl = url.substring(0, url.indexOf("/aets/")) + REJECT_SUFFIX;

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/download/WADODownloaderService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/download/WADODownloaderService.java
@@ -54,7 +54,7 @@ import org.springframework.web.client.RestTemplate;
  * WADO-RS URLs are supported: http://dicom.nema.org/DICOM/2013/output/chtml/part18/sect_6.5.html
  * WADO-URI URLs are supported: http://dicom.nema.org/DICOM/2013/output/chtml/part18/sect_6.2.html
  * 
- * WADO-RS: http://dcm4chee-arc:8081/dcm4chee-arc/aets/DCM4CHEE/rs/studies/1.4.9.12.22.1.8447.5189520782175635475761938816300281982444
+ * WADO-RS: http://dcm4chee-arc:8081/dcm4chee-arc/aets/AS_RECEIVED/rs/studies/1.4.9.12.22.1.8447.5189520782175635475761938816300281982444
  * /series/1.4.9.12.22.1.3337.609981376830290333333439326036686033499
  * /instances/1.4.9.12.22.1.3327.13131999371192661094333587030092502791578
  * 
@@ -62,7 +62,7 @@ import org.springframework.web.client.RestTemplate;
  * this class extracts as well the files contained in the response to
  * the file system.
  * 
- * WADO-URI: http://dcm4chee-arc:8081/dcm4chee-arc/aets/DCM4CHEE/wado?requestType=WADO
+ * WADO-URI: http://dcm4chee-arc:8081/dcm4chee-arc/aets/AS_RECEIVED/wado?requestType=WADO
  * &studyUID=1.4.9.12.22.1.8444.518952078217568647576155668816300281982444
  * &seriesUID=1.4.9.12.22.1.8444.60998137683029030014444439326036686033499
  * &objectUID=1.4.9.12.22.1.8444.1313199937119266109555587030092502791578

--- a/shanoir-ng-datasets/src/main/resources/application.yml
+++ b/shanoir-ng-datasets/src/main/resources/application.yml
@@ -128,9 +128,9 @@ dcm4chee-arc:
   # default is true as we want to use new protocols in sh-ng
   dicom.web: false
   dicom.c-store.aet.called: DCM4CHEE
-  # use "/wado" for dcm4chee2 and "/dcm4chee-arc/aets/DCM4CHEE/wado" for dcm4chee3
-  dicom.wado.uri: /dcm4chee-arc/aets/DCM4CHEE/wado
-  dicom.web.rs: /dcm4chee-arc/aets/DCM4CHEE/rs/studies
+  # use "/wado" for dcm4chee2 and "/dcm4chee-arc/aets/AS_RECEIVED/wado" for dcm4chee3
+  dicom.wado.uri: /dcm4chee-arc/aets/AS_RECEIVED/wado
+  dicom.web.rs: /dcm4chee-arc/aets/AS_RECEIVED/rs/studies
   dicom.web.http.client.max.total: 500
   dicom.web.http.client.max.per.route: 500
 


### PR DESCRIPTION
This makes dcm4chee return the DICOM objects as they were received and stored (it disables attribute coercion and merge of information)