### PR TITLE
Fix mysql container hanging at startup

### DIFF
--- a/docker-compose/database/shanoir-entrypoint.sh
+++ b/docker-compose/database/shanoir-entrypoint.sh
@@ -46,7 +46,7 @@ wait_mysqld()
 {
 	echo "$HEADER wait mysqld"
 	for i in {30..0} ; do
-		if [ -f /mysql-init-complete ] && $MYSQLADMIN ping ; then
+		if [ -f /var/lib/mysql-files/mysql-init-complete ] && $MYSQLADMIN ping ; then
 			echo "$HEADER wait mysqld done"
 			break
 		fi


### PR DESCRIPTION
As of mysql/mysql-server:5.7.34 `/mysql-init-complete` was moved into the `/var/lib/mysql-files/` directory.