### PR TITLE
hide "reconnecting" error message

### DIFF
--- a/shanoir-ng-front/src/app/shared/utils/handle-error.service.ts
+++ b/shanoir-ng-front/src/app/shared/utils/handle-error.service.ts
@@ -63,6 +63,9 @@ export class HandleErrorService implements ErrorHandler {
     }
 
     private handleDefaultError(error: any) {
+        if (error?.message?.startsWith('No activity within')) {
+            return;
+        }
         try {
             let msg: string = 'Error' 
             if (error.name != 'Error') msg += ' : ' + error.name;


### PR DESCRIPTION
fix https://github.com/fli-iam/shanoir-ng/issues/1909

the error message appears when the jobs/tasks permanent connection is interrupted more than 45s (you can pause the user container)