### PR TITLE
Manage git submodules update with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+---
+version: 2
+updates:
+ # Update the git submodules
+ - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "automerge"
+---


### PR DESCRIPTION
Hi @michael,

It seems it's possible to use dependabot to update git submodules :
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
- https://nicholaswilde.io/libbash/installation/#update

With this custom config, dependabot should check weekly if there is a new commit in https://github.com/Inria-Empenn/shanoir_downloader/ and submit a pull request as for other dependencies