### PR TITLE
[fli-iam#1663] Check rights when running pipeline on datasets

### DIFF
--- a/shanoir-ng-front/src/app/solr/solr.search.component.ts
+++ b/shanoir-ng-front/src/app/solr/solr.search.component.ts
@@ -516,8 +516,21 @@ export class SolrSearchComponent implements AfterViewChecked, AfterContentInit {
     }
 
     initExecutionMode() {
-        this.processingService.setDatasets(this.selectedDatasetIds);
-        this.router.navigate(['/processing']);
+        let noAdminStudies: Set<string> = new Set();
+        this.datasetAcquisitionService.getAllForDatasets([...this.selectedDatasetIds]).then(acquisitions => {
+            acquisitions.forEach(acq => {
+                if (!this.hasAdminRight(acq.examination?.study?.id)) {
+                    noAdminStudies.add(acq.examination?.study?.name);
+                }
+            });
+            if(noAdminStudies.size > 0){
+                this.confirmDialogService.error('Invalid selection', 'You don\'t have the right to run pipelines on studies you don\'t administrate. '
+                    + 'Remove datasets that belongs to the following study(ies) from your selection : ' + [...noAdminStudies].join(', '));
+            }else{
+                this.processingService.setDatasets(this.selectedDatasetIds);
+                this.router.navigate(['/processing']);
+            }
+        });
     }
 
     copyIds() {


### PR DESCRIPTION
When clicking "Run a process" in solr view, check if user has the correct rights on selected datasets.
If not, an error dialog will be displayed.

See https://github.com/fli-iam/shanoir-ng/wiki/Roles-and-rights-specification#synthesis-table
- Admin can run a process
- User can not run a process
- Expert with CAN_ADMIN rights on all selected datasets can run a process

