### PR TITLE
[fli-iam#1846] Correct order by numeric value in lists

### DIFF
--- a/shanoir-ng-front/src/app/shared/components/entity/entity.abstract.service.ts
+++ b/shanoir-ng-front/src/app/shared/components/entity/entity.abstract.service.ts
@@ -102,9 +102,8 @@ export abstract class EntityService<T extends Entity> {
             })
     }
 
-    get(id: number, withStorageVolume = false): Promise<T> {
-        return this.http.get<any>(this.API_URL + '/' + id
-            + (withStorageVolume ? '?withStorageVolume=true' : ''))
+    get(id: number): Promise<T> {
+        return this.http.get<any>(this.API_URL + '/' + id)
             .toPromise()
             .then(this.mapEntity);
     }

--- a/shanoir-ng-front/src/app/shared/components/table/browser-paging.model.ts
+++ b/shanoir-ng-front/src/app/shared/components/table/browser-paging.model.ts
@@ -2,12 +2,12 @@
  * Shanoir NG - Import, manage and share neuroimaging data
  * Copyright (C) 2009-2019 Inria - https://www.inria.fr/
  * Contact us on https://project.inria.fr/shanoir/
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
  */
@@ -29,20 +29,20 @@ export class BrowserPaging<T> {
     public setItems(items: T[]) {
         this.items = items;
     }
-    
+
     public setColumnDefs(columnDefs: ColumnDefinition[]) {
         this.columnDefs = columnDefs;
     }
 
     public getPage(pageable: FilterablePageable): Page<T> {
-        if ((!this.lastSort || !this.lastSort.equals(pageable.sort)) 
+        if ((!this.lastSort || !this.lastSort.equals(pageable.sort))
                 && pageable.sort && pageable.sort.orders && pageable.sort.orders.length > 0 ) {
             this.lastSort = pageable.sort;
             this.items = this.sortItems(this.items, pageable); // SORT
         }
         let filtered: T[] = this.filter(this.items, pageable.filter); // FILTER
         let result: T[] = this.slice(filtered, pageable); // SLICE
-        
+
         let page: Page<T> = new Page();
         page.content = result;
         page.number = pageable.pageNumber;
@@ -81,7 +81,7 @@ export class BrowserPaging<T> {
         if (col["disableSorting"] || col["type"] == "button") {
             return;
         }
-        // Regarding the data type, we set a neg infinity because unless this, 
+        // Regarding the data type, we set a neg infinity because unless this,
         // null values can't be compared
         let negInf: any;
         switch (col["type"]) {
@@ -98,7 +98,7 @@ export class BrowserPaging<T> {
         items.sort((n1, n2) => {
             let cell1 = TableComponent.getCellValue(n1, col);
             let cell2 = TableComponent.getCellValue(n2, col);
-            if (col["type"] == "date") {
+            if (col["type"] == "date" || col["type"] == "number") {
                 // Real value for date
                 cell1 = TableComponent.getFieldRawValue(n1, col["field"])
                 cell2 = TableComponent.getFieldRawValue(n2, col["field"])

--- a/shanoir-ng-front/src/app/shared/components/table/table.component.ts
+++ b/shanoir-ng-front/src/app/shared/components/table/table.component.ts
@@ -144,11 +144,11 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
                 savedState.selection.forEach(id => this.selection.add(id));
                 this.emitSelectionChange();
             }
-            this.goToPage(savedState.currentPage ? savedState.currentPage : 1, true)
+            this.goToPage(savedState.currentPage ? savedState.currentPage : 1)
                 .then(() => this.firstLoading = false);
         } else {
             this.getDefaultSorting();
-            this.goToPage(1, true)
+            this.goToPage(1)
                 .then(() => this.firstLoading = false);
         }
     }
@@ -326,9 +326,7 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
         let getPage: Page<any> | Promise<Page<any>> =  this.getPage(this.getPageable(), forceRefresh)
         if (getPage instanceof Promise) {
             return getPage.then(page => {
-                if(forceRefresh){
                     this.pageLoaded.emit(page);
-                }
                 return this.computePage(page);
             }).catch(reason => {
                 setTimeout(() => {
@@ -339,9 +337,7 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
             });
         } else if (getPage instanceof Page) {
             return Promise.resolve(this.computePage(getPage)).then(page => {
-                if(forceRefresh){
-                    this.pageLoaded.emit(page);
-                }
+                this.pageLoaded.emit(page);
                 return page;
             });
         }

--- a/shanoir-ng-front/src/app/studies/shared/study.service.ts
+++ b/shanoir-ng-front/src/app/studies/shared/study.service.ts
@@ -56,6 +56,13 @@ export class StudyService extends EntityService<Study> implements OnDestroy {
         super(http)
     }
 
+    get(id: number, withStorageVolume = false): Promise<Study> {
+        return this.http.get<any>(this.API_URL + '/' + id
+            + (withStorageVolume ? '?withStorageVolume=true' : ''))
+            .toPromise()
+            .then(this.mapEntity);
+    }
+
     getEntityInstance() { return new Study(); }
 
     findStudiesByUserId(): Promise<Study[]> {
@@ -311,7 +318,7 @@ export class StudyService extends EntityService<Study> implements OnDestroy {
         if(size == null){
             return "";
         }
-        
+
         if(size == 0){
             return "0 " + units[0];
         }

--- a/shanoir-ng-front/src/app/studies/study-list/study-list.component.html
+++ b/shanoir-ng-front/src/app/studies/study-list/study-list.component.html
@@ -20,8 +20,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
     [columnDefs]="columnDefs"
     [customActionDefs]="customActionDefs"
     [rowRoute]="getRowRoute.bind(this)"
-    (rowClick)="goToViewFromEntity($event)"
-    (pageLoaded)="fetchStorageVolumes($event)">
+    (rowClick)="goToViewFromEntity($event)">
 </shanoir-table>
 
 <!-- <study-detail *ngIf="selectedId" [id]="selectedId" mode="view"></study-detail> -->

--- a/shanoir-ng-front/src/app/studies/study-list/study-list.component.html
+++ b/shanoir-ng-front/src/app/studies/study-list/study-list.component.html
@@ -20,7 +20,8 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
     [columnDefs]="columnDefs"
     [customActionDefs]="customActionDefs"
     [rowRoute]="getRowRoute.bind(this)"
-    (rowClick)="goToViewFromEntity($event)">
+    (rowClick)="goToViewFromEntity($event)"
+    (pageLoaded)="fetchStorageVolumes($event)">
 </shanoir-table>
 
 <!-- <study-detail *ngIf="selectedId" [id]="selectedId" mode="view"></study-detail> -->

--- a/shanoir-ng-front/src/app/studies/study-list/study-list.component.ts
+++ b/shanoir-ng-front/src/app/studies/study-list/study-list.component.ts
@@ -171,7 +171,7 @@ export class StudyListComponent extends BrowserPaginEntityListComponent<Study> {
             {
                 headerName: "Storage volume", field: "totalSize", disableSearch: true, disableSorting: this.isStudyVolumesFetching, type: "number", orderBy: ["totalSize"],
                 cellRenderer: (params: any) => {
-                    if (params.data.totalSize != null && this.isStudyVolumesFetching) {
+                    if (params.data.totalSize == null && this.isStudyVolumesFetching) {
                         return "Fetching..."
                     }
                     return this.studyService.storageVolumePrettyPrint(params.data.totalSize);

--- a/shanoir-ng-front/src/app/studies/study-list/study-list.component.ts
+++ b/shanoir-ng-front/src/app/studies/study-list/study-list.component.ts
@@ -233,8 +233,13 @@ export class StudyListComponent extends BrowserPaginEntityListComponent<Study> {
         let studies = page.content
         let ids = new Set<number>();
         studies.forEach(study => {
-            ids.add(study.id);
+            if(study.totalSize == null){
+                ids.add(study.id);
+            }
         });
+        if(ids.size == 0){
+            return;
+        }
         this.studyService.getStudiesStorageVolume(ids).then(volumes => {
             studies.forEach( study => {
                 (study as Study).totalSize = volumes.get(study.id)?.total;

--- a/shanoir-ng-front/src/app/studies/study-list/study-list.component.ts
+++ b/shanoir-ng-front/src/app/studies/study-list/study-list.component.ts
@@ -26,6 +26,7 @@ import {StudyCardComponent} from "../../study-cards/study-card/study-card.compon
 import {PublicStudyData} from "../shared/study.dto";
 import {User} from "../../users/shared/user.model";
 import {DatasetExpressionFormat} from "../../enum/dataset-expression-format.enum";
+import {Page} from "../../shared/components/table/pageable.model";
 
 
 @Component({
@@ -92,31 +93,6 @@ export class StudyListComponent extends BrowserPaginEntityListComponent<Study> {
                     }
                 }
             }
-            let ids = new Set<number>();
-            studies.forEach(study => {
-               ids.add(study.id);
-            });
-            this.studyService.getStudiesStorageVolume(ids).then(volumes => {
-                studies.forEach( study => {
-                    (study as Study).totalSize = volumes.get(study.id)?.total;
-                    let sizesByLabel = new Map<String, number>()
-
-                    if(volumes.get(study.id)?.volumeByFormat){
-                        for(let sizeByFormat of volumes.get(study.id)?.volumeByFormat){
-                            if(sizeByFormat.size > 0){
-                                sizesByLabel.set(DatasetExpressionFormat.getLabel(sizeByFormat.format), sizeByFormat.size);
-                            }
-                        }
-                    }
-
-                    if(volumes.get(study.id)?.extraDataSize && volumes.get(study.id)?.extraDataSize > 0){
-                        sizesByLabel.set("Other files (DUA, protocol...)", volumes.get(study.id)?.extraDataSize);
-                    }
-
-                    (study as Study).detailedSizes = sizesByLabel;
-                    this.isStudyVolumesFetching = false;
-                });
-            })
         });
         return earlyResult;
     }
@@ -215,4 +191,33 @@ export class StudyListComponent extends BrowserPaginEntityListComponent<Study> {
             }
         }
     }
+
+    fetchStorageVolumes(page: Page<Study>) {
+        let studies = page.content
+        let ids = new Set<number>();
+        studies.forEach(study => {
+            ids.add(study.id);
+        });
+        this.studyService.getStudiesStorageVolume(ids).then(volumes => {
+            studies.forEach( study => {
+                (study as Study).totalSize = volumes.get(study.id)?.total;
+                let sizesByLabel = new Map<String, number>()
+
+                if(volumes.get(study.id)?.volumeByFormat){
+                    for(let sizeByFormat of volumes.get(study.id)?.volumeByFormat){
+                        if(sizeByFormat.size > 0){
+                            sizesByLabel.set(DatasetExpressionFormat.getLabel(sizeByFormat.format), sizeByFormat.size);
+                        }
+                    }
+                }
+
+                if(volumes.get(study.id)?.extraDataSize && volumes.get(study.id)?.extraDataSize > 0){
+                    sizesByLabel.set("Other files (DUA, protocol...)", volumes.get(study.id)?.extraDataSize);
+                }
+
+                (study as Study).detailedSizes = sizesByLabel;
+                this.isStudyVolumesFetching = false;
+            });
+        });
+    };
 }

--- a/shanoir-ng-front/src/app/studies/study-list/study-list.component.ts
+++ b/shanoir-ng-front/src/app/studies/study-list/study-list.component.ts
@@ -171,7 +171,7 @@ export class StudyListComponent extends BrowserPaginEntityListComponent<Study> {
             {
                 headerName: "Storage volume", field: "totalSize", disableSearch: true, disableSorting: this.isStudyVolumesFetching, type: "number", orderBy: ["totalSize"],
                 cellRenderer: (params: any) => {
-                    if (this.isStudyVolumesFetching) {
+                    if (!params.data.totalSize && this.isStudyVolumesFetching) {
                         return "Fetching..."
                     }
                     return this.studyService.storageVolumePrettyPrint(params.data.totalSize);

--- a/shanoir-ng-front/src/app/studies/study-list/study-list.component.ts
+++ b/shanoir-ng-front/src/app/studies/study-list/study-list.component.ts
@@ -133,7 +133,14 @@ export class StudyListComponent extends BrowserPaginEntityListComponent<Study> {
             }));
         }
 
-        Promise.all(promises).then(() => this.isStudyVolumesFetching = false);
+        Promise.all(promises).then(() => {
+            this.table.columnDefs.forEach(column => {
+                if(column.headerName === "Storage volume"){
+                    column.disableSorting = false;
+                }
+            })
+            return this.isStudyVolumesFetching = false;
+        });
     }
 
     getColumnDefs(): ColumnDefinition[] {
@@ -169,9 +176,9 @@ export class StudyListComponent extends BrowserPaginEntityListComponent<Study> {
                 headerName: "Members", field: "nbMembers", type: "number", width: '30px'
             },
             {
-                headerName: "Storage volume", field: "totalSize", disableSearch: true, disableSorting: this.isStudyVolumesFetching, type: "number", orderBy: ["totalSize"],
+                headerName: "Storage volume", field: "totalSize", disableSearch: true, disableSorting: true, type: "number", orderBy: ["totalSize"],
                 cellRenderer: (params: any) => {
-                    if (params.data.totalSize == null && this.isStudyVolumesFetching) {
+                    if (this.isStudyVolumesFetching) {
                         return "Fetching..."
                     }
                     return this.studyService.storageVolumePrettyPrint(params.data.totalSize);

--- a/shanoir-ng-front/src/app/studies/study-list/study-list.component.ts
+++ b/shanoir-ng-front/src/app/studies/study-list/study-list.component.ts
@@ -171,7 +171,7 @@ export class StudyListComponent extends BrowserPaginEntityListComponent<Study> {
             {
                 headerName: "Storage volume", field: "totalSize", disableSearch: true, disableSorting: this.isStudyVolumesFetching, type: "number", orderBy: ["totalSize"],
                 cellRenderer: (params: any) => {
-                    if (!params.data.totalSize && this.isStudyVolumesFetching) {
+                    if (params.data.totalSize != null && this.isStudyVolumesFetching) {
                         return "Fetching..."
                     }
                     return this.studyService.storageVolumePrettyPrint(params.data.totalSize);

--- a/shanoir-ng-front/src/app/studies/study/study.component.ts
+++ b/shanoir-ng-front/src/app/studies/study/study.component.ts
@@ -124,9 +124,10 @@ export class StudyComponent extends EntityComponent<Study> {
         this.studyRightsService.getMyRightsForStudy(this.id).then(rights => {
             this.hasDownloadRight = this.keycloakService.isUserAdmin() || rights.includes(StudyUserRight.CAN_DOWNLOAD);
         })
-        let studyPromise: Promise<Study> = this.studyService.get(this.id, true).then(study => {
+        let studyPromise: Promise<Study> = this.studyService.get(this.id).then(study => {
 
           this.study = study;
+          this.setLabeledSizes(this.study);
 
           if (study.profile == null) {
                 let pro = new Profile();
@@ -251,16 +252,18 @@ export class StudyComponent extends EntityComponent<Study> {
         return formGroup;
     }
 
-    private getLabeledSizes(id: number): Promise<Map<String, number>> {
-        let waitUploads: Promise<void> = this.studyService.fileUploadings.has(id)
-            ? this.studyService.fileUploadings.get(id)
+    private setLabeledSizes(study: Study): void {
+        let waitUploads: Promise<void> = this.studyService.fileUploadings.has(study.id)
+            ? this.studyService.fileUploadings.get(study.id)
             : Promise.resolve();
 
         this.uploading = true;
-        return waitUploads.then(() => {
-            return this.studyService.getStudyDetailedStorageVolume(id).then(dto => {
+        waitUploads.then(() => {
+            return this.studyService.getStudyDetailedStorageVolume(study.id).then(dto => {
 
                 let datasetSizes = dto;
+
+                study.totalSize = datasetSizes.total
                 let sizesByLabel = new Map<String, number>()
 
                 for(let sizeByFormat of datasetSizes.volumeByFormat){
@@ -274,9 +277,7 @@ export class StudyComponent extends EntityComponent<Study> {
                 }
 
                 let total = datasetSizes.total;
-                sizesByLabel.set("Total", total);
-
-                return sizesByLabel;
+                study.detailedSizes = sizesByLabel;
             });
         }).finally(() => {
             this.uploading = false;

--- a/shanoir-ng-front/src/app/studies/study/study.component.ts
+++ b/shanoir-ng-front/src/app/studies/study/study.component.ts
@@ -119,8 +119,6 @@ export class StudyComponent extends EntityComponent<Study> {
 
     initView(): Promise<void> {
 
-        console.log(this.breadcrumbsService.currentStep.entity);
-
         this.studyRightsService.getMyRightsForStudy(this.id).then(rights => {
             this.hasDownloadRight = this.keycloakService.isUserAdmin() || rights.includes(StudyUserRight.CAN_DOWNLOAD);
         })

--- a/shanoir-ng-front/src/app/studies/study/study.component.ts
+++ b/shanoir-ng-front/src/app/studies/study/study.component.ts
@@ -118,6 +118,9 @@ export class StudyComponent extends EntityComponent<Study> {
     }
 
     initView(): Promise<void> {
+
+        console.log(this.breadcrumbsService.currentStep.entity);
+
         this.studyRightsService.getMyRightsForStudy(this.id).then(rights => {
             this.hasDownloadRight = this.keycloakService.isUserAdmin() || rights.includes(StudyUserRight.CAN_DOWNLOAD);
         })
@@ -159,6 +162,7 @@ export class StudyComponent extends EntityComponent<Study> {
     }
 
     initEdit(): Promise<void> {
+
         let studyPromise: Promise<Study> = this.studyService.get(this.id, true).then(study => {
             this.study = study;
 

--- a/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/service/StudyServiceImpl.java
+++ b/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/service/StudyServiceImpl.java
@@ -705,26 +705,18 @@ public class StudyServiceImpl implements StudyService {
 	@Override
 	public Map<Long, StudyStorageVolumeDTO> getDetailedStorageVolumeByStudy(List<Long> studyIds) {
 
-		// DEBUG !!!
-		try {
-			Thread.sleep(10000);
-		} catch (InterruptedException e) {
-			throw new RuntimeException(e);
-		}
-
 		Map<Long, StudyStorageVolumeDTO> detailedStorageVolumes;
 		try {
 			String resultAsString = (String) this.rabbitTemplate.convertSendAndReceive(RabbitMQConfiguration.STUDY_DATASETS_TOTAL_STORAGE_VOLUME, studyIds);
 			if(resultAsString != null && !resultAsString.isEmpty()){
 				detailedStorageVolumes = objectMapper.readValue(resultAsString,  new TypeReference<HashMap<Long, StudyStorageVolumeDTO>>() {});
 			}else{
-				detailedStorageVolumes = new HashMap<>();
+				return new HashMap<>();
 			}
 		} catch (AmqpException | JsonProcessingException e) {
 			LOG.error("Error while fetching studies [{}] datasets volume storage details.", studyIds, e);
 			return null;
 		}
-
 
 		this.studyRepository.findAllById(studyIds).forEach( study -> {
 				if(!detailedStorageVolumes.containsKey(study.getId())){

--- a/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/service/StudyServiceImpl.java
+++ b/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/service/StudyServiceImpl.java
@@ -704,6 +704,14 @@ public class StudyServiceImpl implements StudyService {
 
 	@Override
 	public Map<Long, StudyStorageVolumeDTO> getDetailedStorageVolumeByStudy(List<Long> studyIds) {
+
+		// DEBUG !!!
+		try {
+			Thread.sleep(10000);
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+
 		Map<Long, StudyStorageVolumeDTO> detailedStorageVolumes;
 		try {
 			String resultAsString = (String) this.rabbitTemplate.convertSendAndReceive(RabbitMQConfiguration.STUDY_DATASETS_TOTAL_STORAGE_VOLUME, studyIds);

--- a/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/service/StudyServiceImpl.java
+++ b/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/service/StudyServiceImpl.java
@@ -727,6 +727,9 @@ public class StudyServiceImpl implements StudyService {
 
 
 		this.studyRepository.findAllById(studyIds).forEach( study -> {
+				if(!detailedStorageVolumes.containsKey(study.getId())){
+					return;
+				}
 				Long filesSize = this.getStudyFilesSize(study);
 				StudyStorageVolumeDTO dto = detailedStorageVolumes.get(study.getId());
 				dto.setExtraDataSize(filesSize + dto.getExtraDataSize());


### PR DESCRIPTION
In study list :
- Sorting by "storage volume" is now correct
- Sorting on "storage volume" is disabled while fetching
- ~Storage volumes are fetched only for studies loaded in the current page~ (not possible due to sorting)

Correct https://github.com/fli-iam/shanoir-ng/issues/1868

How to test :
- Display study list as admin (so all the studies will be loaded, it will take some time)
- Order by "storage volume", asc & desc (must be disabled while fetching)
- Display study details