### PR TITLE
[fli-iam#1816][fli-iam#1802] Delete animal subject only through subject

### DIFF
--- a/shanoir-ng-front/src/app/preclinical/animalSubject/edit/animalSubject-form.component.html
+++ b/shanoir-ng-front/src/app/preclinical/animalSubject/edit/animalSubject-form.component.html
@@ -168,7 +168,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 				[state]="footerState"
 				(save)="save()"
 				(edit)="goToEdit()"
-                (delete) = "delete()"
+                (delete) = "deleteBySubject(this.entity.subject)"
 				(cancel)="goToView(this.entity.animalSubject.id)"
 				(back)="goBack()">
 			</form-footer>

--- a/shanoir-ng-front/src/app/preclinical/animalSubject/edit/animalSubject-form.component.ts
+++ b/shanoir-ng-front/src/app/preclinical/animalSubject/edit/animalSubject-form.component.ts
@@ -543,4 +543,11 @@ export class AnimalSubjectFormComponent extends EntityComponent<PreclinicalSubje
         this.breadcrumbsService.currentStep.data.subjectNode = node;
     }
 
+    deleteBySubject(subject: Subject) {
+        this.subjectService.deleteWithConfirmDialog("preclinical-subject", subject).then(deleted => {
+            if(deleted){
+                this.goToList();
+            }
+        });
+    }
 }

--- a/shanoir-ng-front/src/app/preclinical/animalSubject/list/animalSubject-list.component.ts
+++ b/shanoir-ng-front/src/app/preclinical/animalSubject/list/animalSubject-list.component.ts
@@ -131,14 +131,14 @@ export class AnimalSubjectsListComponent  extends BrowserPaginEntityListComponen
                 'Delete', 'Are you sure you want to delete preclinical-subject n° ' + entity.id + ' ?'
             ).then(res => {
                 if (res) {
-                    this.animalSubjectService.delete(entity.id).then((res) => {
+                    this.subjectService.delete(entity.id).then((res) => {
                         this.onDelete.next({entity: entity});
                         const index: number = this.preclinicalSubjects.indexOf(entity);
                         if (index !== -1) {
                             this.preclinicalSubjects.splice(index);
                         }
                         this.table.refresh();
-                        this.consoleService.log('info', 'The preclinical-subject n°' + entity.id + ' sucessfully deleted');
+                        this.consoleService.log('info', 'The preclinical-subject n°' + entity.id + ' was sucessfully deleted');
                     }
                     ).catch(reason => {
                         if (reason && reason.error) {

--- a/shanoir-ng-preclinical/src/main/java/org/shanoir/ng/preclinical/subjects/controller/AnimalSubjectApi.java
+++ b/shanoir-ng-preclinical/src/main/java/org/shanoir/ng/preclinical/subjects/controller/AnimalSubjectApi.java
@@ -46,14 +46,6 @@ public interface AnimalSubjectApi {
 			@Parameter(name = "AnimalSubject object to add", required = true) @RequestBody @Valid final PreclinicalSubjectDto animalSubject,
 			final BindingResult result) throws RestServiceException;
 
-	@Operation(summary = "Deletes an animalSubject", description = "")
-	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Successful operation"),
-			@ApiResponse(responseCode = "400", description = "Invalid subject value"),
-			@ApiResponse(responseCode = "500", description = "Unexpected Error") })
-	@DeleteMapping(value = "/{id}", produces = { "application/json" })
-	ResponseEntity<Void> deleteAnimalSubject(
-			@Parameter(name = "AnimalSubject id to delete", required = true) @PathVariable("id") Long id);
-
 	@Operation(summary  = "Find animalSubject by subject Id", description = "Returns a subject")
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Successful operation"),
 		@ApiResponse(responseCode = "400", description = "Invalid ID supplied"),

--- a/shanoir-ng-preclinical/src/main/java/org/shanoir/ng/preclinical/subjects/controller/AnimalSubjectApiController.java
+++ b/shanoir-ng-preclinical/src/main/java/org/shanoir/ng/preclinical/subjects/controller/AnimalSubjectApiController.java
@@ -221,26 +221,6 @@ public class AnimalSubjectApiController implements AnimalSubjectApi {
 					new ErrorModel(HttpStatus.UNPROCESSABLE_ENTITY.value(), BAD_ARGUMENTS, new ErrorDetails(errors)));
 		}
 	}
-
-	@Override
-	public ResponseEntity<Void> deleteAnimalSubject(
-			@Parameter(name = "subject id of AnimalSubject to delete", required = true) @PathVariable("id") Long id) {
-		try {
-			AnimalSubject animalSubject = subjectService.getBySubjectId(id);
-			if (animalSubject == null) {
-				return new ResponseEntity<>(HttpStatus.OK);
-			}
-			subjectPathologyService.deleteByAnimalSubject(animalSubject);
-			subjectTherapyService.deleteByAnimalSubject(animalSubject);
-			subjectService.deleteBySubjectId(id);
-			eventService.publishEvent(new ShanoirEvent(ShanoirEventType.DELETE_PRECLINICAL_SUBJECT_EVENT, id.toString(), KeycloakUtil.getTokenUserId(), "", ShanoirEvent.SUCCESS));
-		} catch (ShanoirException e) {
-			LOG.error("ERROR while deleting animal subject " + id, e);
-			return new ResponseEntity<>(HttpStatus.NOT_ACCEPTABLE);
-		}
-		return new ResponseEntity<>(HttpStatus.OK);
-	}
-
 	private FieldErrorMap getUniqueConstraintErrors(final AnimalSubject subject) {
 		return uniqueValidator.validate(subject);
 	}

--- a/shanoir-ng-preclinical/src/test/java/org/shanoir/ng/preclinical/subjects/AnimalSubjectApiControllerTest.java
+++ b/shanoir-ng-preclinical/src/test/java/org/shanoir/ng/preclinical/subjects/AnimalSubjectApiControllerTest.java
@@ -127,13 +127,6 @@ public class AnimalSubjectApiControllerTest {
 	}
 
 	@Test
-	@WithMockKeycloakUser(id = 12, username = "test", authorities = { "ROLE_ADMIN" })
-	public void deleteSubjectTest() throws Exception {
-		mvc.perform(MockMvcRequestBuilders.delete(REQUEST_PATH_WITH_ID).accept(MediaType.APPLICATION_JSON))
-				.andExpect(status().isOk());
-	}
-
-	@Test
 	public void findSubjectByIdTest() throws Exception {
 		mvc.perform(MockMvcRequestBuilders.get(REQUEST_PATH_WITH_ID).accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk());


### PR DESCRIPTION
Deletion of an animal subject is now only possible via API through the deletion of its linked subject.
The animal subject deletion is triggered through a RabbitMQ event.

This allow the check of the user rights on the subject, and the deletion of linked objects on subject side (e.g. examinations)

Solve #1816 and #1802

How to test :
- Delete an animal subject through the list or the detail view
- Check that the list is well updated, and that the linked objects are deleted also