### PR TITLE
#2097 - error during import leads to deletion and error swallow

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/ImporterService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/ImporterService.java
@@ -199,7 +199,7 @@ public class ImporterService {
                         // revert quality tag
                         subjectStudy.setQualityTag(tagSave);
                         subjectStudyService.update(qualityResult.getUpdatedSubjectStudies());
-                        throw new ShanoirException("Error while saving data in pacs, the import is canceled and acquisitions were not saved");
+                        throw new ShanoirException("Error while saving data in pacs, the import is canceled and acquisitions were not saved", e);
                     }
                 }
             } else {


### PR DESCRIPTION
How to test: good question.
- Stop pacs microservice before the import ?
- The error isn't clear -> It says "could not delete from pacs" which is not quite logic. The error should change.