### PR TITLE
#1922-acquisition-deletion

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/service/DatasetServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/service/DatasetServiceImpl.java
@@ -93,9 +93,9 @@ public class DatasetServiceImpl implements DatasetService {
 		if (datasetDb == null) {
 			throw new EntityNotFoundException(Dataset.class, id);
 		}
-		repository.deleteById(id);
 		solrService.deleteFromIndex(id);
 		this.deleteDatasetFromPacs(datasetDb);
+		repository.deleteById(id);
 		shanoirEventService.publishEvent(new ShanoirEvent(ShanoirEventType.DELETE_DATASET_EVENT, id.toString(), KeycloakUtil.getTokenUserId(), "", ShanoirEvent.SUCCESS, datasetDb.getStudyId()));
 	}
 

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dicom/web/service/DICOMWebService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dicom/web/service/DICOMWebService.java
@@ -295,7 +295,7 @@ public class DICOMWebService {
 		HttpPost post = new HttpPost(rejectURL);
 		post.setHeader(HttpHeaders.CONTENT_TYPE, CONTENT_TYPE_JSON);
 		try (CloseableHttpResponse response = httpClient.execute(post)) {
-			if (response.getCode() == HttpStatus.NO_CONTENT.value()) {
+			if (HttpStatus.OK.value() == response.getCode()) {
 				LOG.info("Rejected from PACS: " + url);
 			} else {
 				LOG.error(response.getCode() + ": Could not reject instance from PACS: " + response.getReasonPhrase()
@@ -304,8 +304,8 @@ public class DICOMWebService {
 				+ "for rejectURL: " + rejectURL);
 			}
 		} catch (IOException e) {
-			LOG.error(e.getMessage(), e);
-			throw new ShanoirException(e.getMessage());
+			LOG.error("Could not reject instance from PACS: for rejectURL: " + rejectURL, e);
+			throw new ShanoirException("Could not reject instance from PACS: for rejectURL: " + url, e);
 		}
 		// STEP 2: Delete from the PACS
 		HttpDelete delete = new HttpDelete(deleteUrl);


### PR DESCRIPTION
- Allow deletion of acquisition
- Allow deletion of dataset correctly
Closes #1922 

How to test:
- Select acquisition with MR data
- Delete acquisition
- Acquisition was well deleted
--> You can check on pacs (either try to retrieve dicom from qualif with dataset_file path or locally on PACS interface)

- delete a dataset
--> You can check on pacs (either try to retrieve dicom from qualif with dataset_file path or locally on PACS interface)

local pacs: http://localhost:8081/dcm4chee-arc/ui2/study/study
Otherwise, CURL from dataset microservice (if possible)
