### PR TITLE
Update ShanoirEvent.java

### DIFF
--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/events/ShanoirEvent.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/events/ShanoirEvent.java
@@ -1,9 +1,6 @@
 package org.shanoir.ng.events;
 
-import java.sql.Types;
-
-import org.hibernate.annotations.JdbcTypeCode;
-
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
@@ -16,9 +13,8 @@ import jakarta.persistence.Table;
 	)
 public class ShanoirEvent extends ShanoirEventLight {
 
-	@JdbcTypeCode(Types.LONGVARCHAR)
+	@Column(columnDefinition = "LONGTEXT")
 	protected String report;
-
 
 	public ShanoirEvent() {
 		// Default empty constructor for json deserializer.
@@ -45,4 +41,5 @@ public class ShanoirEvent extends ShanoirEventLight {
 		setReport(null);
 		return light;
 	}
+
 }


### PR DESCRIPTION
Fixes:
Error executing DDL "create table events (progress float(23), status integer not null, creation_date datetime(6), id bigint not null, last_update datetime(6), study_id bigint, user_id bigint, message varchar(32600), report varchar(32600), event_type varchar(255), object_id varchar(255), primary key (id)) engine=InnoDB" via JDBC [Row size too large. The maximum row size for the used table type, not counting BLOBs, is 65535. This includes storage overhead, check the manual. You have to change some columns to TEXT or BLOBs]