### PR TITLE
shanoir-issue#2132: add modality radiobutton in import from pacs

### DIFF
--- a/shanoir-ng-front/src/app/import/query-pacs/query-pacs.component.html
+++ b/shanoir-ng-front/src/app/import/query-pacs/query-pacs.component.html
@@ -25,7 +25,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
             </legend>
             <p>The maximum number of patients returned is limited to 10, please optimize your query to find relevant results.</p>
             <li>
-                <label>Patient Name</label> 
+                <label>Patient Name</label>
                 <span class="right-col">
                     <input type="text" id="patientName" formControlName="patientName" maxlength="64" [(ngModel)]="dicomQuery.patientName" />
                     <label *ngIf="hasError('patientName', ['maxlength'])" [@slideDown]="hasError('patientName', ['maxlength'])" class="form-validation-alert">Length must not exceed 64!</label>
@@ -34,7 +34,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
                 <tool-tip>Enter the exact value, case sensitive, the wildcard character is not allowed. Ex: TITI^TOTO won't match titi'toto</tool-tip>
             </li>
             <li>
-                <label>Patient ID</label> 
+                <label>Patient ID</label>
                 <span class="right-col">
                     <input type="text" id="patientID" formControlName="patientID" maxlength="64" [(ngModel)]="dicomQuery.patientID" />
                     <label *ngIf="hasError('patientID', ['maxlength'])" [@slideDown]="hasError('patientID', ['maxlength'])" class="form-validation-alert">Length must not exceed 64!</label>
@@ -43,7 +43,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
                 <tool-tip>Enter the exact value, the wildcard character is not allowed.</tool-tip>
             </li>
             <li>
-                <label>Patient Birth Date</label> 
+                <label>Patient Birth Date</label>
                 <span class="right-col">
                     <input type="text" id="patientBirthDate" placeholder="yyyyMMdd" [(ngModel)]="dicomQuery.patientBirthDate" formControlName="patientBirthDate" />
                     <label *ngIf="hasError('patientBirthDate', ['pattern'])" class="form-validation-alert">Date format required by the PACS: yyyyMMdd</label>
@@ -51,7 +51,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
                 <tool-tip>Date format required by the PACS: yyyyMMdd</tool-tip>
             </li>
             <li>
-                <label>Study Description</label> 
+                <label>Study Description</label>
                 <span class="right-col">
                     <input type="text" id="studyDescription" formControlName="studyDescription" maxlength="64" minlength="4" [(ngModel)]="dicomQuery.studyDescription" />
                     <label *ngIf="hasError('studyDescription', ['maxlength', 'minlength'])" [@slideDown]="hasError('studyDescription', ['maxlength', 'minlength'])" class="form-validation-alert">Length must be between 4 and 64!</label>
@@ -59,12 +59,23 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
                 <tool-tip>The wildcard character is allowed. For instance, you can enter STUDY* to find STUDY^NEURO</tool-tip>
             </li>
             <li>
-                <label>Study Date</label> 
+                <label>Study Date</label>
                 <span class="right-col">
                     <input type="text" id="studyDate" placeholder="yyyyMMdd" [(ngModel)]="dicomQuery.studyDate" formControlName="studyDate" />
                     <label *ngIf="hasError('studyDate', ['pattern'])" class="form-validation-alert">Date format required by the PACS: yyyyMMdd</label>
                 </span>
                 <tool-tip>Date format required by the PACS: yyyyMMdd</tool-tip>
+            </li>
+            <li>
+                <label>Modality</label>
+                <span class="right-col">
+                    <input type="radio" formControlName="modality" [(ngModel)]="dicomQuery.modality" value="MR">MR
+                    <input type="radio" formControlName="modality" [(ngModel)]="dicomQuery.modality" value="CT">CT
+                    <input type="radio" formControlName="modality" [(ngModel)]="dicomQuery.modality" value="PT">PT
+                    <input type="radio" formControlName="modality" [(ngModel)]="dicomQuery.modality" value="NM">NM
+                    <input type="radio" formControlName="modality" [(ngModel)]="dicomQuery.modality" value="XA">XA
+                    <input type="radio" formControlName="modality" [(ngModel)]="dicomQuery.modality" value="None">None
+                </span>
             </li>
         </ol>
     </fieldset>

--- a/shanoir-ng-front/src/app/import/query-pacs/query-pacs.component.ts
+++ b/shanoir-ng-front/src/app/import/query-pacs/query-pacs.component.ts
@@ -2,12 +2,12 @@
  * Shanoir NG - Import, manage and share neuroimaging data
  * Copyright (C) 2009-2019 Inria - https://www.inria.fr/
  * Contact us on https://project.inria.fr/shanoir/
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
  */
@@ -60,7 +60,7 @@ export class QueryPacsComponent{
                 this.importDataService.patientList = importJob;
                 this.router.navigate(['imports/series']);
             } else {
-                this.consoleService.log('warn', 'Nothing found. Please change your query parameters.', ['query : ' + JSON.stringify(this.dicomQuery)]); 
+                this.consoleService.log('warn', 'Nothing found. Please change your query parameters.', ['query : ' + JSON.stringify(this.dicomQuery)]);
             }
         })
     }
@@ -74,7 +74,8 @@ export class QueryPacsComponent{
             'patientID': [this.dicomQuery.patientID, [Validators.maxLength(64), Validators.pattern(noWildcardPattern)]],
             'patientBirthDate': [this.dicomQuery.patientBirthDate, Validators.pattern(pacsDatePattern)],
             'studyDescription': [this.dicomQuery.studyDescription, [Validators.maxLength(64), Validators.minLength(4)]],
-            'studyDate': [this.dicomQuery.studyDate, Validators.pattern(pacsDatePattern)]
+            'studyDate': [this.dicomQuery.studyDate, Validators.pattern(pacsDatePattern)],
+            'modality': [this.dicomQuery.modality]
         }, { validator: atLeastOneNotBlank(Validators.required) });
     }
 

--- a/shanoir-ng-front/src/app/import/shared/dicom-data.model.ts
+++ b/shanoir-ng-front/src/app/import/shared/dicom-data.model.ts
@@ -106,4 +106,5 @@ export class DicomQuery {
     patientBirthDate: string = "";
     studyDescription: string = "";
     studyDate: string = "";
+    modality:  'MR' | 'CT' | 'PT' | 'NM' | 'XA' | 'None' = 'MR';
 }


### PR DESCRIPTION
Fix #2132

In 'import from pacs' page, add modality radio buttons:

![image](https://github.com/fli-iam/shanoir-ng/assets/117283961/6ade0fad-61e1-4c78-9acb-4347f9f0f8f4)


Backend is ongoing in PR #2063 