### PR TITLE
output keycloak logs to an external volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
       - SHANOIR_KEYCLOAK_PASSWORD
       - SHANOIR_ALLOWED_ADMIN_IPS
     build: ./docker-compose/keycloak
+    volumes:
+      - "keycloak-logs:/opt/keycloak/data/log"
     networks:
       - shanoir_ng_network
     ports:
@@ -353,6 +355,7 @@ volumes:
   certificate-share-data:
   tmp:
   logs:
+  keycloak-logs:
 
 networks:
   shanoir_ng_network:

--- a/docker-compose/keycloak/Dockerfile
+++ b/docker-compose/keycloak/Dockerfile
@@ -23,6 +23,7 @@ FROM quay.io/keycloak/keycloak:20.0.0 as base_image
 #
 # All other variables are set in the entrypoint.
 ENV KC_DB="mysql" \
+    KC_LOG="console,file" \
     KC_HTTP_RELATIVE_PATH="/auth"
 
 #
@@ -43,6 +44,7 @@ FROM base_image
 COPY --from=builder /opt/keycloak/ /opt/keycloak/
 COPY --chown=keycloak themes/. /opt/keycloak/themes
 COPY cfg/. /opt/keycloak/
+RUN  mkdir /opt/keycloak/data/log
 
 COPY entrypoint entrypoint_common oneshot /bin/
 


### PR DESCRIPTION
This is just to match the configuration we have in production. Especially we need to set the KC_LOG env variable at build time so that quarkus is not rebuilt at every startup
(see commit 98c52cc04bfe71b2da60b520df89c8a1b3a41590)