### PR TITLE
migration to debian bookworm

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -91,8 +91,10 @@ if [ -n "$build" ] ; then
 	# 1. build a docker image with the java toolchain
 	DEV_IMG=shanoir-ng-dev
 	docker build -t "$DEV_IMG" - <<EOF
-FROM debian:bullseye
-RUN apt-get update && apt-get install -qqy --no-install-recommends openjdk-17-jdk-headless maven bzip2 git
+FROM debian:bookworm
+# NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
+RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
+    && apt-get update -qq && apt-get install -qqy --no-install-recommends openjdk-17-jdk-headless maven bzip2 git
 EOF
 	# 2. run the maven build
 	mkdir -p /tmp/home

--- a/docker-compose/datasets/Dockerfile
+++ b/docker-compose/datasets/Dockerfile
@@ -10,19 +10,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 
-FROM debian:bullseye
+#--------------- common jre base image -------------------------------------
+FROM debian:bookworm
+# NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
+RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
+    && apt-get update -qq \
+    && apt-get install -qqy openjdk-17-jre-headless ca-certificates-java
+#----------------------------------------------------------------------------
 
-RUN set -ex && \
-    echo 'deb http://deb.debian.org/debian bullseye-backports main' \
-      > /etc/apt/sources.list.d/bullseye-backports.list && \
-    apt update -y && \
-    apt install -t \
-      bullseye-backports \
-      openjdk-17-jre \
-      ca-certificates-java -y
 
 RUN apt-get update -qq \
-    && apt-get install -y \
+    && apt-get install -qqy \
     unzip \
     pigz \
     gzip \

--- a/docker-compose/import/Dockerfile
+++ b/docker-compose/import/Dockerfile
@@ -10,23 +10,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 
-FROM debian:bullseye
+#--------------- common jre base image -------------------------------------
+FROM debian:bookworm
+# NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
+RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
+    && apt-get update -qq \
+    && apt-get install -qqy openjdk-17-jre-headless ca-certificates-java
+#----------------------------------------------------------------------------
 
-RUN set -ex && \
-    echo 'deb http://deb.debian.org/debian bullseye-backports main' \
-      > /etc/apt/sources.list.d/bullseye-backports.list && \
-    apt update -y && \
-    apt install -t \
-      bullseye-backports \
-      openjdk-17-jre \
-      ca-certificates-java -y
 
 #32 bits packages are necessary
 RUN dpkg --add-architecture i386
-RUN apt-get update
 
 RUN apt-get update -qq \
-    && apt-get install -y \
+    && apt-get install -qqy \
     git \
     curl \
     build-essential \

--- a/docker-compose/import/Dockerfile
+++ b/docker-compose/import/Dockerfile
@@ -41,11 +41,10 @@ RUN apt-get update -qq \
     libsm6 \
     libxext6 \
     lib32stdc++6 \
-    libtiff5 \
+    libtiff6 \
     libglib2.0-0:i386 \
     locales \
-    locales-all \
-    python
+    locales-all
 
 # Compile DCM2NIIX from source
 ENV DCMCOMMIT_VERSION=v1.0.20210317

--- a/docker-compose/preclinical/Dockerfile
+++ b/docker-compose/preclinical/Dockerfile
@@ -1,15 +1,11 @@
-FROM debian:bullseye
+#--------------- common jre base image -------------------------------------
+FROM debian:bookworm
+# NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
+RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
+    && apt-get update -qq \
+    && apt-get install -qqy openjdk-17-jre-headless ca-certificates-java
+#----------------------------------------------------------------------------
 
-RUN set -ex && \
-    echo 'deb http://deb.debian.org/debian bullseye-backports main' \
-      > /etc/apt/sources.list.d/bullseye-backports.list && \
-    apt update -y && \
-    apt install -t \
-      bullseye-backports \
-      openjdk-17-jre \
-      ca-certificates-java -y
-
-RUN apt-get update
 
 RUN mkdir -pv /var/log/shanoir-ng-logs
 ADD shanoir-ng-preclinical.jar shanoir-ng-preclinical.jar

--- a/docker-compose/studies/Dockerfile
+++ b/docker-compose/studies/Dockerfile
@@ -10,18 +10,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 
-FROM debian:bullseye
+#--------------- common jre base image -------------------------------------
+FROM debian:bookworm
+# NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
+RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
+    && apt-get update -qq \
+    && apt-get install -qqy openjdk-17-jre-headless ca-certificates-java
+#----------------------------------------------------------------------------
 
-RUN set -ex && \
-    echo 'deb http://deb.debian.org/debian bullseye-backports main' \
-      > /etc/apt/sources.list.d/bullseye-backports.list && \
-    apt update -y && \
-    apt install -t \
-      bullseye-backports \
-      openjdk-17-jre \
-      ca-certificates-java -y
-
-RUN apt-get update
 
 RUN mkdir -pv /var/log/shanoir-ng-logs
 ADD shanoir-ng-studies.jar shanoir-ng-studies.jar

--- a/docker-compose/users/Dockerfile
+++ b/docker-compose/users/Dockerfile
@@ -10,18 +10,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 
-FROM debian:bullseye
+#--------------- common jre base image -------------------------------------
+FROM debian:bookworm
+# NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
+RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
+    && apt-get update -qq \
+    && apt-get install -qqy openjdk-17-jre-headless ca-certificates-java
+#----------------------------------------------------------------------------
 
-RUN set -ex && \
-    echo 'deb http://deb.debian.org/debian bullseye-backports main' \
-      > /etc/apt/sources.list.d/bullseye-backports.list && \
-    apt update -y && \
-    apt install -t \
-      bullseye-backports \
-      openjdk-17-jre \
-      ca-certificates-java -y
 
-RUN apt-get update && apt-get install openssl
+RUN apt-get update -qq && apt-get install -qqy openssl
 
 RUN mkdir -pv /var/log/shanoir-ng-logs
 ADD shanoir-ng-users.jar shanoir-ng-users.jar


### PR DESCRIPTION
- I removed the *backports* repository and used the *proposed-updates* repository because it is more stable (and a fixed version of  *ca-certificates-java* was pushed there, see: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472 and https://tracker.debian.org/pkg/ca-certificates-java)

- I changed all dockerfiles using openjdk17 to begin exactly with exactly the same lines (delimited with *common jre base image*), this way the build is faster because it reuses the intermediate images in cache.

- I had to removes obsolete packages for python2 and libtiff4 from the *import* image. It seems that they are not used by any executables in the image (i am not totally sure, i just did a quick check).