### PR TITLE
[CI] Push docker image with version in tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ name: Publish Docker images
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ghcr.io/${{ github.repository }}
-  TAG: ${{ github.ref }}
+  TAG: ${{ github.ref_name }}
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ name: Publish Docker images
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ghcr.io/${{ github.repository }}
-  TAG: ${{ github.ref }}
+  TAG: v1.0
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Publish Docker images
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: $REGISTRY/${{ github.repository }}
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
   TAG: ${{ github.ref }}
 on:
   workflow_dispatch:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,15 +3,15 @@ name: Publish Docker images
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ env.REGISTRY }}/${{ github.repository }}
+  IMAGE_NAME: ${{ REGISTRY }}/${{ github.repository }}
   TAG: ${{ github.ref }}
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'master'
     tags:
       - 'v*'
-  workflow_dispatch:
   
 jobs:
   push_to_registry:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ name: Publish Docker images
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ghcr.io/${{ github.repository }}
-  TAG: v1.0
+  TAG: ${{ github.ref }}
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Publish Docker images
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ REGISTRY }}/${{ github.repository }}
+  IMAGE_NAME: $REGISTRY/${{ github.repository }}
   TAG: ${{ github.ref }}
 on:
   workflow_dispatch:


### PR DESCRIPTION
Hi @michaelkain,

I've been able to successfully manually run this workflow on my fork (https://github.com/youennmerel/shanoir-ng) by putting mock value (`v1.0`) in the $TAG env variable.

This seems to (finally) work fine :
> ![image](https://github.com/fli-iam/shanoir-ng/assets/59697998/95cf3fc7-55c7-4ce5-aba0-ab206c9e38fc)

> ![image](https://github.com/fli-iam/shanoir-ng/assets/59697998/88d4ea47-2bef-43c4-8d70-5ea61596dde4)

The only uncertainty now is that `${{ github.ref }}` will give us the right $TAG value on triggered run, but it seems to be clearly the good variable to use : https://github.com/orgs/community/discussions/26686#discussioncomment-3396593


