### PR TITLE
Fix some small issues on dataset view

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/service/DatasetServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/service/DatasetServiceImpl.java
@@ -185,7 +185,7 @@ public class DatasetServiceImpl implements DatasetService {
 		datasetDb.setId(dataset.getId());
 		datasetDb.setProcessings(dataset.getProcessings());
 		datasetDb.setSubjectId(dataset.getSubjectId());
-		if (dataset.getOriginMetadata().getId().equals(dataset.getUpdatedMetadata().getId())) {
+		if (dataset.getUpdatedMetadata().getId().equals(dataset.getOriginMetadata().getId())) {
 			// Force creation of a new dataset metadata
 			dataset.getUpdatedMetadata().setId(null);
 		}

--- a/shanoir-ng-front/src/app/datasets/dataset/common/dataset.common.component.html
+++ b/shanoir-ng-front/src/app/datasets/dataset/common/dataset.common.component.html
@@ -52,21 +52,15 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
         </li>
 		<li>
 			<label i18n="Dataset detail|Dataset subject@@datasetDetailSubject">Subject</label>
-			<span class="right-col" [ngSwitch]="mode">
-				<ng-template [ngSwitchCase]="'view'">
+			<span class="right-col">
 				<a [routerLink]="[getSubjectLink()]">
 					{{dataset.subject?.name}}
 				</a>
-				</ng-template>
-				<ng-template ngSwitchDefault>
-					<select-box [(ngModel)]="dataset.subject" formControlName="subject" [optionArr]="subjects">
-					</select-box>
-				</ng-template>
 			</span>
 		</li>
 		<li>
 			<label i18n="Dataset detail|Dataset study@@datasetDetailStudy">Study</label>
-			<span class="right-col" [ngSwitch]="mode">
+			<span class="right-col">
 				<a [routerLink]="['/study/details/', dataset.study?.id]">
 					{{dataset.study?.name}}
 				</a>
@@ -83,14 +77,8 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 		</li>
 		<li>
 			<label i18n="Dataset detail|Dataset type@@datasetDetailType">Modality type</label>
-			<span class="right-col" [ngSwitch]="mode">
-				<ng-template [ngSwitchCase]="'view'">
+			<span class="right-col">
 					{{dataset.type}}
-				</ng-template>
-				<ng-template ngSwitchDefault>
-					<select-box [ngModelOptions]="{standalone: true}" [(ngModel)]="dataset.type" [options]="datasetTypes">
-					</select-box>
-				</ng-template>
 			</span>
 		</li>
 	</ol>
@@ -128,7 +116,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 		<li>
 			<label i18n="Dataset detail|Dataset explored entity type@@datasetExploredEntity">Explored entity</label>
 			<span class="right-col" [ngSwitch]="mode">
-				<ng-template [ngSwitchCase]="'view'">{{dataset.updatedMetadata.exploredEntity? dataset.updatedMetadata.exploredEntity : dataset.originMetadata.exploredEntity}}</ng-template>
+				<ng-template [ngSwitchCase]="'view'">{{ExploredEntity.getLabel(dataset.updatedMetadata.exploredEntity? dataset.updatedMetadata.exploredEntity : dataset.originMetadata.exploredEntity)}}</ng-template>
 				<ng-template ngSwitchDefault>
 					<select-box
 							[ngModel]="dataset.updatedMetadata.exploredEntity ? dataset.updatedMetadata.exploredEntity : dataset.originMetadata.exploredEntity"
@@ -141,9 +129,9 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 			</span>
 		</li>
 		<li>
-			<label i18n="Dataset detail|Dataset cardinality of releted subjects@@datasetCardinalityOfRelatedSubjects">Cardinality of releted subjects</label>
+			<label i18n="Dataset detail|Dataset cardinality of related subjects@@datasetCardinalityOfRelatedSubjects">Cardinality of related subjects</label>
 			<span class="right-col" [ngSwitch]="mode">
-				<ng-template [ngSwitchCase]="'view'">{{dataset.updatedMetadata.cardinalityOfRelatedSubjects ? dataset.updatedMetadata.cardinalityOfRelatedSubjects : dataset.originMetadata.cardinalityOfRelatedSubjects}}</ng-template>
+				<ng-template [ngSwitchCase]="'view'">{{ CardinalityOfRelatedSubjects.getLabel(dataset.updatedMetadata.cardinalityOfRelatedSubjects ? dataset.updatedMetadata.cardinalityOfRelatedSubjects : dataset.originMetadata.cardinalityOfRelatedSubjects)}}</ng-template>
 				<ng-template ngSwitchDefault>
 					<input type="radio" name="card" id="card_single"
 						[ngModel]="dataset.updatedMetadata.cardinalityOfRelatedSubjects ? dataset.updatedMetadata.cardinalityOfRelatedSubjects : dataset.originMetadata.cardinalityOfRelatedSubjects"
@@ -163,7 +151,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 		<li>
 			<label i18n="Dataset detail|Dataset processed type subjects@@datasetProcessedType">Processed Type</label>
 			<span class="right-col" [ngSwitch]="mode">
-				<ng-template [ngSwitchCase]="'view'">{{dataset.updatedMetadata.processedDatasetType? dataset.updatedMetadata.processedDatasetType : dataset.originMetadata.processedDatasetType}}</ng-template>
+				<ng-template [ngSwitchCase]="'view'">{{ ProcessedDatasetType.getLabel(dataset.updatedMetadata.processedDatasetType? dataset.updatedMetadata.processedDatasetType : dataset.originMetadata.processedDatasetType)}}</ng-template>
 				<ng-template ngSwitchDefault>
 					<select-box
 							[ngModel]="dataset.updatedMetadata.processedDatasetType ? dataset.updatedMetadata.processedDatasetType : dataset.originMetadata.processedDatasetType"

--- a/shanoir-ng-front/src/app/datasets/dataset/common/dataset.common.component.ts
+++ b/shanoir-ng-front/src/app/datasets/dataset/common/dataset.common.component.ts
@@ -27,6 +27,7 @@ import { DatasetModalityType } from '../../../enum/dataset-modality-type.enum';
 import { DatasetProcessingType } from '../../../enum/dataset-processing-type.enum';
 import { ProcessedDatasetType } from '../../../enum/processed-dataset-type.enum';
 import { DatasetType } from '../../shared/dataset-type.model';
+import {CardinalityOfRelatedSubjects} from "../../../enum/cardinality-of-related-subjects.enum";
 
 @Component({
     selector: 'common-dataset-details',
@@ -43,6 +44,10 @@ export class CommonDatasetComponent implements OnChanges {
     exploredEntityOptions: Option<ExploredEntity>[];
     datasetTypes: Option<DatasetType>[];
     processedDatasetTypeOptions: Option<ProcessedDatasetType>[];
+    CardinalityOfRelatedSubjects = CardinalityOfRelatedSubjects;
+    ExploredEntity = ExploredEntity;
+    ProcessedDatasetType = ProcessedDatasetType;
+
 
     constructor(
             private studyService: StudyService,

--- a/shanoir-ng-front/src/app/datasets/dataset/dataset.component.ts
+++ b/shanoir-ng-front/src/app/datasets/dataset/dataset.component.ts
@@ -2,12 +2,12 @@
  * Shanoir NG - Import, manage and share neuroimaging data
  * Copyright (C) 2009-2019 Inria - https://www.inria.fr/
  * Contact us on https://project.inria.fr/shanoir/
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
  */
@@ -128,7 +128,7 @@ export class DatasetComponent extends EntityComponent<Dataset> {
     convertNiftiToggle() {
         this.toggleMenu();
     }
-    
+
     convertNifti(id: number) {
         this.downloadState.status = TaskStatus.IN_PROGRESS;
         this.datasetService.download(this.dataset, 'nii', id).then(() => this.downloadState.status = TaskStatus.IN_PROGRESS);
@@ -186,5 +186,9 @@ export class DatasetComponent extends EntityComponent<Dataset> {
 
     seeDicomMetadata() {
         this.router.navigate(['/dataset/details/dicom/' + this.dataset.id]);
+    }
+
+    goToList(): void {
+        this.router.navigate(['/solr-search']);
     }
 }


### PR DESCRIPTION
- [fli-iam/shanoir-ng/issues/1921] After deleting a dataset, the user is now redirected to https://shanoir-qualif.irisa.fr/shanoir-ng/solr-search

- [fli-iam/shanoir-ng/issues/1918] `Explored entity`, `Cardinality of relAted subjects`, `Processed Type` fields are now displayed in lower case & capitals in dataset view mode

- [fli-iam/shanoir-ng/issues/1917] User now cannot change the modality of a dataset in edit mode

-  [fli-iam/shanoir-ng/issues/1916] User now cannot change the subject of a dataset in edit mode
