### PR TITLE
#1896 dua corrections

### DIFF
--- a/docker-compose/keycloak/cfg/shanoir-ng-realm.json
+++ b/docker-compose/keycloak/cfg/shanoir-ng-realm.json
@@ -449,25 +449,6 @@
   "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
   "webAuthnPolicyPasswordlessAcceptableAaguids": [],
   "users": [
-    {
-      "id": "ab27195e-089f-425b-b7f6-b3c68eec6b3f",
-      "username": "service-account-service-account",
-      "enabled": true,
-      "totp": false,
-      "emailVerified": true,
-      "firstName": "",
-      "lastName": "",
-      "email": "SHANOIR_ADMIN_EMAIL",
-      "serviceAccountClientId": "service-account",
-      "disableableCredentialTypes": [],
-      "requiredActions": [],
-      "realmRoles": [
-        "SERVICE",
-        "default-roles-shanoir-ng"
-      ],
-      "notBefore": 0,
-      "groups": []
-    }
   ],
   "scopeMappings": [
     {

--- a/shanoir-ng-front/src/app/shared/side-menu/side-menu.component.ts
+++ b/shanoir-ng-front/src/app/shared/side-menu/side-menu.component.ts
@@ -62,7 +62,11 @@ export class SideMenuComponent {
         else this.state = new SideMenuState();
 
         this.userService.accessRequets.subscribe(nb => {
-            this.accessRequestsToValidate = nb;
+            if (nb) {
+                this.accessRequestsToValidate = nb;
+            } else {
+                this.accessRequestsToValidate = 0;
+            }
         });
     }
 

--- a/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/controler/StudyApi.java
+++ b/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/controler/StudyApi.java
@@ -300,19 +300,6 @@ public interface StudyApi {
 			@Parameter(name = "id of the study", required = true) @PathVariable("studyId") Long studyId,
 			@Parameter(name = "file to download", required = true) @PathVariable("fileName") String fileName, HttpServletResponse response) throws RestServiceException, IOException;
 
-	@Operation(summary = "", description = "Deletes the DUA of a study")
-	@ApiResponses(value = { @ApiResponse(responseCode = "204", description = "dua deleted"),
-			@ApiResponse(responseCode = "401", description = "unauthorized"),
-			@ApiResponse(responseCode = "403", description = "forbidden"),
-			@ApiResponse(responseCode = "404", description = "no study found"),
-			@ApiResponse(responseCode = "500", description = "unexpected error") })
-	@RequestMapping(value = "dua-delete/{studyId}", produces = {
-			"application/json" }, method = RequestMethod.DELETE)
-	@PreAuthorize("hasAnyRole('ADMIN', 'EXPERT') and @studySecurityService.hasRightOnStudy(#studyId, 'CAN_ADMINISTRATE')")
-	ResponseEntity<Void> deleteDataUserAgreement(
-			@Parameter(name = "id of the study", required = true) @PathVariable("studyId") Long studyId)
-			throws IOException;
-
 	@Operation(summary = "", description = "Deletes the user of a study")
 	@ApiResponses(value = { @ApiResponse(responseCode = " 204", description = "user removed from study"),
 			@ApiResponse(responseCode = " 401", description = "unauthorized"),

--- a/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/controler/StudyApiController.java
+++ b/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/controler/StudyApiController.java
@@ -21,11 +21,16 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
+import org.joda.time.format.DateTimeFormat;
 import org.shanoir.ng.shared.core.model.IdName;
 import org.shanoir.ng.shared.error.FieldErrorMap;
 import org.shanoir.ng.shared.event.ShanoirEvent;
@@ -60,6 +65,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.util.CollectionUtils;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -72,6 +78,8 @@ import jakarta.validation.Valid;
 
 @Controller
 public class StudyApiController implements StudyApi {
+
+	private static final String PDF_EXTENSION = ".pdf";
 
 	@Value("${studies-data}")
 	private String dataDir;
@@ -116,6 +124,11 @@ public class StudyApiController implements StudyApi {
 			if (study.getExaminations() != null && !study.getExaminations().isEmpty()) {
 				// Error => should not be able to do this see #793
 				return new ResponseEntity<>(HttpStatus.UNPROCESSABLE_ENTITY);
+			}
+			
+			List<DataUserAgreement> duas = dataUserAgreementService.findDUAByStudyId(studyId);
+			if (!CollectionUtils.isEmpty(duas)) {
+				this.dataUserAgreementService.deleteAll(duas);
 			}
 
 			// Delete all linked files and DUA
@@ -370,24 +383,22 @@ public class StudyApiController implements StudyApi {
 			@Parameter(name = "id of the study", required = true) @PathVariable("studyId") Long studyId,
 			@Parameter(name = "dua to upload", required = true) @Valid @RequestBody MultipartFile file) throws RestServiceException {
 		try {
-			if (!file.getOriginalFilename().endsWith(".pdf")  || file.getSize() > 50000000) {
+			if (!file.getOriginalFilename().endsWith(PDF_EXTENSION)  || file.getSize() > 50000000) {
 				LOG.error("Could not upload the file: {}", file.getOriginalFilename());
-				// Clean up: delete from study in case of same file existed before and upload not allowed
+				// Clean up: delete from study in case upload not allowed
 				Study study = studyService.findById(studyId);
-				if (study.getDataUserAgreementPaths() != null) {
+				if (!CollectionUtils.isEmpty(study.getDataUserAgreementPaths())) {
 					study.getDataUserAgreementPaths().remove(file.getName());
 				}
 				studyService.update(study);
 				return new ResponseEntity<>(HttpStatus.NOT_ACCEPTABLE);
 			}
-			String parentDir = dataDir + "/study-" + studyId;
-			Path path = Paths.get( parentDir);
-			Files.createDirectories(path);
-			LOG.info("path: {}", path.getFileName());
-			Path newFilePath = Paths.get(parentDir + "/" + file.getOriginalFilename());
-			Files.createFile(newFilePath);
-			LOG.info("newFilePath: {}", newFilePath.getFileName());
-			file.transferTo(newFilePath);
+			String duaFilePath = this.studyService.getStudyFilePath(studyId, file.getOriginalFilename());
+
+			Path duaPath = Paths.get(duaFilePath);
+			Files.createDirectories(duaPath.getParent());
+			Files.createFile(duaPath);
+			file.transferTo(duaPath);
 		} catch (Exception e) {
 			LOG.error("Error while loading files on study: {}. File not uploaded. {}", studyId, e);
 		}
@@ -411,23 +422,6 @@ public class StudyApiController implements StudyApi {
 			org.apache.commons.io.IOUtils.copy(is, response.getOutputStream());
 			response.flushBuffer();
 		}
-	}
-
-	@Override
-	public ResponseEntity<Void> deleteDataUserAgreement (
-			@Parameter(name = "id of the study", required = true) @PathVariable("studyId") Long studyId) throws IOException {
-		Study study = studyService.findById(studyId);
-
-		if (study.getDataUserAgreementPaths() == null || study.getDataUserAgreementPaths().isEmpty()) {
-			return new ResponseEntity<>(HttpStatus.NO_CONTENT);
-		}
-		String filePath = studyService.getStudyFilePath(studyId, study.getDataUserAgreementPaths().get(0));
-		File fileToDelete = new File(filePath);
-		if (!fileToDelete.exists()) {
-			return new ResponseEntity<>(HttpStatus.NO_CONTENT);
-		}
-		Files.delete(Paths.get(filePath));
-		return new ResponseEntity<>(HttpStatus.OK);
 	}
 
 	@Override

--- a/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/dua/DataUserAgreement.java
+++ b/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/dua/DataUserAgreement.java
@@ -72,7 +72,10 @@ public class DataUserAgreement extends AbstractEntity {
 	
 	@JsonProperty("path")
 	public String getPath() {
-		return this.study.getDataUserAgreementPaths().get(0);
+		if (this.study.getDataUserAgreementPaths() != null && !this.study.getDataUserAgreementPaths().isEmpty()) {
+			return this.study.getDataUserAgreementPaths().get(0);
+		}
+		return null;
 	}
 
 	@JsonProperty("studyName")

--- a/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/dua/DataUserAgreementRepository.java
+++ b/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/dua/DataUserAgreementRepository.java
@@ -23,5 +23,7 @@ public interface DataUserAgreementRepository extends CrudRepository<DataUserAgre
 	List<DataUserAgreement> findByUserIdAndTimestampOfAcceptedIsNull(Long userId);
 
 	DataUserAgreement findByUserIdAndStudy_IdAndTimestampOfAcceptedIsNull(Long userId, Long studyId);
+	
+	List<DataUserAgreement> findByStudyId(Long studyId);
 
 }

--- a/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/dua/DataUserAgreementService.java
+++ b/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/dua/DataUserAgreementService.java
@@ -73,11 +73,11 @@ public class DataUserAgreementService {
 		}
 	}
 	
-	public void createDataUserAgreementForUserInStudy(Study study, Long userId) {
+	public DataUserAgreement createDataUserAgreementForUserInStudy(Study study, Long userId) {
 		DataUserAgreement dataUserAgreement = new DataUserAgreement();
 		dataUserAgreement.setStudy(study);
 		dataUserAgreement.setUserId(userId);
-		repository.save(dataUserAgreement);
+		return repository.save(dataUserAgreement);
 	}
 	
 	public void deleteIncompleteDataUserAgreementForUserInStudy(Study study, Long userId) {
@@ -87,7 +87,20 @@ public class DataUserAgreementService {
 		}
 	}
 
+	public List<DataUserAgreement> findDUAByStudyId(Long studyId) {
+		return repository.findByStudyId(studyId);
+	}
+
 	public DataUserAgreement findDUAByUserIdAndStudyId(Long userId, Long studyId) {
 		return repository.findByUserIdAndStudy_IdAndTimestampOfAcceptedIsNull(userId, studyId);
 	}
+
+	public void deleteAll(Iterable<DataUserAgreement> duas) {
+		this.repository.deleteAll(duas);
+	}
+
+	public void update(DataUserAgreement dua) {
+		this.repository.save(dua);
+	}
+
 }

--- a/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/service/StudyServiceImpl.java
+++ b/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/service/StudyServiceImpl.java
@@ -15,6 +15,7 @@
 package org.shanoir.ng.study.service;
 
 import java.io.File;
+import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -32,6 +33,7 @@ import org.shanoir.ng.shared.security.rights.StudyUserRight;
 import org.shanoir.ng.study.dto.StudyDTO;
 import org.shanoir.ng.study.dto.StudyStorageVolumeDTO;
 import org.shanoir.ng.study.dto.mapper.StudyMapper;
+import org.shanoir.ng.study.dua.DataUserAgreement;
 import org.shanoir.ng.study.dua.DataUserAgreementService;
 import org.shanoir.ng.study.model.Study;
 import org.shanoir.ng.study.model.StudyUser;
@@ -58,7 +60,10 @@ import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -457,6 +462,12 @@ public class StudyServiceImpl implements StudyService {
 		for (StudyUser su : studyDb.getStudyUserList()) {
 			existing.put(su.getId(), su);
 		}
+		
+		boolean addNewDua = CollectionUtils.isEmpty(studyDb.getDataUserAgreementPaths()) && !CollectionUtils.isEmpty(study.getDataUserAgreementPaths());
+		boolean deleteDua = !CollectionUtils.isEmpty(studyDb.getDataUserAgreementPaths()) && CollectionUtils.isEmpty(study.getDataUserAgreementPaths());
+		boolean updateDua = !CollectionUtils.isEmpty(studyDb.getDataUserAgreementPaths()) 
+						 && !CollectionUtils.isEmpty(study.getDataUserAgreementPaths())
+						 && !study.getDataUserAgreementPaths().get(0).equals(studyDb.getDataUserAgreementPaths().get(0));
 
 		Map<Long, StudyUser> replacing = new HashMap<>();
 		for (StudyUser su : study.getStudyUserList()) {
@@ -464,24 +475,27 @@ public class StudyServiceImpl implements StudyService {
 				toBeCreated.add(su);
 			} else {
 				replacing.put(su.getId(), su);
-				if (study.getDataUserAgreementPaths() != null && !study.getDataUserAgreementPaths().isEmpty()) {
-					// new DUA added to study
-					if (studyDb.getDataUserAgreementPaths() == null || studyDb.getDataUserAgreementPaths().isEmpty()) {
-						su.setConfirmed(false);
-						dataUserAgreementService.createDataUserAgreementForUserInStudy(studyDb, su.getUserId());
-					}
+				if (addNewDua || updateDua) {
+					// new / updated DUA added to study
+					su.setConfirmed(false);
+					// Remove current unfinished signing
+					dataUserAgreementService.deleteIncompleteDataUserAgreementForUserInStudy(studyDb, su.getUserId());
+					// Create a new dataset user agreement
+					DataUserAgreement duaSigning = dataUserAgreementService.createDataUserAgreementForUserInStudy(studyDb, su.getUserId());
 					// The user that creates a study is confirmed (he's the one uploading the DUA, he doesn't have to sign it)
 					if (KeycloakUtil.getTokenUserId().equals(su.getUserId())) {
 						su.setConfirmed(true);
+						duaSigning.setTimestampOfAccepted(new Date());
+						dataUserAgreementService.update(duaSigning);
 					}
-				} else {
+					this.archiveDuaFile(studyDb);
+				} else if (deleteDua){
 					// existing DUA removed from study
-					if (studyDb.getDataUserAgreementPaths() != null && !studyDb.getDataUserAgreementPaths().isEmpty()) {
-						su.setConfirmed(true); // without DUA all StudyUser are confirmed, set back to true, if false
-						// before
-						dataUserAgreementService.deleteIncompleteDataUserAgreementForUserInStudy(studyDb,
-								su.getUserId());
-					}
+					this.archiveDuaFile(studyDb);
+
+					su.setConfirmed(true);
+					// without DUA all StudyUser are confirmed, set back to true, if false before
+					dataUserAgreementService.deleteIncompleteDataUserAgreementForUserInStudy(studyDb, su.getUserId());
 				}
 			}
 		}
@@ -555,9 +569,19 @@ public class StudyServiceImpl implements StudyService {
 
 		// Use updated study "study" to decide, to send email to which user
 		sendStudyUserReport(study, created);
-
 	}
 
+	private void archiveDuaFile(Study study) {
+		if (CollectionUtils.isEmpty(study.getDataUserAgreementPaths())) {
+			return;
+		}
+		// Archive old DUA -> Rename it with deletion date
+		SimpleDateFormat formatter = new SimpleDateFormat("yyyymmddHHMM");
+		File deletedFile = new File(this.getStudyFilePath(study.getId(), study.getDataUserAgreementPaths().get(0)));
+		File archiveFile = new File(this.getStudyFilePath(study.getId(), "archive_" + formatter.format(new Date()) + "_" + study.getDataUserAgreementPaths().get(0)));
+		deletedFile.renameTo(archiveFile);
+	}
+	
 	private void sendStudyUserReport(Study study, List<StudyUser> created) {
 		// Get all recipients
 		List<Long> recipients = new ArrayList<Long>();


### PR DESCRIPTION
- Allow study deletion with a DUA
- Archive existing DUAs
- Keep trace of DUA signing
- Re-ask DUA signing when updating DUA
- Show notifications correctly

Closes #1897
Closes #1896 
Closes #1873 
Closes #1764 

How to test:
- Create a new study as expert
- Add another user (not admin)
--> The user has access to the study
- Add a DUA to this study
--> The other has no access anymore, but has a notif to sign it
- Sign the DUA as the other user
--> The user has access to the study
- Update this DUA 
--> The other has no access anymore, but has a notif to sign it
- Delete the DUA
--> The user has access to the study

The check in microservice
- DB -> We kept the trace of every user signing
- /var/studies-data/study-XX -> We archived all the DUAs
