### PR TITLE
#1668 - invitation as expert bug

### DIFF
--- a/shanoir-ng-front/src/app/studies/studyuser/studyuser-list.component.ts
+++ b/shanoir-ng-front/src/app/studies/studyuser/studyuser-list.component.ts
@@ -271,7 +271,7 @@ export class StudyUserListComponent implements ControlValueAccessor, OnChanges {
                 this.addUser(request.user);
             }
         }).catch(exception =>  {
-            this.consoleService.log('error', "An internal error occured while adding the user. Please try again later or contact an administrator.");
+            this.consoleService.log('error', "No user found with such login, please check the user information or use its email.");
         });
     }
 

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/accessrequest/controller/AccessRequestApi.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/accessrequest/controller/AccessRequestApi.java
@@ -120,6 +120,6 @@ public interface AccessRequestApi {
 			@RequestParam(value = "studyId", required = true) Long studyId,
 			@ApiParam(value = "Study name the user is invited in", required = true) 
 			@RequestParam(value = "studyName", required = true) String studyName,
-			@ApiParam(value = "The email of the invited user.") 
-    		@RequestParam(value = "email", required = true) String email) throws RestServiceException, JsonProcessingException, AmqpException;
+			@ApiParam(value = "The email or login of the invited user.") 
+    		@RequestParam(value = "email", required = true) String emailOrLogin) throws RestServiceException, JsonProcessingException, AmqpException;
 }

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/accessrequest/controller/AccessRequestApiController.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/accessrequest/controller/AccessRequestApiController.java
@@ -194,7 +194,7 @@ public class AccessRequestApiController implements AccessRequestApi {
 		Optional<User> user = this.userService.findByEmail(email);
 		
 		if (!user.isPresent()) {
-			user = this.userService.findByUsername(email);
+			user = this.userService.findByUsernameForInvitation(email);
 		}
 
 		// User exists => return an access request to be added

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/accessrequest/controller/AccessRequestApiController.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/accessrequest/controller/AccessRequestApiController.java
@@ -187,14 +187,18 @@ public class AccessRequestApiController implements AccessRequestApi {
 			@RequestParam(value = "studyId", required = true) Long studyId,
 			@ApiParam(value = "Study name the user is invited in", required = true) 
 			@RequestParam(value = "studyName", required = true) String studyName,
-			@ApiParam(value = "The email of the invited user.") 
-			@RequestParam(value = "email", required = true) String email) throws RestServiceException, JsonProcessingException, AmqpException {
+			@ApiParam(value = "The email or login of the invited user.") 
+			@RequestParam(value = "email", required = true) String emailOrLogin) throws RestServiceException, JsonProcessingException, AmqpException {
 
-		// Check if user with such email/username exists
-		Optional<User> user = this.userService.findByEmail(email);
-		
-		if (!user.isPresent()) {
-			user = this.userService.findByUsernameForInvitation(email);
+		boolean isEmail = emailOrLogin.contains("@");
+
+		Optional<User> user;
+
+		if (isEmail) {
+			// Check if user with such email/username exists
+			user = this.userService.findByEmail(emailOrLogin);
+		} else {
+			user = this.userService.findByUsernameForInvitation(emailOrLogin);
 		}
 
 		// User exists => return an access request to be added
@@ -209,16 +213,17 @@ public class AccessRequestApiController implements AccessRequestApi {
 			return new ResponseEntity<AccessRequest>(request, HttpStatus.OK);
 		}
 
-		// Otherwise, send a mail to the new user
-		StudyInvitationEmail mail = new StudyInvitationEmail();
-		mail.setInvitedMail(email);
-		mail.setStudyId(studyId.toString());
-		mail.setStudyName(studyName);
-
-		// User does not exists, just send an email
-		this.emailService.inviteToStudy(mail);
-
-		return new ResponseEntity<AccessRequest>(HttpStatus.NO_CONTENT);
+		// Otherwise, send a mail to the new user if we have a mail in entry
+		if (isEmail) {
+			StudyInvitationEmail mail = new StudyInvitationEmail();
+			mail.setInvitedMail(emailOrLogin);
+			mail.setStudyId(studyId.toString());
+			mail.setStudyName(studyName);
+			
+			this.emailService.inviteToStudy(mail);
+			return new ResponseEntity<AccessRequest>(HttpStatus.NO_CONTENT);
+		}
+		return new ResponseEntity<AccessRequest>(HttpStatus.BAD_REQUEST);
 	}
 
 	public ResponseEntity<List<AccessRequest>> findAllByStudyId(

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/user/service/UserService.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/user/service/UserService.java
@@ -111,6 +111,15 @@ public interface UserService {
 	 */
 	@PreAuthorize("hasRole('ADMIN') or (hasAnyRole('USER', 'EXPERT') and @isMeSecurityService.isMe(#username))")
 	Optional<User> findByUsername(String username);
+	
+	/**
+	 * Find user by its username.
+	 *
+	 * @param username the username.
+	 * @return a user or null.
+	 */
+	@PreAuthorize("hasRole('ADMIN') or (hasAnyRole('USER', 'EXPERT'))")
+	Optional<User> findByUsernameForInvitation(String username);
 
 	/**
 	 * Find users that will soon expire and have not yet received the first notification.

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/user/service/UserServiceImpl.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/user/service/UserServiceImpl.java
@@ -217,6 +217,11 @@ public class UserServiceImpl implements UserService {
 	public Optional<User> findByUsername(final String username) {
 		return userRepository.findByUsername(username);
 	}
+
+	@Override
+	public Optional<User> findByUsernameForInvitation(final String username) {
+		return userRepository.findByUsername(username);
+	}
 	
 	@Override
 	public List<User> getUsersToReceiveFirstExpirationNotification() {

--- a/shanoir-ng-users/src/test/java/org/shanoir/ng/accessrequest/AccessRequestApiControllerTest.java
+++ b/shanoir-ng-users/src/test/java/org/shanoir/ng/accessrequest/AccessRequestApiControllerTest.java
@@ -306,18 +306,18 @@ public class AccessRequestApiControllerTest {
 	@WithMockKeycloakUser(id = 1)
 	public void inviteExistingUserTest() throws Exception {
 		// We invite an user that exists
-		Mockito.when(this.userService.findByEmail("mail")).thenReturn(Optional.of(user));
+		Mockito.when(this.userService.findByEmail("mail@mail")).thenReturn(Optional.of(user));
 		
 		Map<String, Object> theMap = new LinkedHashMap<>();
 		theMap.put("studyId", 1l);
 		theMap.put("studyName", "name");
-		theMap.put("email", "mail");
+		theMap.put("email", "mail@mail");
 
 		MvcResult result = mvc.perform(MockMvcRequestBuilders.put(REQUEST_PATH + "/invitation/").accept(MediaType.APPLICATION_JSON)
 				.contentType(MediaType.APPLICATION_JSON)
 				.param("studyId", "" + 1l)
 				.param("studyName", "name")
-				.param("email", "mail"))
+				.param("email", "mail@mail"))
 				.andExpect(status().isOk())
 				.andReturn();
 		
@@ -334,19 +334,18 @@ public class AccessRequestApiControllerTest {
 	@WithMockKeycloakUser(id = 1)
 	public void inviteExistingUserFromUserNameTest() throws Exception {
 		// We invite an user that exists
-		Mockito.when(this.userService.findByEmail("mail")).thenReturn(Optional.empty());
-		Mockito.when(this.userService.findByUsernameForInvitation("mail")).thenReturn(Optional.of(user));
+		Mockito.when(this.userService.findByUsernameForInvitation("login")).thenReturn(Optional.of(user));
 
 		Map<String, Object> theMap = new LinkedHashMap<>();
 		theMap.put("studyId", 1l);
 		theMap.put("studyName", "name");
-		theMap.put("email", "mail");
+		theMap.put("email", "login");
 
 		MvcResult result = mvc.perform(MockMvcRequestBuilders.put(REQUEST_PATH + "/invitation/").accept(MediaType.APPLICATION_JSON)
 				.contentType(MediaType.APPLICATION_JSON)
 				.param("studyId", "" + 1l)
 				.param("studyName", "name")
-				.param("email", "mail"))
+				.param("email", "login"))
 				.andExpect(status().isOk())
 				.andReturn();
 		
@@ -361,30 +360,50 @@ public class AccessRequestApiControllerTest {
 
 	@Test
 	@WithMockKeycloakUser(id = 1)
-	public void inviteNotExistingUserTest() throws JsonProcessingException, Exception {
+	public void inviteNotExistingUserMailTest() throws JsonProcessingException, Exception {
 		// We invite an user that does not exists
-		Mockito.when(this.userService.findByEmail("mail")).thenReturn(Optional.empty());
-		Mockito.when(this.userService.findByUsername("mail")).thenReturn(Optional.empty());
+		Mockito.when(this.userService.findByEmail("mail@mail")).thenReturn(Optional.empty());
+		//Mockito.when(this.userService.findByUsername("mail")).thenReturn(Optional.empty());
 
 		
 		Map<String, Object> theMap = new LinkedHashMap<>();
 		theMap.put("studyId", 1l);
 		theMap.put("studyName", "name");
-		theMap.put("email", "mail");
+		theMap.put("email", "mail@mail");
 		
 		mvc.perform(MockMvcRequestBuilders.put(REQUEST_PATH + "/invitation/").accept(MediaType.APPLICATION_JSON)
 				.contentType(MediaType.APPLICATION_JSON)
 				.param("studyId", "" + 1l)
 				.param("studyName", "name")
-				.param("email", "mail"))
+				.param("email", "mail@mail"))
 				.andExpect(status().isNoContent());
 		
 		ArgumentCaptor<StudyInvitationEmail> emailCaptor = ArgumentCaptor.forClass(StudyInvitationEmail.class);
 		Mockito.verify(this.emailService).inviteToStudy(emailCaptor.capture());
 		
-		assertEquals("mail", emailCaptor.getValue().getInvitedMail());
+		assertEquals("mail@mail", emailCaptor.getValue().getInvitedMail());
 		assertEquals("1", emailCaptor.getValue().getStudyId());
 		assertEquals("name", emailCaptor.getValue().getStudyName());
+	}
+	
+	@Test
+	@WithMockKeycloakUser(id = 1)
+	public void inviteNotExistingUserLoginTest() throws JsonProcessingException, Exception {
+		// We invite an user that does not exists using its login
+		//Mockito.when(this.userService.findByEmail("mail")).thenReturn(Optional.empty());
+		Mockito.when(this.userService.findByUsernameForInvitation("login")).thenReturn(Optional.empty());
+
+		Map<String, Object> theMap = new LinkedHashMap<>();
+		theMap.put("studyId", 1l);
+		theMap.put("studyName", "name");
+		theMap.put("email", "login");
+		
+		mvc.perform(MockMvcRequestBuilders.put(REQUEST_PATH + "/invitation/").accept(MediaType.APPLICATION_JSON)
+				.contentType(MediaType.APPLICATION_JSON)
+				.param("studyId", "" + 1l)
+				.param("studyName", "name")
+				.param("email", "login"))
+				.andExpect(status().isBadRequest());
 	}
 
 	@Test

--- a/shanoir-ng-users/src/test/java/org/shanoir/ng/accessrequest/AccessRequestApiControllerTest.java
+++ b/shanoir-ng-users/src/test/java/org/shanoir/ng/accessrequest/AccessRequestApiControllerTest.java
@@ -335,7 +335,7 @@ public class AccessRequestApiControllerTest {
 	public void inviteExistingUserFromUserNameTest() throws Exception {
 		// We invite an user that exists
 		Mockito.when(this.userService.findByEmail("mail")).thenReturn(Optional.empty());
-		Mockito.when(this.userService.findByUsername("mail")).thenReturn(Optional.of(user));
+		Mockito.when(this.userService.findByUsernameForInvitation("mail")).thenReturn(Optional.of(user));
 
 		Map<String, Object> theMap = new LinkedHashMap<>();
 		theMap.put("studyId", 1l);


### PR DESCRIPTION
- Add specific method for invitation to get user by username

Closes #1668 

How to test:
- Connect as an expert
- Go to an administrable study detail
- Edit it to add a member using its username (and not mail)
--> The user is well added