### PR TITLE
remove deprecated column

### DIFF
--- a/docker-compose/database/db-changes/datasets/0037_remove_deprecated_column.sql
+++ b/docker-compose/database/db-changes/datasets/0037_remove_deprecated_column.sql
@@ -1,0 +1,4 @@
+-- the rule_id column has been replaced by a join table and all associations has already been copied in it
+-- see docker-compose/database/db-changes/datasets/0023_quality_control_modify_study_cards.sql
+alter table study_card_condition drop foreign key FKpi8v33fmd0wn64e06q8it8pkv;
+alter table study_card_condition drop column rule_id;


### PR DESCRIPTION
This column is deprecated and only leads to confusion.
It was removed by this script : docker-compose/database/db-changes/datasets/0023_quality_control_modify_study_cards.sql