### PR TITLE
shanoir-issue#2069: during subject creation, make it mandatory to pick a study

### DIFF
--- a/shanoir-ng-front/src/app/subjects/subject/subject.component.html
+++ b/shanoir-ng-front/src/app/subjects/subject/subject.component.html
@@ -167,6 +167,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 			</fieldset>
 			<fieldset *ngIf="mode !== 'view' && !forceStudy">
 				<subject-study-list [subject]="subject" [selectableList]="studies" [(ngModel)]="subject.subjectStudyList" formControlName="subjectStudyList" [mode]="mode"></subject-study-list>
+                <label *ngIf="hasError('subjectStudyList', ['required'])" class="form-validation-alert" i18n="Subject detail|Subject StudyList required error@@subjectDetailSubjectStudyListRequiredError">Study is required!</label>
 			</fieldset>
 			<fieldset *ngIf="mode !== 'view' && forceStudy">
 				<ol>

--- a/shanoir-ng-front/src/app/subjects/subject/subject.component.ts
+++ b/shanoir-ng-front/src/app/subjects/subject/subject.component.ts
@@ -124,7 +124,7 @@ export class SubjectComponent extends EntityComponent<Subject> implements OnInit
             'lastName': [this.lastName],
             'birthDate': [this.subject.birthDate],
             'sex': [this.subject.sex],
-            'subjectStudyList': [],
+            'subjectStudyList': [this.subject.subjectStudyList, [Validators.required]],
             'manualHemisphericDominance': [this.subject.manualHemisphericDominance],
             'languageHemisphericDominance': [this.subject.languageHemisphericDominance],
             'personalComments': []


### PR DESCRIPTION
How to test:
Go to subject
Click 'new'
Fill the mandatory forms (first name, last name, common name, date of birth): 'create' button is disabled
Pick a study: 'create' button is enabled
Remove the study: 'create' button is disabled and a message says "study is required"

Now, you can't create a subject without linking it to a study