### PR TITLE
#1544 - access request - allow user deletion & access request

### DIFF
--- a/shanoir-ng-front/src/app/studies/study/study.component.html
+++ b/shanoir-ng-front/src/app/studies/study/study.component.html
@@ -203,10 +203,10 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 				</ol>
 			</fieldset>
 			<fieldset [class.hidden]="activeTab != 'general'">
-				<legend i18n="Study detail|Name label@@studyDetailDefaultAccessLevel">Default access level</legend>
+				<legend i18n="Study detail|Name label@@studyDetailDefaultAccessLevel">Access level</legend>
 				<ol>
 					<li>
-						<label i18n="Study detail|Visible by default label@@studyDetailVisibleByDefault">Visible by default</label>
+						<label i18n="Study detail|Visible by default label@@studyDetailVisibleByDefault">Visible</label>
 						<span class="right-col" [ngSwitch]="mode">
 							<ng-template [ngSwitchCase]="'view'">
 								<span *ngIf="study.visibleByDefault" class="bool-true"><i class="fas fa-check"></i></span>
@@ -218,7 +218,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 						</span>
 					</li>
 					<li>
-						<label i18n="Study detail|Data downloadable by default label@@studyDetailDownloadableByDefault">Data downloadable by default</label>
+						<label i18n="Study detail|Data downloadable by default label@@studyDetailDownloadableByDefault">Data accessibility</label>
 						<span class="right-col" [ngSwitch]="mode">
 							<ng-template [ngSwitchCase]="'view'">
 								<span *ngIf="study.downloadableByDefault" class="bool-true"><i class="fas fa-check"></i></span>

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/accessrequest/controller/AccessRequestApiController.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/accessrequest/controller/AccessRequestApiController.java
@@ -148,7 +148,7 @@ public class AccessRequestApiController implements AccessRequestApi {
 
 		if (validation) {
 			// if there is an account request, accept it.
-			if (resolvedRequest.getUser().isAccountRequestDemand()) {
+			if (resolvedRequest.getUser().isAccountRequestDemand() != null && resolvedRequest.getUser().isAccountRequestDemand()) {
 				this.userService.confirmAccountRequest(resolvedRequest.getUser());
 			}
 			// Update study to add a new user

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/user/model/User.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/user/model/User.java
@@ -17,17 +17,21 @@ package org.shanoir.ng.user.model;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.PostLoad;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 
 import org.hibernate.validator.constraints.NotBlank;
+import org.shanoir.ng.accessrequest.model.AccessRequest;
 import org.shanoir.ng.accountrequest.model.AccountRequestInfo;
 import org.shanoir.ng.extensionrequest.model.ExtensionRequestInfo;
 import org.shanoir.ng.role.model.Role;
@@ -122,6 +126,10 @@ public class User extends HalEntity implements UserDetails {
 	private String username;
 
 	private String teamName;
+
+	@JsonIgnore
+    @OneToMany(mappedBy = "user", orphanRemoval = true)
+	List<AccessRequest> accessRequests;
 
 	/**
 	 * Init HATEOAS links

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/user/service/UserServiceImpl.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/user/service/UserServiceImpl.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.shanoir.ng.accessrequest.controller.AccessRequestService;
 import org.shanoir.ng.accessrequest.model.AccessRequest;
 import org.shanoir.ng.accessrequest.repository.AccessRequestRepository;
 import org.shanoir.ng.accountrequest.repository.AccountRequestInfoRepository;
@@ -130,6 +131,7 @@ public class UserServiceImpl implements UserService {
 	@Override
 	public void deleteById(final Long id) throws EntityNotFoundException {
 		final User user = (User) userRepository.findById(id).orElse(null);
+		
 		if (user == null) {
 			throw new EntityNotFoundException(User.class, id);
 		}


### PR DESCRIPTION
Closes #1544 
Hi @michaelkain, I don't really get how we arrived to this.
- Users impossible deletion was quite logic -> They are still linked to one ore more access request. I updated the logic so that, when a user is deleted, associated access requests are deleted.

For the second point, it's quite misterious, we have user with "account_request_on_demand" set to NULL, as they should be set to either "true" (non existing user) or "false" (existing user).
For the already existing user, I can imagine that the "on demand" could be set to null, and I added a check, but for non existing user, I cannot understand how we arrived in that state..
I'll check a little bit further..
Jean-Côme