### PR TITLE
build the source maps by default

### DIFF
--- a/shanoir-ng-front/package.json
+++ b/shanoir-ng-front/package.json
@@ -4,8 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build --configuration production",
-    "build:source-map": "ng build --configuration production --source-map",
+    "build": "ng build --configuration production --source-map",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",


### PR DESCRIPTION
since shanoir is open source, i don't see any reason not to build the source maps