### PR TITLE
shanoir-issue#2087: do not throw exception when pacs can't delete

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dicom/web/service/DICOMWebService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dicom/web/service/DICOMWebService.java
@@ -299,9 +299,14 @@ public class DICOMWebService {
 				LOG.info("Rejected from PACS: " + url);
 			} else {
 				LOG.error(response.getCode() + ": Could not reject instance from PACS: " + response.getReasonPhrase()
-					+ "for rejectURL: " + rejectURL);
-				throw new ShanoirException(response.getCode() + ": Could not reject instance from PACS: " + response.getReasonPhrase()
-				+ "for rejectURL: " + rejectURL);
+					+ " for rejectURL: " + rejectURL);
+				if (response.getCode() == 404 && response.getReasonPhrase().startsWith("Not Found")) {
+					LOG.error("Could not delete from pacs: " + response.getCode() + response.getReasonPhrase());
+					return;
+				} else {
+					throw new ShanoirException(response.getCode() + ": Could not reject instance from PACS: " + response.getReasonPhrase()
+							+ " for rejectURL: " + rejectURL);
+				}
 			}
 		} catch (IOException e) {
 			LOG.error("Could not reject instance from PACS: for rejectURL: " + rejectURL, e);

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dicom/web/service/DICOMWebService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dicom/web/service/DICOMWebService.java
@@ -301,7 +301,7 @@ public class DICOMWebService {
 				LOG.error(response.getCode() + ": Could not reject instance from PACS: " + response.getReasonPhrase()
 					+ " for rejectURL: " + rejectURL);
 				if (response.getCode() == 404 && response.getReasonPhrase().startsWith("Not Found")) {
-					LOG.error("Could not delete from pacs: " + response.getCode() + response.getReasonPhrase());
+					LOG.error("Could not delete from pacs: " + response.getCode() + " " + response.getReasonPhrase());
 					return;
 				} else {
 					throw new ShanoirException(response.getCode() + ": Could not reject instance from PACS: " + response.getReasonPhrase()


### PR DESCRIPTION
How to test:
Create a study
Import dataset in it
Go to pacs and reject series
Go to examination page and delete the created exam

Before:
Error is thrown and examination is not properly deleted

Now:
No error is thrown and examination is deleted

Tested on: local and qualif