### PR TITLE
Revert + Fix long center name

### DIFF
--- a/shanoir-ng-front/src/app/shared/select/select.component.css
+++ b/shanoir-ng-front/src/app/shared/select/select.component.css
@@ -3,8 +3,8 @@
 :host.compact { width: 25px; border: none !important; }
 .root.disabled { opacity: 0.3; }
 .root.disabled:after { content: ""; display: block; position: absolute; top: 0; bottom: 0; left: 0; right: -6px; }
-.frame { display: inline-flex; overflow: hidden; height: 19px; width: 100%; }
-.input-container { position: relative; width: 100%; overflow: hidden; text-overflow: ellipsis; }
+.frame { display: inline-flex; position: relative; overflow: hidden; height: 19px; width: 100%; }
+.input-container { position: relative; width: 100%; }
 :host:not(.read-only) .input-container { cursor: pointer; }
 .fake-input { color: transparent; }
 .auto-width label { width: auto; }
@@ -35,11 +35,12 @@
     /* .commands > .button:last-child { border-radius: 0 2px 2px 0; } */
         .open { border: none; cursor: default !important; }
         .open:hover { color: inherit !important; background-color: inherit !important; }
-
-.list {
+        
+.list { 
     color: var(--very-dark-grey);
     position: absolute;
-    z-index: 1000;
+    z-index: 1000; 
+    /*max-height: 320px;*/
     min-width: 216px;
     min-height: 20px;
     border: 1px solid var(--grey);
@@ -50,7 +51,7 @@
     text-align: left;
 }
 .list.down { top: 19px; }
-.list.up { bottom: 18px; }
+.list.up { bottom: 18px; } 
 .hidden-list { opacity: 0; }
 input { border: none !important; }
 input:hover { cursor: pointer; }
@@ -58,7 +59,7 @@ input:focus:hover { cursor: initial; }
 :host::ng-deep caption { display: block; text-align: center; color: var(--color-a); padding: 0 5px; font-style: italic; }
 :host::ng-deep .option-section.hidden { display: none; }
 
-.option { height: 20px; display:block; border: none; white-space: nowrap; color: var(--dark-grey); cursor: pointer; padding: 0 5px; width: 210px; overflow: hidden; text-overflow: ellipsis; }
+.option { height: 20px; display:block; border: none; white-space: nowrap; color: var(--dark-grey); cursor: pointer; padding: 0 5px; }
 .option.selected { background-color: var(--color-b-light); }
 .option.focused { background-color: var(--grey) !important; }
 .option.disabled { opacity: 0.5; cursor: default !important; }
@@ -88,7 +89,7 @@ input:focus:hover { cursor: initial; }
 
 .commands > .clear { color: var(--grey); display: none; }
 .clear i { vertical-align: 2px; }
-.frame:hover .commands > .clear { display: inline-block; }
+.frame:hover .commands > .clear { display: inline-block; } 
 :host.auto-width .clear { display: inline-block; font-size: 10px !important; order: 2 !important; }
 
 :host.error .empty { color: var(--color-light-error); }
@@ -99,4 +100,3 @@ toggle-switch { margin: 0 10px; }
 
 :host.read-only { border: none !important; }
 .compact-button { cursor: pointer !important; color: var(--color-a); }
-.content { position: absolute; width: auto; font-size: 12px; background-color: lightgoldenrodyellow; padding: 6px 12px; box-shadow: 0 0 var(--shadow-height) 0 var(--shadow-color); color: var(--dark-grey); top: 20px; left: 16px; font-weight: normal; text-align: left; z-index: 10; }

--- a/shanoir-ng-front/src/app/shared/select/select.component.html
+++ b/shanoir-ng-front/src/app/shared/select/select.component.html
@@ -13,31 +13,25 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 -->
 
 <div class="root" [class.disabled]="disabled" *ngIf="!readOnly">
-    <span class="frame" *ngIf="!compactMode">
+    <span class="frame" *ngIf="!compactMode"> 
         <span class="input-container left-icon" [style.color]="selectionColor ? selectedOption?.color : null">
             <span  *ngIf="selectedOption?.awesome"><i class="{{selectedOption?.awesome}}"></i></span>
-<!--            <span class="fake-input">
+            <span class="fake-input">
                 {{inputText ? inputText : (placeholder ? placeholder : 'Select an option...')}}
-            </span>-->
+            </span>
             <input #input
                 *ngIf="options?.length > 0"
-                type="text"
-                tabindex="-1"
-                class="label"
+                type="text" 
+                tabindex="-1" 
+                class="label" 
                 [class.icon]="selectedOption?.awesome"
-                [ngModel]="inputText"
-                (ngModelChange)="onTypeText($event)"
-                [placeholder]="placeholder ? placeholder : 'Select an option...'"
+                [ngModel]="inputText" 
+                (ngModelChange)="onTypeText($event)" 
+                [placeholder]="placeholder ? placeholder : 'Select an option...'" 
                 (click)="isOpen() ? close() : open()"
                 (focus)="onInputFocus()"
-                [readOnly]="!search"
-                (mouseleave)="hideCenterName()" (mouseover)="showCenterName()">
-
+                [readOnly]="!search">
         </span>
-        <div class="content"
-             *ngIf="opened && selectedOption && selectedOption.label.length > 20">
-            {{ selectedOption?.label }}
-        </div>
         <span *ngIf="options?.length == 0" class="label empty">Empty list</span>
         <span class="commands">
             <span class="clear button" *ngIf="inputText && clear" (click)="onClear()"><i class="fas fa-times"></i></span>
@@ -52,13 +46,13 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
             <span class="open button compact-button" (click)="isOpen() ? close() : open()"><i class="fas fa-plus"></i></span>
         </span>
     </span>
-    <div *ngIf="displayedOptions?.length > 0"
-            [class.hidden-list]="hideToComputeHeight"
-            class="list"
-            [class.down]="way=='down'"
-            [class.up]="way=='up'"
-            (wheel)="onWheel($event)"
-            [class.scrollable]="scrollable"
+    <div *ngIf="displayedOptions?.length > 0" 
+            [class.hidden-list]="hideToComputeHeight" 
+            class="list" 
+            [class.down]="way=='down'" 
+            [class.up]="way=='up'" 
+            (wheel)="onWheel($event)" 
+            [class.scrollable]="scrollable" 
             [style.width]="maxWidth + 'px'"
             (mouseleave)="focusedOptionIndex = null"
             (dragover)="allowDrop($event)"
@@ -69,10 +63,10 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
                     {{option.section}}
                 </span>
             </div>
-            <div class="option"
-                    (click)="onUserSelectedOption(option)"
-                    [class.selected]="isOptionSelected(option)"
-                    [class.disabled]="option.disabled"
+            <div class="option" 
+                    (click)="onUserSelectedOption(option)" 
+                    [class.selected]="isOptionSelected(option)" 
+                    [class.disabled]="option.disabled" 
                     [class.compatible]="option.compatible"
                     [class.not-compatible]="option.compatible != undefined && !option.compatible"
                     [class.focused]="i == focusedOptionIndex"
@@ -85,8 +79,8 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
             </div>
         </ng-container>
         <div *ngIf="scrollable" class="scrollbar">
-            <div class="top-scroll-button"
-                    (mousedown)="scrollButtonOn('up')"
+            <div class="top-scroll-button" 
+                    (mousedown)="scrollButtonOn('up')" 
                     (mouseup)="scrollButtonOff()"
                     (mouseleave)="scrollButtonOff()"
                 ><i class="fas fa-chevron-up"></i></div>
@@ -94,7 +88,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
                 <div class="lift" [style.top.px]="liftHeight" draggable="true" (dragstart)="onDragStart($event)"></div>
             </div>
             <div class="bottom-scroll-button"
-                    (mousedown)="scrollButtonOn('down')"
+                    (mousedown)="scrollButtonOn('down')" 
                     (mouseup)="scrollButtonOff()"
                     (mouseleave)="scrollButtonOff()"
                 ><i class="fas fa-chevron-down"></i></div>

--- a/shanoir-ng-front/src/app/shared/select/select.component.ts
+++ b/shanoir-ng-front/src/app/shared/select/select.component.ts
@@ -636,31 +636,6 @@ export class SelectBoxComponent implements ControlValueAccessor, OnDestroy, OnCh
         else if (this.options) return this.options;
         else return null;
     }
-
-    opened: boolean = false;
-    private opening: boolean = false;
-    private closing: boolean = false;
-    showCenterName() {
-      if (!this.opening) {
-        this.closing = false;
-        this.opening = true;
-        setTimeout(() =>  {
-          if (this.opening)
-            this.opened = true;
-        }, 500);
-      }
-    }
-
-    hideCenterName() {
-      if (!this.closing) {
-        this.closing = true;
-        this.opening = false;
-        setTimeout(() =>  {
-          if (this.closing)
-            this.opened = false;
-        }, 500);
-      }
-    }
 }
 
 

--- a/shanoir-ng-front/src/app/studies/study/study.component.css
+++ b/shanoir-ng-front/src/app/studies/study/study.component.css
@@ -43,3 +43,4 @@ textarea { resize : both; }
 .motivation { color: var(--color-c); }
 .access-requests .link i { color: var(--color-a); }
 .access-requests .link:hover { opacity: 0.5; }
+.hidden-tab { position: fixed; opacity: 0 !important; }

--- a/shanoir-ng-front/src/app/studies/study/study.component.html
+++ b/shanoir-ng-front/src/app/studies/study/study.component.html
@@ -45,34 +45,34 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 				</ng-container>
 			</ul>
 
-			<fieldset [class.hidden]="activeTab != 'general'">
+			<fieldset *ngIf="activeTab == 'general'">
 				<legend i18n="Study detail|Name label@@studyDetailGeneral">General</legend>
 				<ol>
-          <li>
-            <label i18n="Study detail|Name label@@studyDetailName">Name</label>
-            <span class="right-col" [ngSwitch]="mode">
-              <ng-template [ngSwitchCase]="'view'">
-                {{study.name}}
-              </ng-template>
-              <ng-template ngSwitchDefault>
-                <input type="text" formControlName="name" [(ngModel)]="study.name" />
-                <label *ngIf="hasError('name', ['required'])" [@slideDown]="hasError('name', ['required'])" class="form-validation-alert" i18n="Edit study|Name required error@@studyDetailNameRequiredError">Name is required!</label>
-                <label *ngIf="hasError('name', ['minlength', 'maxlength'])" [@slideDown]="hasError('name', ['minlength', 'maxlength'])" class="form-validation-alert" i18n="Edit study|Name length error@@studyDetailNameLengthError">Name length must be between 2 and 200!</label>
-                <label *ngIf="hasError('name', ['unique'])" [@slideDown]="hasError('name', ['unique'])" class="form-validation-alert" i18n="Study detail|Name unique error@@studyDetailNameUniqueError">Name should be unique!</label>
-              </ng-template>
-            </span>
-          </li>
-          <li>
-            <label i18n="Study detail|Name label@@studyDetailPublicDescription">Public description</label>
-            <span class="right-col" [ngSwitch]="mode">
-              <ng-template [ngSwitchCase]="'view'">
-                {{study.description}}
-              </ng-template>
-              <ng-template ngSwitchDefault>
-                <textarea type="text" formControlName="description" [(ngModel)]="study.description"></textarea>
-              </ng-template>
-            </span>
-          </li>
+					<li>
+						<label i18n="Study detail|Name label@@studyDetailName">Name</label>
+						<span class="right-col" [ngSwitch]="mode">
+						<ng-template [ngSwitchCase]="'view'">
+							{{study.name}}
+						</ng-template>
+						<ng-template ngSwitchDefault>
+							<input type="text" formControlName="name" [(ngModel)]="study.name" />
+							<label *ngIf="hasError('name', ['required'])" [@slideDown]="hasError('name', ['required'])" class="form-validation-alert" i18n="Edit study|Name required error@@studyDetailNameRequiredError">Name is required!</label>
+							<label *ngIf="hasError('name', ['minlength', 'maxlength'])" [@slideDown]="hasError('name', ['minlength', 'maxlength'])" class="form-validation-alert" i18n="Edit study|Name length error@@studyDetailNameLengthError">Name length must be between 2 and 200!</label>
+							<label *ngIf="hasError('name', ['unique'])" [@slideDown]="hasError('name', ['unique'])" class="form-validation-alert" i18n="Study detail|Name unique error@@studyDetailNameUniqueError">Name should be unique!</label>
+						</ng-template>
+						</span>
+					</li>
+					<li>
+						<label i18n="Study detail|Name label@@studyDetailPublicDescription">Public description</label>
+						<span class="right-col" [ngSwitch]="mode">
+						<ng-template [ngSwitchCase]="'view'">
+							{{study.description}}
+						</ng-template>
+						<ng-template ngSwitchDefault>
+							<textarea type="text" formControlName="description" [(ngModel)]="study.description"></textarea>
+						</ng-template>
+						</span>
+					</li>
 					<li>
 						<label i18n="Study detail|Start date label@@studyDetailStartDate">Start date</label>
 						<span class="right-col">
@@ -98,9 +98,9 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 							</ng-template>
 						</span>
 					</li>
-          <li>
-            <label i18n="Study detail|Status label@@studyDetailStatus">Status</label>
-            <span class="right-col" [ngSwitch]="mode">
+					<li>
+						<label i18n="Study detail|Status label@@studyDetailStatus">Status</label>
+						<span class="right-col" [ngSwitch]="mode">
 							<ng-template [ngSwitchCase]="'view'">
 								{{studyStatusStr(study.studyStatus)}}
 							</ng-template>
@@ -110,12 +110,12 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 								<label *ngIf="hasError('studyStatus', ['required'])" class="form-validation-alert" i18n="Study detail|Status required error@@studyDetailStatusRequiredError">Status is required!</label>
 							</ng-template>
 						</span>
-          </li>
-          <li>
-            <label i18n="Study detail|Status label@@studyDetailStatus">Pseudonymization profile</label>
-            <span class="right-col" [ngSwitch]="mode">
+					</li>
+					<li>
+						<label>Pseudonymization profile</label>
+						<span class="right-col" [ngSwitch]="mode">
 							<ng-container *ngIf="mode == 'view' || mode == 'edit'">
-								{{ (study.profile.profileName) }}
+								{{study.profile?.profileName}}
 							</ng-container>
 							<ng-container *ngIf="mode == 'create'">
 								<select-box formControlName="profile" [(ngModel)]="study.profile" [options]="profileOptions">
@@ -123,17 +123,16 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 								<label *ngIf="hasError('profile', ['required'])" class="form-validation-alert" i18n="Study detail|Profile required error@@studyDetailStatusRequiredError">Profile is required!</label>
 							</ng-container>
 						</span>
-          </li>
-          <li>
-            <label i18n="Study detail|Status label@@studyDetailStatus">Storage volume</label>
-            <span class="right-col" *ngIf="!uploading">
-				{{ studySizeStr(study.size) }}
-			</span>
-			<span class="right-col" *ngIf="uploading">
-				<i class="fas fa-spinner fa-pulse"></i>
-			</span>
-          </li>
-          <li>
+					</li>
+					<li>
+						<label i18n="Study detail|Status label@@studyDetailStatus">Storage volume</label>
+						<span class="right-col" *ngIf="!uploading">
+							{{ studySizeStr(study.size) }}
+						</span>
+						<span class="right-col" *ngIf="uploading">
+							<i class="fas fa-spinner fa-pulse"></i>
+						</span>
+					</li>
 					<li>
 						<label i18n="Study detail|Clinical label@@studyDetailClinical">Is clinical</label>
 						<span class="right-col" [ngSwitch]="mode">
@@ -146,18 +145,18 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 							</ng-template>
 						</span>
 					</li>
-          <li *ngIf="keycloakService.isUserAdmin()">
-              <label i18n="Study detail|Challenge label@@studyDetailChalenge">Challenge</label>
-              <span class="right-col" [ngSwitch]="mode">
-                  <ng-template [ngSwitchCase]="'view'">
-                      <span *ngIf="study.challenge" class="bool-true"><i class="fas fa-check"></i></span>
-                      <span *ngIf="!study.challenge" class="bool-false"><i class="fas fa-times"></i></span>
-                  </ng-template>
-                  <ng-template ngSwitchDefault>
-                      <checkbox [(ngModel)]="study.challenge" formControlName="challenge"></checkbox>
-                  </ng-template>
-              </span>
-          </li>
+					<li *ngIf="keycloakService.isUserAdmin()">
+						<label i18n="Study detail|Challenge label@@studyDetailChalenge">Challenge</label>
+						<span class="right-col" [ngSwitch]="mode">
+							<ng-template [ngSwitchCase]="'view'">
+								<span *ngIf="study.challenge" class="bool-true"><i class="fas fa-check"></i></span>
+								<span *ngIf="!study.challenge" class="bool-false"><i class="fas fa-times"></i></span>
+							</ng-template>
+							<ng-template ngSwitchDefault>
+								<checkbox [(ngModel)]="study.challenge" formControlName="challenge"></checkbox>
+							</ng-template>
+						</span>
+					</li>
 					<li>
 						<label i18n="Study detail|With examination label@@studyDetailWithExamination">Is with examination</label>
 						<span class="right-col" [ngSwitch]="mode">
@@ -172,7 +171,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 					</li>
 				</ol>
 			</fieldset>
-			<fieldset [class.hidden]="activeTab != 'files'">
+			<fieldset [class.hidden-tab]="activeTab != 'files'">
 				<legend i18n="Study detail|Data User Agreement label@@studyDetailDataUserAgreement">
 					Data user agreement (DUA)
 					<tool-tip class="larger">
@@ -212,7 +211,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 					</li>
 				</ol>
 			</fieldset>
-			<fieldset [class.hidden]="activeTab != 'general'">
+			<fieldset [class.hidden-tab]="activeTab != 'general'">
 				<legend i18n="Study detail|Name label@@studyDetailDefaultAccessLevel">Access level</legend>
 				<ol>
 					<li>
@@ -241,12 +240,12 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 					</li>
 				</ol>
 			</fieldset>
-			<fieldset [class.hidden]="activeTab != 'subjects'">
+			<fieldset [class.hidden-tab]="activeTab != 'subjects'">
         <legend>Subject tags</legend>
         <tag-creator ngDefaultControl [mode]="mode" [study]="study" [(ngModel)]="study.tags" (onChange)="onTagListChange()" formControlName="tags"></tag-creator>
 				<subject-study-list [study]="study" [selectableList]="subjects" [(ngModel)]="study.subjectStudyList" formControlName="subjectStudyList" [mode]="mode"></subject-study-list>
 			</fieldset>
-			<fieldset [class.hidden]="activeTab != 'centers'">
+			<fieldset [class.hidden-tab]="activeTab != 'centers'">
 				<legend i18n="Study detail|Name label@@studyDetailCentersAndPITitle">List of centers</legend>
 				<ol>
 					<li>
@@ -310,7 +309,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 					</li>
 				</ol>
 			</fieldset>
-			<fieldset [class.hidden]="activeTab != 'files'">
+			<fieldset [class.hidden-tab]="activeTab != 'files'">
 				<legend i18n="Study detail|Protocol files label@@studyDetailProtocolFiles">Study files</legend>
 				<ol>
 					<li *ngIf="mode != 'view'">
@@ -339,7 +338,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
                     </li>
 				</ol>
 			</fieldset>
-			<fieldset [class.hidden]="activeTab != 'members'">
+			<fieldset [class.hidden-tab]="activeTab != 'members'">
 				<legend i18n="Study detail|Study Members@@studyMembers">Study members</legend>
 				<studyuser-list
 				    formControlName="studyUserList"
@@ -362,11 +361,11 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 					</li>
 				</ul>
       </fieldset>
-			<fieldset [class.hidden]="activeTab != 'quality'" *ngIf="mode == 'view'">
+			<fieldset [class.hidden-tab]="activeTab != 'quality'" *ngIf="mode == 'view'">
 				<legend>Quality control</legend>
 				<quality-control [studyId]="study.id" (tagUpdate)="reloadSubjectStudies()"></quality-control>
 			</fieldset>
-			<fieldset [class.hidden]="activeTab != 'tree'" *ngIf="mode != 'create'">
+			<fieldset [class.hidden-tab]="activeTab != 'tree'" *ngIf="mode != 'create'">
 				<legend>Tree</legend>
 				<study-node [input]="studyNode"
 						(selectedChange)="onTreeSelectedChange($event)"
@@ -374,11 +373,11 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 						[hasBox]="true">
 				</study-node>
 			</fieldset>
-            <fieldset [class.hidden]="activeTab != 'tags'" *ngIf="mode != 'view' || (study.studyTags && study.studyTags.length > 0)">
+            <fieldset [class.hidden-tab]="activeTab != 'tags'" *ngIf="mode != 'view' || (study.studyTags && study.studyTags.length > 0)">
                 <legend>Public Study tags</legend>
                 <tag-creator ngDefaultControl [mode]="mode" [study]="study" [(ngModel)]="study.studyTags" (onChange)="onStudyTagListChange()" formControlName="studyTags"></tag-creator>
             </fieldset>
-            <fieldset *ngIf="mode == 'view'" [class.hidden]="activeTab != 'bids'">
+            <fieldset *ngIf="mode == 'view'" [class.hidden-tab]="activeTab != 'bids'">
 				        <legend>BIDS tree</legend>
                 <bids-tree [studyId]="id"></bids-tree>
             </fieldset>

--- a/shanoir-ng-front/src/app/studies/study/study.component.html
+++ b/shanoir-ng-front/src/app/studies/study/study.component.html
@@ -28,20 +28,20 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 			</span>
 
 			<ul class="tabs">
-				<li [class.active]="activeTab == 'general'" [routerLink]="'.'" [fragment]="'general'" skipLocationChange replaceUrl="true">General</li>
-				<li [class.active]="activeTab == 'files'" [routerLink]="'.'" [fragment]="'files'" skipLocationChange replaceUrl="true">Files</li>
-				<li [class.active]="activeTab == 'subjects'" [routerLink]="'.'" [fragment]="'subjects'" skipLocationChange replaceUrl="true">Subjects</li>
-				<li [class.active]="activeTab == 'centers'" [routerLink]="'.'" [fragment]="'centers'" skipLocationChange replaceUrl="true">Centers</li>
-				<li [class.active]="activeTab == 'members'" [routerLink]="'.'" [fragment]="'members'" skipLocationChange replaceUrl="true">Members</li>
-				<li [class.active]="activeTab == 'tags'" [routerLink]="'.'" [fragment]="'tags'" skipLocationChange replaceUrl="true">Tags</li>
+				<li [class.active]="activeTab == 'general'" [routerLink]="'.'" fragment="general" replaceUrl="true">General</li>
+				<li [class.active]="activeTab == 'files'" [routerLink]="'.'" [fragment]="'files'" replaceUrl="true">Files</li>
+				<li [class.active]="activeTab == 'subjects'" [routerLink]="'.'" [fragment]="'subjects'" replaceUrl="true">Subjects</li>
+				<li [class.active]="activeTab == 'centers'" [routerLink]="'.'" [fragment]="'centers'" replaceUrl="true">Centers</li>
+				<li [class.active]="activeTab == 'members'" [routerLink]="'.'" [fragment]="'members'" replaceUrl="true">Members</li>
+				<li [class.active]="activeTab == 'tags'" [routerLink]="'.'" [fragment]="'tags'" replaceUrl="true">Tags</li>
 				<ng-container *ngIf="mode == 'view'">
-					<li *ngIf="isStudyAdmin" [class.active]="activeTab == 'quality'" [routerLink]="'.'" [fragment]="'quality'" skipLocationChange replaceUrl="true">Quality</li>				
-					<li [class.active]="activeTab == 'tree'" [routerLink]="'.'" [fragment]="'tree'" skipLocationChange replaceUrl="true">Tree</li>
-					<li [class.active]="activeTab == 'bids'" [routerLink]="'.'" [fragment]="'bids'" skipLocationChange replaceUrl="true">BIDS</li>
+					<li *ngIf="isStudyAdmin" [class.active]="activeTab == 'quality'" [routerLink]="'.'" [fragment]="'quality'" replaceUrl="true">Quality</li>				
+					<li [class.active]="activeTab == 'tree'" [routerLink]="'.'" [fragment]="'tree'" replaceUrl="true">Tree</li>
+					<li [class.active]="activeTab == 'bids'" [routerLink]="'.'" [fragment]="'bids'" replaceUrl="true">BIDS</li>
 				</ng-container>
 				<ng-container *ngIf="mode != 'view'">
-					<li [class.active]="activeTab == 'tree'" class="disabled" skipLocationChange replaceUrl="true">Tree</li>
-					<li [class.active]="activeTab == 'bids'" class="disabled" skipLocationChange replaceUrl="true">BIDS</li>
+					<li [class.active]="activeTab == 'tree'" class="disabled" replaceUrl="true">Tree</li>
+					<li [class.active]="activeTab == 'bids'" class="disabled" replaceUrl="true">BIDS</li>
 				</ng-container>
 			</ul>
 

--- a/shanoir-ng-front/src/app/studies/study/study.component.html
+++ b/shanoir-ng-front/src/app/studies/study/study.component.html
@@ -264,15 +264,15 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 						</span>
 						<span *ngIf="mode == 'view'" class="left-col">
 						    <p><b>Centers</b></p>
-						    <ol *ngFor="let studyCenter of study.studyCenterList;">
-								<li class="center-list">- {{studyCenter.center.name}}<span *ngIf="studyCenter.subjectNamePrefix">: {{studyCenter.subjectNamePrefix}}</span></li>
-							</ol>
+						    <ol *ngFor="let studyCenter of study.studyCenterList; let i = index; let even = even; let odd = odd;" [class.even]="even" [class.odd]="odd">
+                                <li class="center-list">- {{studyCenter.center.name}}<span *ngIf="studyCenter.subjectNamePrefix">: {{studyCenter.subjectNamePrefix}}</span></li>
+                            </ol>
 						</span>
 					</li>
 					<li *ngIf="mode != 'view'">
 						<label i18n="Study detail|List of centers label@@studyDetailCentersAndPI">Center</label>
 						<span class="right-col">
-							<select-box formControlName="studyCenter" [ngModel]="selectedCenter" (userChange)="onCenterChange($event)" placeholder="Select a center ..." (onAddClick)="onCenterAdd()" [addDisabled]="!enableAddIcon()" [options]="centerOptions">
+							<select-box [ngModel]="selectedCenter" [ngModelOptions]="{standalone: true}" (userChange)="onCenterChange($event)" placeholder="Select a center ..." (onAddClick)="onCenterAdd()" [addDisabled]="!enableAddIcon()" [options]="centerOptions">
 							</select-box>
 							<label *ngIf="hasError('studyCenterList', ['required'])" class="form-validation-alert right-col">At least one center is required !</label>
 						</span>

--- a/shanoir-ng-front/src/app/studies/study/study.component.ts
+++ b/shanoir-ng-front/src/app/studies/study/study.component.ts
@@ -237,7 +237,6 @@ export class StudyComponent extends EntityComponent<Study> {
             'visibleByDefault': [this.study.visibleByDefault],
             'downloadableByDefault': [this.study.downloadableByDefault],
             'monoCenter': [{value: this.study.monoCenter, disabled: this.study.studyCenterList && this.study.studyCenterList.length > 1}, [Validators.required]],
-            'studyCenter': [this.study.studyCenterList, [Validators.required]],
             'studyCenterList': [this.study.studyCenterList, [this.validateCenter]],
             'subjectStudyList': [this.study.subjectStudyList],
             'tags': [this.study.tags],
@@ -345,17 +344,11 @@ export class StudyComponent extends EntityComponent<Study> {
 
     /** Center section management  **/
     onMonoMultiChange() {
-      if (this.study.monoCenter) {
-        this.centerOptions.forEach(option => option.disabled = false);
-      }
-      if (this.study.monoCenter && this.study.studyCenterList.length >= 1) {
-          this.study.studyCenterList = [this.study.studyCenterList[0]];
-          let option = this.centerOptions.find(option => option.value.id == this.study.studyCenterList[0].center.id);
-          if (option) this.selectedCenter = option.value;
-      }
-      if (!this.study.monoCenter) {
-        this.centerOptions.forEach(option => option.disabled = this.study.studyCenterList.findIndex(studyCenter => studyCenter.center.id == option.value.id) != -1);
-      }
+        if (this.study.monoCenter && this.study.studyCenterList.length >= 1) {
+            this.study.studyCenterList = [this.study.studyCenterList[0]];
+            let option = this.centerOptions.find(option => option.value.id == this.study.studyCenterList[0].center.id);
+            if (option) this.selectedCenter = option.value;
+        }
     }
 
     goToCenter(id: number) {
@@ -370,9 +363,7 @@ export class StudyComponent extends EntityComponent<Study> {
             studyCenter.center.name = this.selectedCenter.name;
             this.study.studyCenterList.push(studyCenter);
             this.study.studyCenterList = [...this.study.studyCenterList];
-            if (!this.study.monoCenter) {
-              this.centerOptions.forEach(option => option.disabled = this.study.studyCenterList.findIndex(studyCenter => studyCenter.center.id == option.value.id) != -1);
-            }
+            this.centerOptions.forEach(option => option.disabled = this.study.studyCenterList.findIndex(studyCenter => studyCenter.center.id == option.value.id) != -1);
         }
         this.form.get('studyCenterList').markAsDirty();
         this.form.get('studyCenterList').updateValueAndValidity();
@@ -383,9 +374,6 @@ export class StudyComponent extends EntityComponent<Study> {
       if (this.study.monoCenter) {
         this.study.studyCenterList = []
         this.onCenterAdd();
-      }
-      if (!this.study.monoCenter) {
-        this.centerOptions.forEach(option => option.disabled = this.study.studyCenterList.findIndex(studyCenter => studyCenter.center.id == option.value.id) != -1);
       }
     }
 

--- a/shanoir-ng-front/src/assets/css/common.css
+++ b/shanoir-ng-front/src/assets/css/common.css
@@ -113,7 +113,7 @@ form { color: var(--dark-grey); position: relative; }
     form fieldset fieldset label { display: block; width: auto; }
     form fieldset fieldset label { margin-left: 183px; }
   form legend { padding: 0 10px 0 0; color: var(--color-a); font-size: 14px; margin: 10px 0; color: var(--color-c); width: 100%; }
-  form li > label { display: inline-block; width: 250px; vertical-align: top; }
+  form li > label { display: inline-block; width: 250px; vertical-align: top; height: 20px; line-height: 20px; }
   form fieldset ol { margin: 0; padding: 0; }
   form fieldset li { list-style: none; padding: 3px 0; margin: 0; min-height: 22px; }
     form fieldset li input,


### PR DESCRIPTION
Sorry I'm reverting the previous PR because 
* it broke the studycard/qualitycard rule edition, shrinking select boxes
* there can't be specific code mentioning "center" in an ultra generic component like select-box
* there was already a method in select.component.ts named computeMinWidth() that was supposed to compute the minimum width of the list
* the actual problem was that when opening the study page, the center tab is display:none which interfere with the width calculation