### PR TITLE
Security fix after Rennes's hack

### DIFF
--- a/docker-compose/database/db-changes/datasets/0027_downloadable_datasets.sql
+++ b/docker-compose/database/db-changes/datasets/0027_downloadable_datasets.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `dataset` ADD COLUMN `downloadable` bit(1) NOT NULL DEFAULT 1;
+UPDATE dataset SET downloadable = 1;
+UPDATE dataset d SET d.downloadable = 0 WHERE d.dataset_acquisition_id in (SELECT da.id FROM dataset_acquisition da where da.creation_date > '2023-06-17' AND da.creation_date < '2023-06-28');

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/model/Dataset.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/model/Dataset.java
@@ -150,6 +150,9 @@ public abstract class Dataset extends AbstractEntity {
 	/** Subject. */
 	private Long subjectId;
 
+	/** Can we download the subject ? */
+	private boolean downloadable;
+
 	/** Metadata updated by study card. */
 	@OneToOne(cascade = CascadeType.ALL)
 	private DatasetMetadata updatedMetadata;
@@ -406,6 +409,14 @@ public abstract class Dataset extends AbstractEntity {
 	@Deprecated
 	public void setImportedStudyId(Long importedStudyId) {
 		this.importedStudyId = importedStudyId;
+	}
+
+	public boolean isDownloadable() {
+		return downloadable;
+	}
+
+	public void setDownloadable(boolean downloadable) {
+		this.downloadable = downloadable;
 	}
 
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/service/DatasetDownloaderServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/service/DatasetDownloaderServiceImpl.java
@@ -87,6 +87,11 @@ public class DatasetDownloaderServiceImpl {
 			throw new RestServiceException(
 					new ErrorModel(HttpStatus.NOT_FOUND.value(), "Dataset with id not found.", null));
 		}
+		
+		if (!dataset.isDownloadable()) {
+			throw new RestServiceException(
+					new ErrorModel(HttpStatus.UNAUTHORIZED.value(), "Dataset cannot be downloaded for security reasons.", null));
+		}
 
 		String subjectName = "unknownSubject";
 		Optional<Subject> subjectOpt = subjectRepository.findById(dataset.getSubjectId());
@@ -205,6 +210,9 @@ public class DatasetDownloaderServiceImpl {
 		try(ZipOutputStream zipOutputStream = new ZipOutputStream(response.getOutputStream())) {
 
 			for (Dataset dataset : datasets) {
+				if (!dataset.isDownloadable()) {
+					continue;
+				}
 				try {
 
 					List<String> datasetFiles = new ArrayList<>();


### PR DESCRIPTION
How to test:
- Before deploying, import some data (or force creation date)
- Download old data = OK
- Download data with acquisition creation_date  between 17 to 28 june -> Download fails. 