### PR TITLE
#1676 import logs not working anymore

### DIFF
--- a/shanoir-ng-import/src/main/resources/logback-spring.xml
+++ b/shanoir-ng-import/src/main/resources/logback-spring.xml
@@ -52,11 +52,6 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
     <logger name="org.shanoir.ng.importer.ImporterManagerService" level="INFO" additivity="false">
         <appender-ref ref="IMPORTS_FILE_LOG" />
     </logger>
-    <logger name="org.shanoir.ng.importer.ImporterManagerService" level="ERROR" additivity="false">
-        <appender-ref ref="CONSOLE" />
-        <appender-ref ref="FILE" />
-    </logger>
-
     <logger name="org.dcm4che3" level="WARN" additivity="false">
         <appender-ref ref="FILE" />
     </logger>


### PR DESCRIPTION
- Remove faulty line that was removing import logs.
Closes #1676 

@michaelkain that was my bad.

How to test:
- Make an import
- Logs are now in import.log and not anywhere else