### PR TITLE
[CI] Docker push : change trigger condition

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,10 +8,8 @@ env:
 on:
   workflow_dispatch:
   push:
-    branches:
-      - 'master'
     tags:
-      - 'v*'
+      - '*'
   
 jobs:
   push_to_registry:


### PR DESCRIPTION
Hi @michaelkain,

So sorry, but i had a doubt about the trigger condition for the docker workflow :
- This mean that the workflow will be also be triggered when pushing on master, so this will create a docker tag `master` :
```
branches:
      - 'master'
```
I've removed this condition to keep only the `tags` one.

- This regex won't work with `NG_vx.x.x` tags
```
     tags:
      - 'v*'
```
