### PR TITLE
Fix for problem of PH: by default go to public catalog

### DIFF
--- a/docker-compose/nginx/shanoir.template.conf
+++ b/docker-compose/nginx/shanoir.template.conf
@@ -14,6 +14,10 @@ proxy_buffering 	off;
 proxy_set_header	Host $http_host;
 # NOTE: X-Forward-For/X-Forwarded-Proto are added by the entrypoint
 
+location = / {
+    return 301 /shanoir-ng/welcome;
+}
+
 #
 # Keycloak
 #


### PR DESCRIPTION
Hi, my local tests work:
- https://shanoir-ng-nginx goes to /shanoir-ng/welcome
- when I click access, I go to the login page, when I cancel I come back