### PR TITLE
[fli-iam#1866] Upload of VIP result data fail when content too long

### DIFF
--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/CarminDataApi.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/CarminDataApi.java
@@ -14,6 +14,7 @@
 
 package org.shanoir.ng.importer;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.shanoir.ng.importer.model.carmin.Path;
 import org.shanoir.ng.importer.model.carmin.UploadData;
 import org.shanoir.ng.shared.exception.RestServiceException;
@@ -41,12 +42,16 @@ public interface CarminDataApi {
 	@PreAuthorize("hasRole('ADMIN') or (hasAnyRole('EXPERT', 'USER'))")
 	ResponseEntity<Void> deletePath();
 
-	@Operation(summary = "Upload data to a path", description = "A request without content creates a directory (an error should be returned if the path already exists). A request with a specific content type (\"application/carmin+json\") allows to upload data encoded in base64. The base64 content (part of a json payload) can either be an encoded file, are an encoded zip archive that will create a directory. All other content (with any content type) will be considered as a raw file and will override the existing path content. If the parent directory of the file/directory to create does not exist, an error must be returned.")
+	@Operation(summary = "Upload data to a path", description = "A request without content creates a directory (an error should be returned if the path already exists). " +
+			"A request with a specific content type (\"application/carmin+json\") allows to upload data encoded in base64. " +
+			"The base64 content (part of a json payload) can either be an encoded file, or an encoded zip archive that will create a directory. " +
+			"All other content (with any content type) will be considered as a raw file and will override the existing path content. " +
+			"If the parent directory of the file/directory to create does not exist, an error must be returned.")
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "The upload is successful and finished."),
 			@ApiResponse(responseCode = "500", description = "A functional or internal error occured processing the request") })
 	@RequestMapping(value = "/**", produces = { "application/json" }, consumes = { "application/carmin+json",
 			"application/octet-stream" }, method = RequestMethod.PUT)
 	@PreAuthorize("hasRole('ADMIN') or (hasAnyRole('EXPERT', 'USER'))")
-	ResponseEntity<Path> uploadPath(@Valid @RequestBody UploadData body) throws RestServiceException;
+	ResponseEntity<Path> uploadPath(@Valid @RequestBody String body) throws RestServiceException, JsonProcessingException;
 
 }

--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/CarminDataApiController.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/CarminDataApiController.java
@@ -19,6 +19,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Date;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 
@@ -69,8 +74,15 @@ public class CarminDataApiController implements CarminDataApi {
 
     @Override
     public ResponseEntity<Path> uploadPath(
-            @Parameter(name = "") @Valid @RequestBody UploadData body)
-            throws RestServiceException {
+            @Parameter(name = "") @Valid @RequestBody String body)
+            throws RestServiceException, JsonProcessingException {
+
+        JsonFactory jsonFactory = JsonFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build())
+                        .build();
+
+        ObjectMapper objectMapper = JsonMapper.builder(jsonFactory).build();
+        UploadData received = objectMapper.readValue(body, UploadData.class);
 
         String importPath = getImportPathFromRequest(httpServletRequest);
 
@@ -85,7 +97,7 @@ public class CarminDataApiController implements CarminDataApi {
                 resultDir.mkdirs();
             }
 
-            byte[] bytes = Base64.decodeBase64(body.getBase64Content());
+            byte[] bytes = Base64.decodeBase64(received.getBase64Content());
             FileUtils.writeByteArrayToFile(resultFile, bytes);
 
             path.setPlatformPath(resultDir.getAbsolutePath());


### PR DESCRIPTION
How to test :
Send a big examination (grouped by examination) through the `test-shanoir/0.1` VIP pipeline

![image](https://github.com/fli-iam/shanoir-ng/assets/59697998/9486f56a-28df-4e46-b65a-89bf80151af6)


The creation of the processed dataset should not fail.