### PR TITLE
#1609-uploader-subject-identifier

### DIFF
--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/action/ImportFromCsvRunner.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/action/ImportFromCsvRunner.java
@@ -325,7 +325,11 @@ public class ImportFromCsvRunner extends SwingWorker<Void, Integer> {
 			dicomData = new DicomDataTransferObject(null, pat, stud);
 
 			// Calculate identifier
-			subjectIdentifier = this.identifierCalculator.calculateIdentifier(dicomData.getFirstName(), dicomData.getLastName(), dicomData.getBirthDate());
+
+			// #1609 we encounter problems when using same subject data accross multiple studies.
+			// We add study id in front of identifier to correct this
+			subjectIdentifier = stud.getId() +  this.identifierCalculator.calculateIdentifier(dicomData.getFirstName(), dicomData.getLastName(), dicomData.getBirthDate());
+
 			dicomData.setSubjectIdentifier(subjectIdentifier);
 
 			// Change birth date to first day of year


### PR DESCRIPTION
- Add study ID to identifier using CSV import to avoid problems with subject in multiple studies
Close #1609 

How to test:
- Import data with CSV with shanoir-uploader in a study A, with a subject already existing in study B (the user should not have any rights in this other study)
--> The subject is well created and importer