### PR TITLE
Shanoir issue#2032 hotfix processed datasets download

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/service/DatasetDownloaderServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/service/DatasetDownloaderServiceImpl.java
@@ -132,7 +132,7 @@ public class DatasetDownloaderServiceImpl {
 					DatasetFileUtils.getDatasetFilePathURLs(dataset, pathURLs, DatasetExpressionFormat.BIDS, downloadResult);
 					DatasetFileUtils.copyNiftiFilesForURLs(pathURLs, zipOutputStream, dataset, subjectName, true, datasetFilePath);
 					// Manage errors here
-				} else if (!CollectionUtils.isEmpty(dataset.getProcessings())) {
+				} else if (dataset.getDatasetProcessing() != null) {
 					// DOWNLOAD PROCESSED DATASET
 					DatasetFileUtils.getDatasetFilePathURLs(dataset, pathURLs, DatasetExpressionFormat.NIFTI_SINGLE_FILE, downloadResult);
 					DatasetFileUtils.copyNiftiFilesForURLs(pathURLs, zipOutputStream, dataset, subjectName, true, datasetFilePath);


### PR DESCRIPTION
Hotfix to correct problem for PRIMUS

How to test:
- Import a processed dataset on a dataset A
- Download dataset A as dicom
-> The dataset is downloaded as nifti