### PR TITLE
#1685-does-not-contain-study-card

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/model/Operation.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/model/Operation.java
@@ -21,7 +21,8 @@ public enum Operation {
 	ENDS_WITH(3),
 	CONTAINS(4),
 	SMALLER_THAN(5),
-	BIGGER_THAN(6);
+	BIGGER_THAN(6),
+	DOES_NOT_CONTAIN(7);
 	
 	private int id;
 	
@@ -56,7 +57,7 @@ public enum Operation {
 	}
 	
 	public boolean isTextual() {
-		return this.equals(CONTAINS) || this.equals(ENDS_WITH) || this.equals(EQUALS) || this.equals(STARTS_WITH);
+		return this.equals(CONTAINS) || this.equals(DOES_NOT_CONTAIN) || this.equals(ENDS_WITH) || this.equals(EQUALS) || this.equals(STARTS_WITH);
 	}
 
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/model/condition/StudyCardCondition.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/model/condition/StudyCardCondition.java
@@ -94,6 +94,8 @@ public abstract class StudyCardCondition extends AbstractEntity {
                 return original.equals(studycardStr);
             } else if (Operation.CONTAINS.equals(operation)) {
                 return original.contains(studycardStr);
+            } else if (Operation.DOES_NOT_CONTAIN.equals(operation)) {
+                return !original.contains(studycardStr);
             } else if (Operation.STARTS_WITH.equals(operation)) {
                 return original.startsWith(studycardStr);
             } else if (Operation.ENDS_WITH.equals(operation)) {

--- a/shanoir-ng-front/src/app/study-cards/shared/study-card.model.ts
+++ b/shanoir-ng-front/src/app/study-cards/shared/study-card.model.ts
@@ -101,7 +101,7 @@ export class DicomTag {
     }
 }
 
-export type Operation = 'STARTS_WITH' | 'EQUALS' | 'ENDS_WITH' | 'CONTAINS' | 'SMALLER_THAN' | 'BIGGER_THAN';
+export type Operation = 'STARTS_WITH' | 'EQUALS' | 'ENDS_WITH' | 'CONTAINS' | 'DOES_NOT_CONTAIN' | 'SMALLER_THAN' | 'BIGGER_THAN';
 
 export type ConditionScope = 'StudyCardDICOMCondition' | 'AcqMetadataCondOnAcq' | 'AcqMetadataCondOnDatasets' | 
     'DatasetMetadataCondOnDataset' | 'ExamMetadataCondOnAcq' | 'ExamMetadataCondOnDatasets';

--- a/shanoir-ng-front/src/app/study-cards/study-card-rules/condition/condition.component.ts
+++ b/shanoir-ng-front/src/app/study-cards/study-card-rules/condition/condition.component.ts
@@ -37,7 +37,7 @@ export class StudyCardConditionComponent implements OnInit, OnDestroy, OnChanges
     @Input() fields: ShanoirMetadataField[];
     tagOptions: Option<DicomTag>[];
     shanoirFieldOptions: Option<any>[];
-    operations: Operation[] = ['STARTS_WITH', 'EQUALS', 'ENDS_WITH', 'CONTAINS', 'SMALLER_THAN', 'BIGGER_THAN'];
+    operations: Operation[] = ['STARTS_WITH', 'EQUALS', 'ENDS_WITH', 'CONTAINS', "DOES_NOT_CONTAIN", 'SMALLER_THAN', 'BIGGER_THAN'];
     @Output() delete: EventEmitter<void> = new EventEmitter();
     init: boolean = false;
     conditionTypeOptions: Option<ConditionScope>[];


### PR DESCRIPTION
- Add "does not contain" rule in study cards

Closes #1685 

How to test:
- Create a study card with a specific "does not contain" rule
- Import data with and without this rule beeing respected
- Check that the output corresponds