### PR TITLE
#1621 - download bar to NaN following zipInputFile download

### DIFF
--- a/shanoir-ng-front/src/app/datasets/download/dataset-download.component.html
+++ b/shanoir-ng-front/src/app/datasets/download/dataset-download.component.html
@@ -1,7 +1,7 @@
 <button type="button" (click)="prepareDownloadAll()" [disabled]="progressBar.progress != 0" class="right-icon">Download all datasets<i class="fas fa-download"></i></button>
 <button type="button" (click)="prepareDownloadSelected()" [disabled]="progressBar.progress != 0 || !datasetIds || datasetIds.length <= 0" class="right-icon">Download selected datasets<i class="fas fa-download"></i></button> 
 <div [hidden]="progressBar.progress == 0">
-    <progress-bar #progressBar [text]="'Preparing download'"></progress-bar>
+    <progress-bar #progressBar [text]="'Preparing download'" [unknownDownload]="true"></progress-bar>
 </div>
 <app-modal #downloadDialog >
     <div class="main">

--- a/shanoir-ng-front/src/app/datasets/shared/dataset.service.ts
+++ b/shanoir-ng-front/src/app/datasets/shared/dataset.service.ts
@@ -110,7 +110,7 @@ export class DatasetService extends EntityService<Dataset> implements OnDestroy 
               progressBar.progress = -1;
               break;
             case HttpEventType.DownloadProgress:
-              progressBar.progress = (event.loaded / event.total);
+              progressBar.progress = event.loaded;
               break;
             case HttpEventType.Response:
                 progressBar.progress = 0;

--- a/shanoir-ng-front/src/app/examinations/examination/examination.component.html
+++ b/shanoir-ng-front/src/app/examinations/examination/examination.component.html
@@ -187,7 +187,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 				<button *ngIf="mode == 'view' && hasDownloadRight && hasDicom" [disabled]="progressBar.progress != 0 || noDatasets" type="button" class="right-icon" i18n="Buttons|Download button label@@downloadButton" (click)="download('dcm')">Download DICOM<i class="fas fa-download"></i></button>
 				<button *ngIf="mode == 'view' && hasDownloadRight && hasDicom" [disabled]="progressBar.progress != 0 || noDatasets" type="button" class="right-icon" i18n="Buttons|Download button label@@downloadButton" (click)="download('nii')">Download NIfTI<i class="fas fa-download"></i></button>
                 <div [hidden]="progressBar.progress == 0">
-                    <progress-bar #progressBar [text]="'Preparing download'"></progress-bar>
+                    <progress-bar #progressBar [text]="'Preparing download'" [unknownDownload]="true"></progress-bar>
                 </div>
 			</form-footer>
 		</div>

--- a/shanoir-ng-front/src/app/examinations/shared/examination.service.ts
+++ b/shanoir-ng-front/src/app/examinations/shared/examination.service.ts
@@ -76,7 +76,7 @@ export class ExaminationService extends EntityService<Examination> implements On
               progressBar.progress = -1;
               break;
             case HttpEventType.DownloadProgress:
-              progressBar.progress = (event.loaded / event.total);
+              progressBar.progress = event.loaded;
               break;
             case HttpEventType.Response:
                 saveAs(event.body, this.getFilename(event));

--- a/shanoir-ng-front/src/app/examinations/tree/examination-node.component.html
+++ b/shanoir-ng-front/src/app/examinations/tree/examination-node.component.html
@@ -12,7 +12,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 -->
 <div [hidden]="progressBar.progress == 0">
-    <progress-bar #progressBar [text]="'Preparing download'"></progress-bar>
+    <progress-bar #progressBar [text]="'Preparing download'" [unknownDownload]="true"></progress-bar>
 </div>
 <node
         *ngIf="node"

--- a/shanoir-ng-front/src/app/home/challenge/challenge-block.component.html
+++ b/shanoir-ng-front/src/app/home/challenge/challenge-block.component.html
@@ -28,7 +28,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
     <td>
         <ul class="challenge-files">
             <div [hidden]="progressBar.progress == 0">
-                <progress-bar #progressBar [text]="'Preparing download'"></progress-bar>
+                <progress-bar #progressBar [text]="'Preparing download'" [unknownDownload]="true"></progress-bar>
             </div>
             <li *ngFor="let filePath of challengeStudy.protocolFilePaths">
                 <i class="fas fa-download" (click)="downloadFile(filePath)"></i>

--- a/shanoir-ng-front/src/app/shared/components/loading-bar/loading-bar.component.html
+++ b/shanoir-ng-front/src/app/shared/components/loading-bar/loading-bar.component.html
@@ -12,7 +12,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 -->
 
-<span class="inner" [class.done]="progress >= 1" [style.width]="(progress * width) + 'px'">
+<span class="inner" [class.done]="progress == 0" [style.width]="(unknownDownload ? width : (progress * width)) + 'px'">
     <div class="left-text" [style.width]="width + 'px'">{{getProgressText()}}</div>
 </span>
 <span class="text">{{getProgressText()}}</span>

--- a/shanoir-ng-front/src/app/shared/components/loading-bar/loading-bar.component.ts
+++ b/shanoir-ng-front/src/app/shared/components/loading-bar/loading-bar.component.ts
@@ -25,6 +25,7 @@ export class LoadingBarComponent {
 
     @Input() progress: number = 0;
     @Input() text: string = "";
+    @Input() unknownDownload: boolean = false;
     @Input() width: number = 200;
 
     @HostBinding('style.width') get pixelWidth() {
@@ -35,7 +36,26 @@ export class LoadingBarComponent {
         if (this.progress === -1 && this.text) {
             return this.text;
         }
+        if (this.unknownDownload) {
+            return this.studySizeStr(this.progress);
+        }
         return Math.floor(this.progress * 100) + "%";
+    }
+
+    studySizeStr(size: number) {
+
+      const base: number = 1024;
+      const units: string[] = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+
+      if(size == null || size == 0){
+        return "0 " + units[0];
+      }
+
+      const exponent: number = Math.floor(Math.log(size) / Math.log(base));
+      let value: number = parseFloat((size / Math.pow(base, exponent)).toFixed(2));
+      let unit: string = units[exponent];
+
+      return value + " " + unit;
     }
 
     onResized(event) {

--- a/shanoir-ng-front/src/app/solr/solr.search.component.html
+++ b/shanoir-ng-front/src/app/solr/solr.search.component.html
@@ -173,7 +173,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
         </div>
 
         <div [hidden]="progressBar.progress == 0">
-            <progress-bar #progressBar [text]="'Preparing download'"></progress-bar>
+            <progress-bar #progressBar [text]="'Preparing download'" [unknownDownload]="true"></progress-bar>
         </div>
 
         <div class="tabs">

--- a/shanoir-ng-front/src/app/studies/shared/study.service.ts
+++ b/shanoir-ng-front/src/app/studies/shared/study.service.ts
@@ -193,7 +193,7 @@ export class StudyService extends EntityService<Study> implements OnDestroy {
               progressBar.progress = -1;
               break;
             case HttpEventType.DownloadProgress:
-              progressBar.progress = (event.loaded / event.total);
+              progressBar.progress = event.loaded;
               break;
             case HttpEventType.Response:
                 saveAs(event.body, this.getFilename(event));

--- a/shanoir-ng-front/src/app/studies/study/study.component.html
+++ b/shanoir-ng-front/src/app/studies/study/study.component.html
@@ -197,7 +197,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 					<li *ngIf="mode == 'view'">
 						<label i18n="Study detail|dua label@@studyDetailDataUserAgreement">DUA file</label>
 						<div [hidden]="DUAprogressBar.progress == 0">
-                            <progress-bar #DUAprogressBar [text]="'Preparing download'"></progress-bar>
+                            <progress-bar #DUAprogressBar [text]="'Preparing download'" [unknownDownload]="true"></progress-bar>
                         </div>
                         <span class="right-col">
 							<span *ngIf="study.dataUserAgreementPaths && study.dataUserAgreementPaths[0]">
@@ -322,7 +322,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 					</li>
                     <li *ngIf="mode == 'view'">
                         <div [hidden]="PFprogressBar.progress == 0">
-                            <progress-bar #PFprogressBar [text]="'Preparing download'"></progress-bar>
+                            <progress-bar #PFprogressBar [text]="'Preparing download'" [unknownDownload]="true"></progress-bar>
                         </div>
                         <span class="right-col">
                             <span *ngIf="study.protocolFilePaths && study.protocolFilePaths[0]">


### PR DESCRIPTION
- Do not display progress anymore for download
- Display size downloaded
- still display progress for uploads

Closes #1621 

How to test:
Download data from
- solr detail
- examination detail
- Study detail (dataset + associated files (DUA potentially)
- dataset detail
--> We display the size

Upload data during import
--> We display the upload bar correctly