### PR TITLE
shanoir-issue#2186: change dockerfiles to upgrade java 17 to 21

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -91,10 +91,10 @@ if [ -n "$build" ] ; then
 	# 1. build a docker image with the java toolchain
 	DEV_IMG=shanoir-ng-dev
 	docker build -t "$DEV_IMG" - <<EOF
-FROM debian:bookworm
+FROM debian:trixie
 # NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
-RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
-    && apt-get update -qq && apt-get install -qqy --no-install-recommends openjdk-17-jdk-headless maven bzip2 git
+RUN echo "deb http://deb.debian.org/debian trixie-proposed-updates main" >> /etc/apt/sources.list \
+    && apt-get update -qq && apt-get install -qqy --no-install-recommends openjdk-21-jdk-headless maven bzip2 git
 EOF
 	# 2. run the maven build
 	mkdir -p /tmp/home

--- a/docker-compose/datasets/Dockerfile
+++ b/docker-compose/datasets/Dockerfile
@@ -11,11 +11,11 @@
 # along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 
 #--------------- common jre base image -------------------------------------
-FROM debian:bookworm
-# NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
-RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
+FROM debian:trixie
+# NOTE: using trixie for jdk21
+RUN echo "deb http://deb.debian.org/debian trixie-proposed-updates main" >> /etc/apt/sources.list \
     && apt-get update -qq \
-    && apt-get install -qqy openjdk-17-jre-headless ca-certificates-java
+    && apt-get install -qqy openjdk-21-jre-headless ca-certificates-java
 #----------------------------------------------------------------------------
 
 

--- a/docker-compose/import/Dockerfile
+++ b/docker-compose/import/Dockerfile
@@ -11,11 +11,11 @@
 # along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 
 #--------------- common jre base image -------------------------------------
-FROM debian:bookworm
-# NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
-RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
+FROM debian:trixie
+# NOTE: using trixie for jdk21
+RUN echo "deb http://deb.debian.org/debian trixie-proposed-updates main" >> /etc/apt/sources.list \
     && apt-get update -qq \
-    && apt-get install -qqy openjdk-17-jre-headless ca-certificates-java
+    && apt-get install -qqy openjdk-21-jre-headless ca-certificates-java
 #----------------------------------------------------------------------------
 
 

--- a/docker-compose/nifti-conversion/Dockerfile
+++ b/docker-compose/nifti-conversion/Dockerfile
@@ -10,12 +10,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 
-FROM debian:bookworm
+FROM debian:trixie
 
-# NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
+# NOTE: using trixie for jdk21
 RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
     && apt-get update -qq \
-    && apt-get install -qqy openjdk-17-jdk ca-certificates-java
+    && apt-get install -qqy openjdk-21-jdk ca-certificates-java
 
 #32 bits packages are necessary
 RUN dpkg --add-architecture i386

--- a/docker-compose/preclinical/Dockerfile
+++ b/docker-compose/preclinical/Dockerfile
@@ -1,9 +1,9 @@
 #--------------- common jre base image -------------------------------------
-FROM debian:bookworm
-# NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
-RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
+FROM debian:trixie
+# NOTE: using trixie for jdk21
+RUN echo "deb http://deb.debian.org/debian trixie-proposed-updates main" >> /etc/apt/sources.list \
     && apt-get update -qq \
-    && apt-get install -qqy openjdk-17-jre-headless ca-certificates-java
+    && apt-get install -qqy openjdk-21-jre-headless ca-certificates-java
 #----------------------------------------------------------------------------
 
 

--- a/docker-compose/studies/Dockerfile
+++ b/docker-compose/studies/Dockerfile
@@ -11,11 +11,11 @@
 # along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 
 #--------------- common jre base image -------------------------------------
-FROM debian:bookworm
-# NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
-RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
+FROM debian:trixie
+# NOTE: using trixie for jdk21
+RUN echo "deb http://deb.debian.org/debian trixie-proposed-updates main" >> /etc/apt/sources.list \
     && apt-get update -qq \
-    && apt-get install -qqy openjdk-17-jre-headless ca-certificates-java
+    && apt-get install -qqy openjdk-21-jre-headless ca-certificates-java
 #----------------------------------------------------------------------------
 
 

--- a/docker-compose/users/Dockerfile
+++ b/docker-compose/users/Dockerfile
@@ -11,11 +11,11 @@
 # along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 
 #--------------- common jre base image -------------------------------------
-FROM debian:bookworm
-# NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
-RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
+FROM debian:trixie
+# NOTE: using trixie for jdk21
+RUN echo "deb http://deb.debian.org/debian trixie-proposed-updates main" >> /etc/apt/sources.list \
     && apt-get update -qq \
-    && apt-get install -qqy openjdk-17-jre-headless ca-certificates-java
+    && apt-get install -qqy openjdk-21-jre-headless ca-certificates-java
 #----------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Changes add to dockerfiles and bootstrap.sh

I had no issue starting shanoir, creating a new study and importing datasets in