### PR TITLE
shanoir-issue#2064: scroll and deploy-console button overlap in fedora

### DIFF
--- a/shanoir-ng-front/src/app/shared/console/console.component.css
+++ b/shanoir-ng-front/src/app/shared/console/console.component.css
@@ -19,7 +19,7 @@
 .button .tab { position: absolute;  color: var(--light-grey); text-align: center; cursor: pointer; }
 .button i { padding: 4px; }
 .button-top .tab { top: 0; border-bottom: 20px solid var(--dark-grey); border-right: 10px solid transparent; height: 0; }
-.right-tab { float: right; color: var(--light-grey); margin-right: -6px; cursor: pointer; }
+.right-tab { float: right; color: var(--light-grey); cursor: pointer; }
 
 i { vertical-align: 1px; }
 .number { color: violet; }

--- a/shanoir-ng-front/src/app/shared/console/console.component.css
+++ b/shanoir-ng-front/src/app/shared/console/console.component.css
@@ -19,7 +19,7 @@
 .button .tab { position: absolute;  color: var(--light-grey); text-align: center; cursor: pointer; }
 .button i { padding: 4px; }
 .button-top .tab { top: 0; border-bottom: 20px solid var(--dark-grey); border-right: 10px solid transparent; height: 0; }
-.right-tab { float: right; color: var(--light-grey); cursor: pointer; }
+.right-tab { float: right; color: var(--light-grey); margin-right: 2px; cursor: pointer; }
 
 i { vertical-align: 1px; }
 .number { color: violet; }


### PR DESCRIPTION
Slightly shift the 'widden console' arrow so that it's not overlapped by the scroll bar on linux systems

![image](https://github.com/fli-iam/shanoir-ng/assets/117283961/10fbc40d-6b76-4c25-842a-c28d5c62f15a)
