### PR TITLE
fix keycloak build-time config

### DIFF
--- a/docker-compose/keycloak/Dockerfile
+++ b/docker-compose/keycloak/Dockerfile
@@ -10,12 +10,25 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 
-ARG BASE_IMAGE=quay.io/keycloak/keycloak:20.0.0
+FROM quay.io/keycloak/keycloak:20.0.0 as base_image
+
+# keycloak options (https://www.keycloak.org/server/all-config)
+#
+# Here we list only the variables that need to be set at both runtime *and* at
+# buildtime ("kc.sh build"). If they do not have the same values then the
+# quarkus image has to be rebuilt at runtime, which delays container startup
+# with a message like: "(Quarkus augmentation completed in 180315ms)"
+#
+# The relevant variables can be listed with: /opt/keycloak/bin/kc.sh show-config
+#
+# All other variables are set in the entrypoint.
+ENV KC_DB="mysql" \
+    KC_HTTP_RELATIVE_PATH="/auth"
 
 #
 # Use builder to integrate custom provider
 #
-FROM $BASE_IMAGE as builder
+FROM base_image as builder
 
 COPY shanoir-ng-keycloak-auth.jar /opt/keycloak/providers
 
@@ -25,7 +38,7 @@ RUN /opt/keycloak/bin/kc.sh build
 #
 # Create actual image, based on builder before
 #
-FROM $BASE_IMAGE
+FROM base_image
 
 COPY --from=builder /opt/keycloak/ /opt/keycloak/
 COPY --chown=keycloak themes/. /opt/keycloak/themes

--- a/docker-compose/keycloak/entrypoint
+++ b/docker-compose/keycloak/entrypoint
@@ -30,7 +30,9 @@ sed -i -E "s/SHANOIR_URL_HOST/$SHANOIR_URL_HOST/g" /opt/keycloak/themes/shanoir-
 # keycloak options
 # see: https://www.keycloak.org/server/all-config
 #
-export KC_HTTP_RELATIVE_PATH="/auth"
+# NOTE: options that must also be set at build-time (eg: KC_DB,
+#       KC_HTTP_RELATIVE_PATH) are set in the Dockerfile.
+#
 export KC_PROXY="${KC_PROXY:-edge}"
 export KC_SPI_THEME_WELCOME_THEME="shanoir-theme"
 
@@ -42,7 +44,6 @@ export KC_SPI_THEME_WELCOME_THEME="shanoir-theme"
 export KC_HOSTNAME_STRICT="${KC_HOSTNAME_STRICT:false}"
 export KC_HOSTNAME_STRICT_HTTPS="${KC_HOSTNAME_STRICT_HTTPS:false}"
 
-export KC_DB="${DB_VENDOR:-mysql}"
 export KC_DB_URL=jdbc:mysql://"${DB_ADDR:-${SHANOIR_PREFIX}keycloak-database}":"${DB_PORT:-3306}"/"${DB_DATABASE:-keycloak}"
 export KC_DB_USERNAME="${DB_USER:-keycloak}"
 export KC_DB_PASSWORD="${DB_PASSWORD:-password}"


### PR DESCRIPTION
8df648cc1610 removed code which was not actually dead.

A small list of keycloak variables have to be set at runtime *and* at buildtime. If not, then the quarkus image is dynamically rebuilt at each startup, which currently cause a 3-minute delay.