### PR TITLE
#1524 preclinical exams bug - not preclinical by default

### DIFF
--- a/shanoir-ng-front/src/app/import/basic-clinical-context/basic-clinical-context.component.ts
+++ b/shanoir-ng-front/src/app/import/basic-clinical-context/basic-clinical-context.component.ts
@@ -128,7 +128,7 @@ export class BasicClinicalContextComponent extends AbstractClinicalContextCompon
 
     private getPrefilledExam(): Examination {
         let newExam = new Examination();
-        newExam.preclinical = true;
+        newExam.preclinical = false;
         newExam.hasStudyCenterData = true;
         newExam.study = new IdName(this.study.id, this.study.name);
         if (this.center) {


### PR DESCRIPTION
Closes #1524 
How to test:
- Import not preclinical data
- The examination now appears in examination list

Scripts to go on Neurinfo
`UPDATE examination SET preclinical = false where id > 19964;`
(I checked, no preclinical datasets were imported in this timeframe)
OFSEP:
`UPDATE examination SET preclinical = false where id > 39439;`
(I checked, no preclinical datasets imported ever on ofsep server)