### PR TITLE
Correct swagger UI

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/controler/DatasetApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/controler/DatasetApiController.java
@@ -560,7 +560,7 @@ public class DatasetApiController implements DatasetApi {
 			) throws RestServiceException, IOException {
 		String tmpDir = System.getProperty(JAVA_IO_TMPDIR);
 		File userDir = DatasetFileUtils.getUserImportDir(tmpDir);
-		File statisticsFile = recreateFile(userDir + File.separator + "shanoirExportStatistics.txt");
+		File statisticsFile = recreateFile(userDir + File.separator + "shanoirExportStatistics.tsv");
 		File zipFile = recreateFile(userDir + File.separator + "shanoirExportStatistics" + ZIP);
 
 		// Get the data

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/controler/DatasetApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/controler/DatasetApiController.java
@@ -560,7 +560,7 @@ public class DatasetApiController implements DatasetApi {
 			) throws RestServiceException, IOException {
 		String tmpDir = System.getProperty(JAVA_IO_TMPDIR);
 		File userDir = DatasetFileUtils.getUserImportDir(tmpDir);
-		File statisticsFile = recreateFile(userDir + File.separator + "shanoirExportStatistics.tsv");
+		File statisticsFile = recreateFile(userDir + File.separator + "shanoirExportStatistics.txt");
 		File zipFile = recreateFile(userDir + File.separator + "shanoirExportStatistics" + ZIP);
 
 		// Get the data

--- a/shanoir-ng-datasets/src/main/resources/application.yml
+++ b/shanoir-ng-datasets/src/main/resources/application.yml
@@ -77,10 +77,13 @@ spring:
 
 springdoc:
   api-docs:
-    path: /api-docs
-  swagger-ui:
-    path: /swagger-ui.html
+    path: '/api-docs'
     enabled: true
+  swagger-ui:
+    url: /shanoir-ng/datasets/api-docs
+    config-url: /shanoir-ng/datasets/api-docs/swagger-config
+    enabled: true
+    disable-swagger-default-url: true
 
 front.server:
   address: ${SHANOIR_URL_SCHEME}://${SHANOIR_URL_HOST}/shanoir-ng/

--- a/shanoir-ng-import/src/main/resources/application.yml
+++ b/shanoir-ng-import/src/main/resources/application.yml
@@ -75,10 +75,13 @@ spring:
 
 springdoc:
   api-docs:
-    path: /api-docs
-  swagger-ui:
-    path: /swagger-ui.html
+    path: '/api-docs'
     enabled: true
+  swagger-ui:
+    url: /shanoir-ng/import/api-docs
+    config-url: /shanoir-ng/import/api-docs/swagger-config
+    enabled: true
+    disable-swagger-default-url: true
 
 front.server:
   address: ${SHANOIR_URL_SCHEME}://${SHANOIR_URL_HOST}/shanoir-ng/

--- a/shanoir-ng-preclinical/src/main/resources/application.yml
+++ b/shanoir-ng-preclinical/src/main/resources/application.yml
@@ -76,8 +76,8 @@ springdoc:
     path: '/api-docs'
     enabled: true
   swagger-ui:
-    url: /shanoir-ng/studies/api-docs
-    config-url: /shanoir-ng/studies/api-docs/swagger-config
+    url: /shanoir-ng/preclinical/api-docs
+    config-url: /shanoir-ng/preclinical/api-docs/swagger-config
     enabled: true
     disable-swagger-default-url: true
 

--- a/shanoir-ng-preclinical/src/main/resources/application.yml
+++ b/shanoir-ng-preclinical/src/main/resources/application.yml
@@ -73,10 +73,13 @@ spring:
 
 springdoc:
   api-docs:
-    path: /api-docs
-  swagger-ui:
-    path: /swagger-ui.html
+    path: '/api-docs'
     enabled: true
+  swagger-ui:
+    url: /shanoir-ng/studies/api-docs
+    config-url: /shanoir-ng/studies/api-docs/swagger-config
+    enabled: true
+    disable-swagger-default-url: true
 
 front.server:
   address: ${SHANOIR_URL_SCHEME}://${SHANOIR_URL_HOST}/shanoir-ng/

--- a/shanoir-ng-studies/src/main/resources/application.yml
+++ b/shanoir-ng-studies/src/main/resources/application.yml
@@ -77,10 +77,13 @@ spring:
 
 springdoc:
   api-docs:
-    path: /api-docs
-  swagger-ui:
-    path: /swagger-ui.html
+    path: '/api-docs'
     enabled: true
+  swagger-ui:
+    url: /shanoir-ng/studies/api-docs
+    config-url: /shanoir-ng/studies/api-docs/swagger-config
+    enabled: true
+    disable-swagger-default-url: true
 
 front.server:
   address: ${SHANOIR_URL_SCHEME}://${SHANOIR_URL_HOST}/shanoir-ng/

--- a/shanoir-ng-users/src/main/resources/application.yml
+++ b/shanoir-ng-users/src/main/resources/application.yml
@@ -75,11 +75,13 @@ spring:
 
 springdoc:
   api-docs:
-    path: /api-docs
+    path: '/api-docs'
+    enabled: true
   swagger-ui:
-    path: /swagger-ui.html
-    enabled: false
-
+    url: /shanoir-ng/users/api-docs
+    config-url: /shanoir-ng/users/api-docs/swagger-config
+    enabled: true
+    disable-swagger-default-url: true
 front:
   server:
     address: ${SHANOIR_URL_SCHEME}://${SHANOIR_URL_HOST}/shanoir-ng/


### PR DESCRIPTION
This PR correct the Swagger viewers.
Documentation is now directly displayed when accessing Swagger UI.
(Already corrected links in Wiki)

(URLs for local instance)
- https://shanoir-ng-nginx/shanoir-ng/datasets/swagger-ui/index.html
- https://shanoir-ng-nginx/shanoir-ng/import/swagger-ui/index.html
- https://shanoir-ng-nginx/shanoir-ng/preclinical/swagger-ui/index.html
- https://shanoir-ng-nginx/shanoir-ng/studies/swagger-ui/index.html

> ![image](https://github.com/fli-iam/shanoir-ng/assets/59697998/60bc9cfc-b6eb-4b71-bf41-9f5965afbbd2)
