### PR TITLE
[fli-iam#2192] New properties API endpoints

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/service/DatasetService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/service/DatasetService.java
@@ -150,4 +150,6 @@ public interface DatasetService {
 	
 	@PreAuthorize("hasRole('ADMIN') or (hasRole('EXPERT') and @datasetSecurityService.hasRightOnDataset(#dataset.getId(), 'CAN_ADMINISTRATE'))")
 	void deleteDatasetFromPacs(Dataset dataset) throws ShanoirException;
+
+	boolean existsById(Long id);
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/service/DatasetServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/service/DatasetServiceImpl.java
@@ -25,8 +25,6 @@ import org.shanoir.ng.dataset.model.Dataset;
 import org.shanoir.ng.dataset.model.DatasetExpression;
 import org.shanoir.ng.dataset.model.DatasetExpressionFormat;
 import org.shanoir.ng.dataset.repository.DatasetRepository;
-import org.shanoir.ng.datasetacquisition.model.DatasetAcquisition;
-import org.shanoir.ng.datasetacquisition.service.DatasetAcquisitionServiceImpl;
 import org.shanoir.ng.datasetfile.DatasetFile;
 import org.shanoir.ng.dicom.web.service.DICOMWebService;
 import org.shanoir.ng.processing.service.DatasetProcessingService;
@@ -62,7 +60,10 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -121,7 +122,6 @@ public class DatasetServiceImpl implements DatasetService {
 					));
 
 		}
-
 		processingService.removeDatasetFromAllProcessingInput(id);
 		propertyService.deleteByDatasetId(id);
 		repository.deleteById(id);
@@ -158,6 +158,11 @@ public class DatasetServiceImpl implements DatasetService {
 			break;
         }
     }
+
+	@Override
+	public boolean existsById(Long id) {
+		return repository.existsById(id);
+	}
 
 	@Override
 	@Transactional

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/controller/DatasetPropertyApi.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/controller/DatasetPropertyApi.java
@@ -23,8 +23,10 @@ public interface DatasetPropertyApi {
     @Operation(summary = "", description = "Returns the dataset properties associated to the given dataset")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "found dataset properties"),
+            @ApiResponse(responseCode = "204", description = "no dataset properties found"),
             @ApiResponse(responseCode = "401", description = "unauthorized"),
             @ApiResponse(responseCode = "403", description = "forbidden"),
+            @ApiResponse(responseCode = "404", description = "dataset does not exists"),
             @ApiResponse(responseCode = "500", description = "unexpected error") })
     @GetMapping(value = "/dataset/{datasetId}", produces = { "application/json" })
     @PreAuthorize("hasAnyRole('ADMIN', 'EXPERT', 'USER') and @datasetSecurityService.hasRightOnDataset(#datasetId, 'CAN_SEE_ALL')")
@@ -33,11 +35,13 @@ public interface DatasetPropertyApi {
             @PathVariable("datasetId")
             Long datasetId);
 
-    @Operation(summary = "", description = "Returns the dataset properties associated to the given dataset")
+    @Operation(summary = "", description = "Returns the dataset properties associated to the given processing")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "found dataset properties"),
+            @ApiResponse(responseCode = "204", description = "no dataset properties found"),
             @ApiResponse(responseCode = "401", description = "unauthorized"),
             @ApiResponse(responseCode = "403", description = "forbidden"),
+            @ApiResponse(responseCode = "404", description = "processing does not exists"),
             @ApiResponse(responseCode = "500", description = "unexpected error") })
     @GetMapping(value = "/processing/{processingId}", produces = { "application/json" })
     @PreAuthorize("hasAnyRole('ADMIN', 'EXPERT', 'USER')")

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/controller/DatasetPropertyApi.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/controller/DatasetPropertyApi.java
@@ -1,0 +1,42 @@
+package org.shanoir.ng.property.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.shanoir.ng.property.model.DatasetProperty;
+import org.shanoir.ng.shared.exception.EntityNotFoundException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@Tag(name = "properties", description = "the dataset properties API")
+@RequestMapping("/properties")
+public interface DatasetPropertyApi {
+
+    @Operation(summary = "", description = "Returns the dataset properties associated to the given dataset")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "found dataset properties"),
+            @ApiResponse(responseCode = "401", description = "unauthorized"),
+            @ApiResponse(responseCode = "403", description = "forbidden"),
+            @ApiResponse(responseCode = "500", description = "unexpected error") })
+    @GetMapping(value = "/dataset/{datasetId}", produces = { "application/json" })
+    @PreAuthorize("hasAnyRole('ADMIN', 'EXPERT', 'USER') and @datasetSecurityService.hasRightOnDataset(#datasetId, 'CAN_SEE_ALL')")
+    ResponseEntity<List<DatasetProperty>> getPropertiesByDatasetId(@Parameter(name = "datasetId", description = "id of the dataset", required = true) @PathVariable("datasetId") Long datasetId);
+
+    @Operation(summary = "", description = "Returns the dataset properties associated to the given dataset")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "found dataset properties"),
+            @ApiResponse(responseCode = "401", description = "unauthorized"),
+            @ApiResponse(responseCode = "403", description = "forbidden"),
+            @ApiResponse(responseCode = "500", description = "unexpected error") })
+    @GetMapping(value = "/processing/{processingId}", produces = { "application/json" })
+    @PreAuthorize("hasAnyRole('ADMIN', 'EXPERT', 'USER')")
+    ResponseEntity<List<DatasetProperty>> getPropertiesByProcessingId(@Parameter(name = "processingId", description = "id of the processing", required = true) @PathVariable("processingId") Long processingId) throws EntityNotFoundException;
+
+}

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/controller/DatasetPropertyApi.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/controller/DatasetPropertyApi.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.shanoir.ng.property.model.DatasetProperty;
+import org.shanoir.ng.property.model.DatasetPropertyDTO;
 import org.shanoir.ng.shared.exception.EntityNotFoundException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -27,7 +28,10 @@ public interface DatasetPropertyApi {
             @ApiResponse(responseCode = "500", description = "unexpected error") })
     @GetMapping(value = "/dataset/{datasetId}", produces = { "application/json" })
     @PreAuthorize("hasAnyRole('ADMIN', 'EXPERT', 'USER') and @datasetSecurityService.hasRightOnDataset(#datasetId, 'CAN_SEE_ALL')")
-    ResponseEntity<List<DatasetProperty>> getPropertiesByDatasetId(@Parameter(name = "datasetId", description = "id of the dataset", required = true) @PathVariable("datasetId") Long datasetId);
+    ResponseEntity<List<DatasetPropertyDTO>> getPropertiesByDatasetId(
+            @Parameter(description = "id of the dataset", required = true)
+            @PathVariable("datasetId")
+            Long datasetId);
 
     @Operation(summary = "", description = "Returns the dataset properties associated to the given dataset")
     @ApiResponses(value = {
@@ -37,6 +41,6 @@ public interface DatasetPropertyApi {
             @ApiResponse(responseCode = "500", description = "unexpected error") })
     @GetMapping(value = "/processing/{processingId}", produces = { "application/json" })
     @PreAuthorize("hasAnyRole('ADMIN', 'EXPERT', 'USER')")
-    ResponseEntity<List<DatasetProperty>> getPropertiesByProcessingId(@Parameter(name = "processingId", description = "id of the processing", required = true) @PathVariable("processingId") Long processingId) throws EntityNotFoundException;
+    ResponseEntity<List<DatasetPropertyDTO>> getPropertiesByProcessingId(@Parameter(description = "id of the processing", required = true) @PathVariable("processingId") Long processingId) throws EntityNotFoundException;
 
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/controller/DatasetPropertyApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/controller/DatasetPropertyApiController.java
@@ -2,6 +2,7 @@ package org.shanoir.ng.property.controller;
 
 import org.shanoir.ng.dataset.controler.DatasetApiController;
 import org.shanoir.ng.dataset.security.DatasetSecurityService;
+import org.shanoir.ng.dataset.service.DatasetService;
 import org.shanoir.ng.property.model.DatasetProperty;
 import org.shanoir.ng.property.model.DatasetPropertyDTO;
 import org.shanoir.ng.property.model.DatasetPropertyMapper;
@@ -21,6 +22,9 @@ import java.util.List;
 public class DatasetPropertyApiController implements DatasetPropertyApi {
 
     @Autowired
+    private DatasetService dsSrv;
+
+    @Autowired
     private DatasetPropertyService propertyService;
 
     @Autowired
@@ -32,13 +36,29 @@ public class DatasetPropertyApiController implements DatasetPropertyApi {
 
     @Override
     public ResponseEntity<List<DatasetPropertyDTO>> getPropertiesByDatasetId(Long datasetId) {
+
+        if(!dsSrv.existsById(datasetId)){
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+
+        List<DatasetProperty> properties = this.propertyService.getByDatasetId(datasetId);
+
+        if(properties.isEmpty()){
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        }
+
         return new ResponseEntity<>(
-                mapper.datasetPropertiesToDatasetPropertyDTOs(this.propertyService.getByDatasetId(datasetId)),
+                mapper.datasetPropertiesToDatasetPropertyDTOs(properties),
                 HttpStatus.OK);
     }
 
     @Override
     public ResponseEntity<List<DatasetPropertyDTO>> getPropertiesByProcessingId(Long processingId) throws EntityNotFoundException {
+
+        if(!propertyService.existsById(processingId)){
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+
         List<DatasetProperty> filteredProperties = new ArrayList<>();
 
         for(DatasetProperty property : this.propertyService.getByDatasetProcessingId(processingId)){
@@ -46,6 +66,11 @@ public class DatasetPropertyApiController implements DatasetPropertyApi {
                 filteredProperties.add(property);
             }
         }
+
+        if(filteredProperties.isEmpty()){
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        }
+
         return new ResponseEntity<>(
                 mapper.datasetPropertiesToDatasetPropertyDTOs(filteredProperties),
                 HttpStatus.OK);

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/controller/DatasetPropertyApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/controller/DatasetPropertyApiController.java
@@ -2,6 +2,8 @@ package org.shanoir.ng.property.controller;
 
 import org.shanoir.ng.dataset.security.DatasetSecurityService;
 import org.shanoir.ng.property.model.DatasetProperty;
+import org.shanoir.ng.property.model.DatasetPropertyDTO;
+import org.shanoir.ng.property.model.DatasetPropertyMapper;
 import org.shanoir.ng.property.service.DatasetPropertyService;
 import org.shanoir.ng.shared.exception.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,14 +23,19 @@ public class DatasetPropertyApiController implements DatasetPropertyApi {
     @Autowired
     private DatasetSecurityService securityService;
 
+    @Autowired
+    private DatasetPropertyMapper mapper;
+
 
     @Override
-    public ResponseEntity<List<DatasetProperty>> getPropertiesByDatasetId(Long datasetId) {
-        return new ResponseEntity<>(this.propertyService.getByDatasetId(datasetId), HttpStatus.OK);
+    public ResponseEntity<List<DatasetPropertyDTO>> getPropertiesByDatasetId(Long datasetId) {
+        return new ResponseEntity<>(
+                mapper.datasetPropertiesToDatasetPropertyDTOs(this.propertyService.getByDatasetId(datasetId)),
+                HttpStatus.OK);
     }
 
     @Override
-    public ResponseEntity<List<DatasetProperty>> getPropertiesByProcessingId(Long processingId) throws EntityNotFoundException {
+    public ResponseEntity<List<DatasetPropertyDTO>> getPropertiesByProcessingId(Long processingId) throws EntityNotFoundException {
         List<DatasetProperty> filteredProperties = new ArrayList<>();
 
         for(DatasetProperty property : this.propertyService.getByDatasetProcessingId(processingId)){
@@ -36,6 +43,9 @@ public class DatasetPropertyApiController implements DatasetPropertyApi {
                 filteredProperties.add(property);
             }
         }
-        return new ResponseEntity<>(filteredProperties, HttpStatus.OK);
+        return new ResponseEntity<>(
+                mapper.datasetPropertiesToDatasetPropertyDTOs(filteredProperties),
+                HttpStatus.OK);
     }
+
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/controller/DatasetPropertyApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/controller/DatasetPropertyApiController.java
@@ -1,0 +1,41 @@
+package org.shanoir.ng.property.controller;
+
+import org.shanoir.ng.dataset.security.DatasetSecurityService;
+import org.shanoir.ng.property.model.DatasetProperty;
+import org.shanoir.ng.property.service.DatasetPropertyService;
+import org.shanoir.ng.shared.exception.EntityNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Controller
+public class DatasetPropertyApiController implements DatasetPropertyApi {
+
+    @Autowired
+    private DatasetPropertyService propertyService;
+
+    @Autowired
+    private DatasetSecurityService securityService;
+
+
+    @Override
+    public ResponseEntity<List<DatasetProperty>> getPropertiesByDatasetId(Long datasetId) {
+        return new ResponseEntity<>(this.propertyService.getByDatasetId(datasetId), HttpStatus.OK);
+    }
+
+    @Override
+    public ResponseEntity<List<DatasetProperty>> getPropertiesByProcessingId(Long processingId) throws EntityNotFoundException {
+        List<DatasetProperty> filteredProperties = new ArrayList<>();
+
+        for(DatasetProperty property : this.propertyService.getByDatasetProcessingId(processingId)){
+            if(securityService.hasRightOnDataset(property.getDataset().getId(), "CAN_SEE_ALL")){
+                filteredProperties.add(property);
+            }
+        }
+        return new ResponseEntity<>(filteredProperties, HttpStatus.OK);
+    }
+}

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/controller/DatasetPropertyApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/controller/DatasetPropertyApiController.java
@@ -1,11 +1,14 @@
 package org.shanoir.ng.property.controller;
 
+import org.shanoir.ng.dataset.controler.DatasetApiController;
 import org.shanoir.ng.dataset.security.DatasetSecurityService;
 import org.shanoir.ng.property.model.DatasetProperty;
 import org.shanoir.ng.property.model.DatasetPropertyDTO;
 import org.shanoir.ng.property.model.DatasetPropertyMapper;
 import org.shanoir.ng.property.service.DatasetPropertyService;
 import org.shanoir.ng.shared.exception.EntityNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +19,8 @@ import java.util.List;
 
 @Controller
 public class DatasetPropertyApiController implements DatasetPropertyApi {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DatasetPropertyApiController.class);
 
     @Autowired
     private DatasetPropertyService propertyService;
@@ -38,9 +43,14 @@ public class DatasetPropertyApiController implements DatasetPropertyApi {
     public ResponseEntity<List<DatasetPropertyDTO>> getPropertiesByProcessingId(Long processingId) throws EntityNotFoundException {
         List<DatasetProperty> filteredProperties = new ArrayList<>();
 
+        LOG.error("[DEBUG] getPropertiesByProcessingId");
+
         for(DatasetProperty property : this.propertyService.getByDatasetProcessingId(processingId)){
             if(securityService.hasRightOnDataset(property.getDataset().getId(), "CAN_SEE_ALL")){
                 filteredProperties.add(property);
+                LOG.error("[DEBUG] Added [{} : {}]", property.getName(), property.getValue());
+            } else {
+                LOG.error("[DEBUG] No right for dataset [{}]", property.getDataset().getId());
             }
         }
         return new ResponseEntity<>(

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/controller/DatasetPropertyApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/controller/DatasetPropertyApiController.java
@@ -20,8 +20,6 @@ import java.util.List;
 @Controller
 public class DatasetPropertyApiController implements DatasetPropertyApi {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DatasetPropertyApiController.class);
-
     @Autowired
     private DatasetPropertyService propertyService;
 
@@ -43,14 +41,9 @@ public class DatasetPropertyApiController implements DatasetPropertyApi {
     public ResponseEntity<List<DatasetPropertyDTO>> getPropertiesByProcessingId(Long processingId) throws EntityNotFoundException {
         List<DatasetProperty> filteredProperties = new ArrayList<>();
 
-        LOG.error("[DEBUG] getPropertiesByProcessingId");
-
         for(DatasetProperty property : this.propertyService.getByDatasetProcessingId(processingId)){
             if(securityService.hasRightOnDataset(property.getDataset().getId(), "CAN_SEE_ALL")){
                 filteredProperties.add(property);
-                LOG.error("[DEBUG] Added [{} : {}]", property.getName(), property.getValue());
-            } else {
-                LOG.error("[DEBUG] No right for dataset [{}]", property.getDataset().getId());
             }
         }
         return new ResponseEntity<>(

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/model/DatasetPropertyDTO.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/model/DatasetPropertyDTO.java
@@ -1,0 +1,44 @@
+package org.shanoir.ng.property.model;
+
+public class DatasetPropertyDTO {
+
+    private Long datasetId;
+
+    private Long processingId;
+
+    private String name;
+
+    private String value;
+
+    public Long getDatasetId() {
+        return datasetId;
+    }
+
+    public void setDatasetId(Long datasetId) {
+        this.datasetId = datasetId;
+    }
+
+    public Long getProcessingId() {
+        return processingId;
+    }
+
+    public void setProcessingId(Long processingId) {
+        this.processingId = processingId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/model/DatasetPropertyMapper.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/model/DatasetPropertyMapper.java
@@ -1,0 +1,28 @@
+package org.shanoir.ng.property.model;
+
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class DatasetPropertyMapper {
+
+    public List<DatasetPropertyDTO> datasetPropertiesToDatasetPropertyDTOs(List<DatasetProperty> properties){
+        List<DatasetPropertyDTO> dtos = new ArrayList<>();
+        for(DatasetProperty property : properties){
+            dtos.add(this.datasetPropertyToDatasetPropertyDTO(property));
+        }
+        return dtos;
+    }
+
+    private DatasetPropertyDTO datasetPropertyToDatasetPropertyDTO(DatasetProperty property) {
+        DatasetPropertyDTO dto = new DatasetPropertyDTO();
+        dto.setDatasetId(property.getDataset().getId());
+        dto.setProcessingId(property.getProcessing().getId());
+        dto.setName(property.getName());
+        dto.setValue(property.getName());
+        return dto;
+    }
+
+}

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/repository/DatasetPropertyRepository.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/repository/DatasetPropertyRepository.java
@@ -4,8 +4,14 @@ import org.shanoir.ng.property.model.DatasetProperty;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface DatasetPropertyRepository extends CrudRepository<DatasetProperty, Long> {
 
     void deleteByDatasetId(Long id);
+
+    List<DatasetProperty> getByDatasetId(Long id);
+
+    List<DatasetProperty> getByProcessingId(Long id);
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/service/DatasetPropertyService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/service/DatasetPropertyService.java
@@ -15,4 +15,5 @@ public interface DatasetPropertyService {
 
     List<DatasetProperty> getByDatasetProcessingId(Long id);
 
+    boolean existsById(Long processingId);
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/service/DatasetPropertyService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/service/DatasetPropertyService.java
@@ -10,4 +10,9 @@ public interface DatasetPropertyService {
     List<DatasetProperty> createAll(List<DatasetProperty> properties);
 
     void deleteByDatasetId(Long id);
+
+    List<DatasetProperty> getByDatasetId(Long id);
+
+    List<DatasetProperty> getByDatasetProcessingId(Long id);
+
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/service/DatasetPropertyServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/service/DatasetPropertyServiceImpl.java
@@ -22,4 +22,15 @@ public class DatasetPropertyServiceImpl implements DatasetPropertyService {
     public void deleteByDatasetId(Long id) {
         repository.deleteByDatasetId(id);
     }
+
+    @Override
+    public List<DatasetProperty> getByDatasetId(Long id) {
+        return repository.getByDatasetId(id);
+    }
+
+    @Override
+    public List<DatasetProperty> getByDatasetProcessingId(Long id) {
+        return repository.getByProcessingId(id);
+    }
+
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/service/DatasetPropertyServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/property/service/DatasetPropertyServiceImpl.java
@@ -33,4 +33,9 @@ public class DatasetPropertyServiceImpl implements DatasetPropertyService {
         return repository.getByProcessingId(id);
     }
 
+    @Override
+    public boolean existsById(Long processingId) {
+        return repository.existsById(processingId);
+    }
+
 }


### PR DESCRIPTION
# Changes
Add 2 endpoints in dataset MS to query dataset properties
 - GET /properties/dataset/{datasetId}
   - check user CAN_SEE_ALL right on given dataset
 - GET /properties/processing/{processingId}
   - keep properties for which user has CAN_SEE_ALL right on dataset

# How to test
- Check datasets swagger doc
- Check APIs with cURL (copy a query example "as cURL" in browser console and adapt it)
- Check different user rights
