### PR TITLE
Dockerfile optimisations

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -1,0 +1,41 @@
+
+## Optimisations it the dockerfiles
+
+We use multiple strategies to decrease the time to build the docker images and
+the overall size of the final image:
+
+- **common base image**: all images requiring a JRE begin with identical steps
+  (delimited with `-- common jre base image --` in the dockerfiles), so as to
+  be built only once. Extra packages are installed using an additional RUN
+  step.
+
+- [**multi-stage dockerfiles**][multi-stage] are used for:
+    - running time-consuming steps in parallel (eg: in *nifti-conversion* we
+      have a separate stage for installing dicomifier and building dcm2niix)
+    - reducing the size of the final image:
+      - by not installing packages that are only needed at build time (eg: gcc,
+        curl, ...)
+      - by not storing intermediate files (eg: dcm4che zip archive in
+        *datasets*)
+
+- **reduced number of steps**: prefer a single RUN step with all commands
+  in a shell script rather than a series short RUN steps
+
+- **caching**: incremental build using the buildkit cache
+
+  - use [**RUN mount --type=cache**][mount-cache] to store the cache of package
+    managers (eg: apt, conda) in external volumes, which yields two benefits:
+    - reduced build time (no need to re-download the packages in future builds)
+    - reduced image size (the package cache is not stored in the final image)
+
+  - use [**COPY --link**][copy-link] as much as possible to make the step
+    independent from the previous ones, which yields two benefits:
+    - it does not need to be rebuilt when the previous step have changed
+    - it can be build without extracting the image of the previous steps, this
+      is significant for large images (eg. the extraction of *nifti-conversion*
+      takes around 50 seconds)
+
+
+[multi-stage]: https://docs.docker.com/build/building/multi-stage/
+[copy-link]: https://docs.docker.com/reference/dockerfile/#copy---link
+[mount-cache]: https://docs.docker.com/reference/dockerfile/#run---mounttypecache

--- a/docker-compose/database/Dockerfile
+++ b/docker-compose/database/Dockerfile
@@ -12,19 +12,15 @@
 
 FROM mysql/mysql-server:5.7
 
-COPY /shanoir-entrypoint.sh /
+COPY --link --chmod=0755 /shanoir-entrypoint.sh /
 ENTRYPOINT ["/shanoir-entrypoint.sh"]
 CMD ["mysqld"]
 
-ADD 1_create_databases.sh /docker-entrypoint-initdb.d/
-ADD 2_add_users.sql /docker-entrypoint-initdb.d/
-ADD 3_add_statistics_procedure.sql /docker-entrypoint-initdb.d/
-ADD 4_add_studyStatistics_procedure.sql /docker-entrypoint-initdb.d/
+COPY --link --chmod=0755 \
+    1_create_databases.sh \
+    2_add_users.sql \
+    3_add_statistics_procedure.sql \
+    4_add_studyStatistics_procedure.sql \
+    /docker-entrypoint-initdb.d/
  
-RUN chmod a+x /docker-entrypoint-initdb.d/1_create_databases.sh
-RUN chmod a+x /docker-entrypoint-initdb.d/2_add_users.sql
-RUN chmod a+x /docker-entrypoint-initdb.d/3_add_statistics_procedure.sql
-RUN chmod a+x /docker-entrypoint-initdb.d/4_add_studyStatistics_procedure.sql
-RUN chmod a+x /shanoir-entrypoint.sh
-
-COPY db-changes /opt/db-changes
+COPY --link db-changes /opt/db-changes

--- a/docker-compose/datasets/Dockerfile
+++ b/docker-compose/datasets/Dockerfile
@@ -48,8 +48,8 @@ ENV LANGUAGE en_US.UTF-8
 COPY --link --from=downloader /target/. /
 
 RUN mkdir -pv /var/log/shanoir-ng-logs
-ADD shanoir-ng-datasets.jar shanoir-ng-datasets.jar
-COPY entrypoint entrypoint_common oneshot /bin/
+COPY --link shanoir-ng-datasets.jar shanoir-ng-datasets.jar
+COPY --link entrypoint entrypoint_common oneshot /bin/
 
 # Use the below line for remote debugging and to active dev profile
 #ENTRYPOINT ["/bin/entrypoint", "java", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=0.0.0.0:9914,suspend=y", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-jar", "/shanoir-ng-datasets.jar"]

--- a/docker-compose/datasets/Dockerfile
+++ b/docker-compose/datasets/Dockerfile
@@ -54,7 +54,7 @@ COPY --link --from=downloader /target/. /
 
 RUN mkdir -pv /var/log/shanoir-ng-logs
 COPY --link shanoir-ng-datasets.jar shanoir-ng-datasets.jar
-COPY --link entrypoint entrypoint_common oneshot /bin/
+COPY --link entrypoint entrypoint_common oneshot /usr/bin/
 
 # Use the below line for remote debugging and to active dev profile
 #ENTRYPOINT ["/bin/entrypoint", "java", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=0.0.0.0:9914,suspend=y", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-jar", "/shanoir-ng-datasets.jar"]

--- a/docker-compose/datasets/Dockerfile
+++ b/docker-compose/datasets/Dockerfile
@@ -24,14 +24,19 @@ RUN wget -qO dcm4che-bin.zip \
 
 #--------------- common jre base image -------------------------------------
 FROM debian:bookworm
-# NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
-RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
+# - disable the automatic "apt-get clean" command (because we mount
+#   /var/cache/apt from an external volume to speed-up the build)
+# - NOTE: using bookworm-proposed-updates because of
+#         https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    rm /etc/apt/apt.conf.d/docker-clean \
+    && echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
     && apt-get update -qq \
     && apt-get install -qqy openjdk-17-jre-headless ca-certificates-java
 #----------------------------------------------------------------------------
 
-
-RUN apt-get update -qq \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    apt-get update -qq \
     && apt-get install -qqy \
     pigz \
     gzip \

--- a/docker-compose/datasets/Dockerfile
+++ b/docker-compose/datasets/Dockerfile
@@ -10,6 +10,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 
+FROM alpine as downloader
+
+# Installation of dcm4che into /opt/dcm4che to manage the store-scu into the
+# PACS dcm4che3, used last version 5.21.0 as available on the 2020-02-14
+# https://sourceforge.net/projects/dcm4che/files/dcm4che3/
+RUN wget -qO dcm4che-bin.zip \
+        https://downloads.sourceforge.net/project/dcm4che/dcm4che3/5.21.0/dcm4che-5.21.0-bin.zip \
+    && mkdir -p /target/opt && cd /target/opt \
+    && unzip /dcm4che-bin.zip && mv dcm4che-* dcm4che \
+    && rm    /dcm4che-bin.zip
+
+
 #--------------- common jre base image -------------------------------------
 FROM debian:bookworm
 # NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
@@ -21,24 +33,19 @@ RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /e
 
 RUN apt-get update -qq \
     && apt-get install -qqy \
-    unzip \
     pigz \
     gzip \
     locales \
-    locales-all \
-    wget
-
-# Installation of dcm4che to manage the store-scu into the PACS
-# dcm4che3, used last version 5.21.0 as available on the 2020-02-14
-# https://sourceforge.net/projects/dcm4che/files/dcm4che3/
-RUN wget -O dcm4che-5.21.0-bin.zip https://downloads.sourceforge.net/project/dcm4che/dcm4che3/5.21.0/dcm4che-5.21.0-bin.zip
-RUN unzip dcm4che-5.21.0-bin.zip
+    locales-all
 
 # take care of path
-ENV PATH /dcm4che-5.21.0/bin:$PATH
+ENV PATH /opt/dcm4che/bin:$PATH
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
+
+# install the files from the 'dowloader' stage
+COPY --link --from=downloader /target/. /
 
 RUN mkdir -pv /var/log/shanoir-ng-logs
 ADD shanoir-ng-datasets.jar shanoir-ng-datasets.jar

--- a/docker-compose/import/Dockerfile
+++ b/docker-compose/import/Dockerfile
@@ -12,8 +12,13 @@
 
 #--------------- common jre base image -------------------------------------
 FROM debian:bookworm
-# NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
-RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
+# - disable the automatic "apt-get clean" command (because we mount
+#   /var/cache/apt from an external volume to speed-up the build)
+# - NOTE: using bookworm-proposed-updates because of
+#         https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    rm /etc/apt/apt.conf.d/docker-clean \
+    && echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
     && apt-get update -qq \
     && apt-get install -qqy openjdk-17-jre-headless ca-certificates-java
 #----------------------------------------------------------------------------

--- a/docker-compose/import/Dockerfile
+++ b/docker-compose/import/Dockerfile
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 RUN mkdir -pv /var/log/shanoir-ng-logs
 
 COPY --link shanoir-ng-import.jar shanoir-ng-import.jar
-COPY --link entrypoint entrypoint_common oneshot /bin/
+COPY --link entrypoint entrypoint_common oneshot /usr/bin/
 
 # Use the below line for remote debugging and to active dev profile
 #ENTRYPOINT ["/bin/entrypoint", "java", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=0.0.0.0:9913,suspend=y", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-jar", "/shanoir-ng-import.jar"]

--- a/docker-compose/import/Dockerfile
+++ b/docker-compose/import/Dockerfile
@@ -20,8 +20,8 @@ RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /e
 
 RUN mkdir -pv /var/log/shanoir-ng-logs
 
-ADD shanoir-ng-import.jar shanoir-ng-import.jar
-COPY entrypoint entrypoint_common oneshot /bin/
+COPY --link shanoir-ng-import.jar shanoir-ng-import.jar
+COPY --link entrypoint entrypoint_common oneshot /bin/
 
 # Use the below line for remote debugging and to active dev profile
 #ENTRYPOINT ["/bin/entrypoint", "java", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=0.0.0.0:9913,suspend=y", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-jar", "/shanoir-ng-import.jar"]

--- a/docker-compose/import/Dockerfile
+++ b/docker-compose/import/Dockerfile
@@ -18,32 +18,6 @@ RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /e
     && apt-get install -qqy openjdk-17-jre-headless ca-certificates-java
 #----------------------------------------------------------------------------
 
-
-#32 bits packages are necessary
-RUN dpkg --add-architecture i386
-
-RUN apt-get update -qq \
-    && apt-get install -qqy \
-    git \
-    curl \
-    build-essential \
-    cmake \
-    pkg-config \
-    libgdcm-tools \
-    libarchive-tools \
-    unzip \
-    pigz \
-    gzip \
-    wget \
-    jq \
-    lib32z1 \
-    libgtk2.0-0 \
-    libsm6 \
-    libxext6 \
-    lib32stdc++6 \
-    libtiff6 \
-    libglib2.0-0:i386
-
 RUN mkdir -pv /var/log/shanoir-ng-logs
 
 ADD shanoir-ng-import.jar shanoir-ng-import.jar

--- a/docker-compose/keycloak-database/Dockerfile
+++ b/docker-compose/keycloak-database/Dockerfile
@@ -12,6 +12,4 @@
 
 FROM mysql/mysql-server:5.7
 
-ADD 1_add_users.sql /docker-entrypoint-initdb.d/
-
-RUN chmod a+x /docker-entrypoint-initdb.d/1_add_users.sql
+COPY --link --chmod=0755 1_add_users.sql /docker-entrypoint-initdb.d/

--- a/docker-compose/nginx/Dockerfile
+++ b/docker-compose/nginx/Dockerfile
@@ -19,7 +19,7 @@ COPY --link nginx.conf http.conf https.conf shanoir.template.conf shanoir.templa
 COPY --link viewer/app-config.js viewer/ohif-viewer.template.conf /etc/nginx/viewer/
 COPY --link --from=viewer /usr/share/nginx/html/. /etc/nginx/viewer/html/
 
-COPY --link entrypoint entrypoint_common /bin/
+COPY --link entrypoint entrypoint_common /usr/bin/
 
 
 

--- a/docker-compose/nginx/Dockerfile
+++ b/docker-compose/nginx/Dockerfile
@@ -14,16 +14,16 @@ FROM ohif/viewer:v4.12.32.19362 AS viewer
 
 FROM nginx
 
-COPY nginx.conf http.conf https.conf shanoir.template.conf shanoir.template.dev.conf shanoir.template.prod.conf /etc/nginx/
+COPY --link nginx.conf http.conf https.conf shanoir.template.conf shanoir.template.dev.conf shanoir.template.prod.conf /etc/nginx/
 
-COPY viewer/app-config.js viewer/ohif-viewer.template.conf /etc/nginx/viewer/
-COPY --from=viewer /usr/share/nginx/html/. /etc/nginx/viewer/html/
+COPY --link viewer/app-config.js viewer/ohif-viewer.template.conf /etc/nginx/viewer/
+COPY --link --from=viewer /usr/share/nginx/html/. /etc/nginx/viewer/html/
 
-COPY entrypoint entrypoint_common /bin/
+COPY --link entrypoint entrypoint_common /bin/
 
 
 
-COPY webapp/ /etc/nginx/html/
+COPY --link webapp/ /etc/nginx/html/
 
 ENTRYPOINT ["/bin/entrypoint"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose/nifti-conversion/Dockerfile
+++ b/docker-compose/nifti-conversion/Dockerfile
@@ -13,6 +13,20 @@
 ARG BASE_IMAGE="debian:bookworm"
 
 
+FROM $BASE_IMAGE as conda
+
+RUN apt-get -qqy update \
+    && apt-get -qqy --no-install-recommends install curl ca-certificates
+
+# Install miniconda
+RUN curl -LSsf -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py311_24.1.2-0-Linux-x86_64.sh \
+    && bash miniconda.sh -b \
+    && rm   miniconda.sh
+
+# Install dicomifier
+RUN /root/miniconda3/bin/conda install -c conda-forge dicomifier -y
+
+
 FROM $BASE_IMAGE as builder
 
 RUN apt-get -qqy update \
@@ -80,19 +94,6 @@ RUN apt-get update -qq \
     python3-yaml \
     software-properties-common
 
-ENV PATH="/root/miniconda3/bin:${PATH}"
-ARG PATH="/root/miniconda3/bin:${PATH}"
-
-#Install miniconda \
-RUN wget \
-    https://repo.anaconda.com/miniconda/Miniconda3-py311_24.1.2-0-Linux-x86_64.sh \
-    && mkdir /root/.conda \
-    && bash Miniconda3-py311_24.1.2-0-Linux-x86_64.sh -b \
-    && rm -f Miniconda3-py311_24.1.2-0-Linux-x86_64.sh
-
-ENV LC_ALL fr_FR.UTF-8
-ENV LANG fr_FR.UTF-8
-ENV LANGUAGE fr_FR.UTF-8
 RUN mkdir -p /opt/nifti-converters
 
 # Copy converters files
@@ -107,15 +108,13 @@ RUN cp -n           external/mcverter/linux/lib/lib*.so.* /usr/lib/x86_64-linux-
 RUN mkdir -m 1777 /.dcm2nii_2008-03-31
 RUN mkdir -m 1777 /.dcm2nii_2014-08-04
 
-# Install dicomifier
-RUN git -C /opt/nifti-converters clone https://github.com/lamyj/dicomifier.git
-RUN conda install -c conda-forge dicomifier -y
 
 # install animaConvertImage to convert Analyze format into nifti
 RUN install -m 755 external/anima/animaConvertImage /usr/local/bin/
 
-# install the binaries built in the 'builder' stage
+# install the binaries built in the 'builder' & 'conda' stages
 COPY --link --from=builder /target/. /
+COPY --link --from=conda   /root/miniconda3 /root/miniconda3
 
 # update the ld cache (so that the new libraries can be loaded)
 RUN ldconfig
@@ -124,5 +123,10 @@ RUN mkdir -pv /var/log/shanoir-ng-logs
 
 ADD nifti-conversion.jar nifti-conversion.jar
 COPY entrypoint entrypoint_common oneshot /bin/
+
+ENV LC_ALL fr_FR.UTF-8
+ENV LANG fr_FR.UTF-8
+ENV LANGUAGE fr_FR.UTF-8
+ENV PATH="/root/miniconda3/bin:${PATH}"
 
 ENTRYPOINT ["/bin/entrypoint", "java", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-jar", "/nifti-conversion.jar"]

--- a/docker-compose/nifti-conversion/Dockerfile
+++ b/docker-compose/nifti-conversion/Dockerfile
@@ -58,41 +58,19 @@ FROM $BASE_IMAGE as final
 # NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
 RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
     && apt-get update -qq \
-    && apt-get install -qqy openjdk-17-jdk ca-certificates-java
+    && apt-get install -qqy openjdk-17-jre ca-certificates-java
 
-#32 bits packages are necessary
-RUN dpkg --add-architecture i386
-RUN apt-get update
-
-RUN apt-get update -qq \
-    && apt-get install -y \
-    git \
-    curl \
-    cmake \
-    build-essential \
-    pkg-config \
+# xvfb+gtk2 needed by mri_conv (headless mode not supported by DicomToNifti)
+# see: https://populse.github.io/mri_conv/Installation/installation.html#scriptwithoutGUI
+RUN apt-get update -qqy \
+    && apt-get install -qqy \
     libgdcm-tools \
-    libarchive-tools \
-    unzip \
-    pigz \
-    gzip \
-    gnupg \
-    wget \
-    jq \
-    lib32z1 \
-    libgtk2.0-0 \
-    libsm6 \
-    libxext6 \
-    lib32stdc++6 \
-    libtiff6 \
-    libglib2.0-0:i386 \
     locales \
     locales-all \
-    xvfb \
-    python3.11 \
-    python3-werkzeug \
-    python3-yaml \
-    software-properties-common
+    jq \
+    libgtk2.0-0 \
+    pigz \
+    xvfb
 
 RUN mkdir -p /opt/nifti-converters
 

--- a/docker-compose/nifti-conversion/Dockerfile
+++ b/docker-compose/nifti-conversion/Dockerfile
@@ -62,13 +62,18 @@ RUN mkdir -p /target/opt/nifti-converters/mriconverter \
     && chmod 0777 . MRIFileManager/MRIManager.jar
 
 
-FROM base_image as final
-
-# NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
+#--------------- common jre base image -------------------------------------
+FROM debian:bookworm as final
+# - disable the automatic "apt-get clean" command (because we mount
+#   /var/cache/apt from an external volume to speed-up the build)
+# - NOTE: using bookworm-proposed-updates because of
+#         https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
+    rm /etc/apt/apt.conf.d/docker-clean \
+    && echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
     && apt-get update -qq \
-    && apt-get install -qqy openjdk-17-jre ca-certificates-java
+    && apt-get install -qqy openjdk-17-jre-headless ca-certificates-java
+#----------------------------------------------------------------------------
 
 # xvfb+gtk2 needed by mri_conv (headless mode not supported by DicomToNifti)
 # see: https://populse.github.io/mri_conv/Installation/installation.html#scriptwithoutGUI
@@ -80,6 +85,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     locales-all \
     jq \
     libgtk2.0-0 \
+    openjdk-17-jre \
     pigz \
     xvfb
 

--- a/docker-compose/nifti-conversion/Dockerfile
+++ b/docker-compose/nifti-conversion/Dockerfile
@@ -112,7 +112,7 @@ RUN ldconfig \
 
 # install the microservice
 COPY --link nifti-conversion.jar nifti-conversion.jar
-COPY --link entrypoint entrypoint_common oneshot /bin/
+COPY --link entrypoint entrypoint_common oneshot /usr/bin/
 
 ENV LC_ALL fr_FR.UTF-8
 ENV LANG fr_FR.UTF-8

--- a/docker-compose/nifti-conversion/Dockerfile
+++ b/docker-compose/nifti-conversion/Dockerfile
@@ -72,35 +72,30 @@ RUN apt-get update -qqy \
     pigz \
     xvfb
 
-RUN mkdir -p /opt/nifti-converters
-
 # Copy converters files
-RUN mkdir external
-COPY external ./external
-RUN install -m 0755 external/dcm2nii/linux/31MARCH2008/dcm2nii /opt/nifti-converters/dcm2nii_2008-03-31
-RUN install -m 0755 external/dcm2nii/linux/dcm2nii /opt/nifti-converters/dcm2nii_2014-08-04
-
-RUN install -m 0755 external/mcverter/linux/mcverter_* /opt/nifti-converters/
-RUN cp -n           external/mcverter/linux/lib/lib*.so.* /usr/lib/x86_64-linux-gnu/
-
-RUN mkdir -m 1777 /.dcm2nii_2008-03-31
-RUN mkdir -m 1777 /.dcm2nii_2014-08-04
-
+COPY --link --chmod=0755 external/dcm2nii/linux/31MARCH2008/dcm2nii /opt/nifti-converters/dcm2nii_2008-03-31
+COPY --link --chmod=0755 external/dcm2nii/linux/dcm2nii             /opt/nifti-converters/dcm2nii_2014-08-04
+COPY --link --chmod=0755 external/mcverter/linux/mcverter_*         /opt/nifti-converters/
+COPY --link external/mcverter/linux/lib/lib*.so.*                   /usr/local/lib/x86_64-linux-gnu/
+RUN mkdir -m 1777 \
+    /.dcm2nii_2008-03-31 \
+    /.dcm2nii_2014-08-04
 
 # install animaConvertImage to convert Analyze format into nifti
-RUN install -m 755 external/anima/animaConvertImage /usr/local/bin/
+COPY --link --chmod=0755 external/anima/animaConvertImage /usr/local/bin/
 
 # install the binaries built in the 'builder' & 'conda' stages
 COPY --link --from=builder /target/. /
 COPY --link --from=conda   /root/miniconda3 /root/miniconda3
 
 # update the ld cache (so that the new libraries can be loaded)
-RUN ldconfig
+# and make the log dir
+RUN ldconfig \
+    && mkdir -pv /var/log/shanoir-ng-logs
 
-RUN mkdir -pv /var/log/shanoir-ng-logs
-
-ADD nifti-conversion.jar nifti-conversion.jar
-COPY entrypoint entrypoint_common oneshot /bin/
+# install the microservice
+COPY --link nifti-conversion.jar nifti-conversion.jar
+COPY --link entrypoint entrypoint_common oneshot /bin/
 
 ENV LC_ALL fr_FR.UTF-8
 ENV LANG fr_FR.UTF-8

--- a/docker-compose/nifti-conversion/Dockerfile
+++ b/docker-compose/nifti-conversion/Dockerfile
@@ -10,7 +10,36 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 
-FROM debian:bookworm
+ARG BASE_IMAGE="debian:bookworm"
+
+
+FROM $BASE_IMAGE as builder
+
+RUN apt-get -qqy update \
+    && apt-get -qqy install \
+        build-essential \
+        curl \
+        cmake \
+        git \
+        pkg-config
+
+# Compile DCM2NIIX from source
+ENV DCM2NIIX_VERSION=v1.0.20210317
+RUN mkdir /src && cd /src \
+    && curl -LSsf https://github.com/rordenlab/dcm2niix/archive/refs/tags/$DCM2NIIX_VERSION.tar.gz \
+    | tar zx \
+    && cd dcm2niix-* && mkdir build \
+    && cd build && cmake .. && make -j4 && make install DESTDIR=/target
+
+# Install mri_conv
+RUN mkdir -p /target/opt/nifti-converters/mriconverter \
+    && cd       /target/opt/nifti-converters/mriconverter \
+    && curl -LSsf https://github.com/populse/mri_conv/archive/refs/heads/master.tar.gz \
+    | tar zx --strip-components 1 \
+    && chmod 0777 . MRIFileManager/MRIManager.jar
+
+
+FROM $BASE_IMAGE as final
 
 # NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
 RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
@@ -61,24 +90,9 @@ RUN wget \
     && bash Miniconda3-py311_24.1.2-0-Linux-x86_64.sh -b \
     && rm -f Miniconda3-py311_24.1.2-0-Linux-x86_64.sh
 
-
-# Compile DCM2NIIX from source
-ENV DCMCOMMIT_VERSION=v1.0.20210317
-ENV DCMCOMMIT=1.0.20210317
 ENV LC_ALL fr_FR.UTF-8
 ENV LANG fr_FR.UTF-8
 ENV LANGUAGE fr_FR.UTF-8
-
-WORKDIR /usr/local/
-RUN curl -#L  https://github.com/rordenlab/dcm2niix/archive/refs/tags/$DCMCOMMIT_VERSION.zip | bsdtar -xf- -C .
-WORKDIR /usr/local/dcm2niix-${DCMCOMMIT}
-RUN mkdir build
-WORKDIR /usr/local/dcm2niix-${DCMCOMMIT}/build
-RUN cmake ..
-RUN make install
-
-WORKDIR /
-
 RUN mkdir -p /opt/nifti-converters
 
 # Copy converters files
@@ -90,15 +104,6 @@ RUN install -m 0755 external/dcm2nii/linux/dcm2nii /opt/nifti-converters/dcm2nii
 RUN install -m 0755 external/mcverter/linux/mcverter_* /opt/nifti-converters/
 RUN cp -n           external/mcverter/linux/lib/lib*.so.* /usr/lib/x86_64-linux-gnu/
 
-WORKDIR /opt/nifti-converters
-RUN mkdir mriconverter
-RUN curl -#L  https://github.com/populse/mri_conv/archive/refs/heads/master.zip | bsdtar -xf- -C mriconverter --strip-components 1
-
-RUN chmod 777 /opt/nifti-converters/mriconverter
-RUN chmod 777 /opt/nifti-converters/mriconverter/MRIFileManager/MRIManager.jar
-
-WORKDIR /
-
 RUN mkdir -m 1777 /.dcm2nii_2008-03-31
 RUN mkdir -m 1777 /.dcm2nii_2014-08-04
 
@@ -108,6 +113,12 @@ RUN conda install -c conda-forge dicomifier -y
 
 # install animaConvertImage to convert Analyze format into nifti
 RUN install -m 755 external/anima/animaConvertImage /usr/local/bin/
+
+# install the binaries built in the 'builder' stage
+COPY --link --from=builder /target/. /
+
+# update the ld cache (so that the new libraries can be loaded)
+RUN ldconfig
 
 RUN mkdir -pv /var/log/shanoir-ng-logs
 

--- a/docker-compose/nifti-conversion/Dockerfile
+++ b/docker-compose/nifti-conversion/Dockerfile
@@ -10,26 +10,35 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 
-ARG BASE_IMAGE="debian:bookworm"
+FROM debian:bookworm as base_image
 
+# - disable the automatic "apt-get clean" command (because we mount
+#   /var/cache/apt from an external volume to speed-up the build)
+# - run "apt-get update" now (to avoid downloading the lists 3 times)
+RUN rm /etc/apt/apt.conf.d/docker-clean \
+    && apt-get update -qq
 
-FROM $BASE_IMAGE as conda
+FROM base_image as conda
 
-RUN apt-get -qqy update \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-conda \
+    apt-get -qqy update \
     && apt-get -qqy --no-install-recommends install curl ca-certificates
 
 # Install miniconda
-RUN curl -LSsf -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py311_24.1.2-0-Linux-x86_64.sh \
-    && bash miniconda.sh -b \
+RUN --mount=type=cache,target=/root/miniconda3/pkgs \
+    curl -LSsf -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py311_24.1.2-0-Linux-x86_64.sh \
+    && bash miniconda.sh -fb \
     && rm   miniconda.sh
 
 # Install dicomifier
-RUN /root/miniconda3/bin/conda install -c conda-forge dicomifier -y
+RUN --mount=type=cache,target=/root/miniconda3/pkgs \
+    /root/miniconda3/bin/conda install -c conda-forge dicomifier -y
 
 
-FROM $BASE_IMAGE as builder
+FROM base_image as builder
 
-RUN apt-get -qqy update \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-builder \
+    apt-get -qqy update \
     && apt-get -qqy install \
         build-essential \
         curl \
@@ -53,16 +62,18 @@ RUN mkdir -p /target/opt/nifti-converters/mriconverter \
     && chmod 0777 . MRIFileManager/MRIManager.jar
 
 
-FROM $BASE_IMAGE as final
+FROM base_image as final
 
 # NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
-RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
     && apt-get update -qq \
     && apt-get install -qqy openjdk-17-jre ca-certificates-java
 
 # xvfb+gtk2 needed by mri_conv (headless mode not supported by DicomToNifti)
 # see: https://populse.github.io/mri_conv/Installation/installation.html#scriptwithoutGUI
-RUN apt-get update -qqy \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    apt-get update -qqy \
     && apt-get install -qqy \
     libgdcm-tools \
     locales \

--- a/docker-compose/nifti-conversion/Dockerfile
+++ b/docker-compose/nifti-conversion/Dockerfile
@@ -25,14 +25,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-conda \
     && apt-get -qqy --no-install-recommends install curl ca-certificates
 
 # Install miniconda
-RUN --mount=type=cache,target=/root/miniconda3/pkgs \
+RUN --mount=type=cache,target=/opt/miniconda3/pkgs \
     curl -LSsf -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py311_24.1.2-0-Linux-x86_64.sh \
-    && bash miniconda.sh -fb \
+    && bash miniconda.sh -fb -p /opt/miniconda3 \
     && rm   miniconda.sh
 
 # Install dicomifier
-RUN --mount=type=cache,target=/root/miniconda3/pkgs \
-    /root/miniconda3/bin/conda install -c conda-forge dicomifier -y
+RUN --mount=type=cache,target=/opt/miniconda3/pkgs \
+    /opt/miniconda3/bin/conda install -c conda-forge dicomifier -y
 
 
 FROM base_image as builder
@@ -97,7 +97,7 @@ COPY --link --chmod=0755 external/anima/animaConvertImage /usr/local/bin/
 
 # install the binaries built in the 'builder' & 'conda' stages
 COPY --link --from=builder /target/. /
-COPY --link --from=conda   /root/miniconda3 /root/miniconda3
+COPY --link --from=conda   /opt/miniconda3 /opt/miniconda3
 
 # update the ld cache (so that the new libraries can be loaded)
 # and make the log dir
@@ -111,6 +111,6 @@ COPY --link entrypoint entrypoint_common oneshot /bin/
 ENV LC_ALL fr_FR.UTF-8
 ENV LANG fr_FR.UTF-8
 ENV LANGUAGE fr_FR.UTF-8
-ENV PATH="/root/miniconda3/bin:${PATH}"
+ENV PATH="/opt/miniconda3/bin:${PATH}"
 
 ENTRYPOINT ["/bin/entrypoint", "java", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-jar", "/nifti-conversion.jar"]

--- a/docker-compose/preclinical/Dockerfile
+++ b/docker-compose/preclinical/Dockerfile
@@ -8,9 +8,9 @@ RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /e
 
 
 RUN mkdir -pv /var/log/shanoir-ng-logs
-ADD shanoir-ng-preclinical.jar shanoir-ng-preclinical.jar
+COPY --link shanoir-ng-preclinical.jar shanoir-ng-preclinical.jar
 
-COPY entrypoint entrypoint_common oneshot /bin/
+COPY --link entrypoint entrypoint_common oneshot /bin/
 
 # Use the below line for remote debugging
 #ENTRYPOINT ["/bin/entrypoint", "java", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=0.0.0.0:9915,suspend=y", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-Dspring.profiles.active=dev", "-jar", "/shanoir-ng-preclinical.jar"]

--- a/docker-compose/preclinical/Dockerfile
+++ b/docker-compose/preclinical/Dockerfile
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 RUN mkdir -pv /var/log/shanoir-ng-logs
 COPY --link shanoir-ng-preclinical.jar shanoir-ng-preclinical.jar
 
-COPY --link entrypoint entrypoint_common oneshot /bin/
+COPY --link entrypoint entrypoint_common oneshot /usr/bin/
 
 # Use the below line for remote debugging
 #ENTRYPOINT ["/bin/entrypoint", "java", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=0.0.0.0:9915,suspend=y", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-Dspring.profiles.active=dev", "-jar", "/shanoir-ng-preclinical.jar"]

--- a/docker-compose/preclinical/Dockerfile
+++ b/docker-compose/preclinical/Dockerfile
@@ -1,7 +1,12 @@
 #--------------- common jre base image -------------------------------------
 FROM debian:bookworm
-# NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
-RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
+# - disable the automatic "apt-get clean" command (because we mount
+#   /var/cache/apt from an external volume to speed-up the build)
+# - NOTE: using bookworm-proposed-updates because of
+#         https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    rm /etc/apt/apt.conf.d/docker-clean \
+    && echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
     && apt-get update -qq \
     && apt-get install -qqy openjdk-17-jre-headless ca-certificates-java
 #----------------------------------------------------------------------------

--- a/docker-compose/solr/Dockerfile
+++ b/docker-compose/solr/Dockerfile
@@ -13,10 +13,10 @@
 FROM solr:8.1
 
 USER root
-RUN mkdir -p /etc/shanoir-core-template
-RUN chown solr:solr /etc/shanoir-core-template
+RUN mkdir -p /etc/shanoir-core-template \
+    && chown solr:solr /etc/shanoir-core-template
 USER solr
 
-COPY ./core /etc/shanoir-core-template
+COPY --link ./core /etc/shanoir-core-template
 
 CMD ["solr-precreate", "shanoir", "/etc/shanoir-core-template"]

--- a/docker-compose/studies/Dockerfile
+++ b/docker-compose/studies/Dockerfile
@@ -12,8 +12,13 @@
 
 #--------------- common jre base image -------------------------------------
 FROM debian:bookworm
-# NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
-RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
+# - disable the automatic "apt-get clean" command (because we mount
+#   /var/cache/apt from an external volume to speed-up the build)
+# - NOTE: using bookworm-proposed-updates because of
+#         https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    rm /etc/apt/apt.conf.d/docker-clean \
+    && echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
     && apt-get update -qq \
     && apt-get install -qqy openjdk-17-jre-headless ca-certificates-java
 #----------------------------------------------------------------------------

--- a/docker-compose/studies/Dockerfile
+++ b/docker-compose/studies/Dockerfile
@@ -20,9 +20,9 @@ RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /e
 
 
 RUN mkdir -pv /var/log/shanoir-ng-logs
-ADD shanoir-ng-studies.jar shanoir-ng-studies.jar
+COPY --link shanoir-ng-studies.jar shanoir-ng-studies.jar
 
-COPY entrypoint entrypoint_common oneshot /bin/
+COPY --link entrypoint entrypoint_common oneshot /bin/
 
 # Use the below line for remote debugging and to active dev profile
 #ENTRYPOINT ["/bin/entrypoint", "java", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=0.0.0.0:9912,suspend=y", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-jar", "/shanoir-ng-studies.jar"]

--- a/docker-compose/studies/Dockerfile
+++ b/docker-compose/studies/Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 RUN mkdir -pv /var/log/shanoir-ng-logs
 COPY --link shanoir-ng-studies.jar shanoir-ng-studies.jar
 
-COPY --link entrypoint entrypoint_common oneshot /bin/
+COPY --link entrypoint entrypoint_common oneshot /usr/bin/
 
 # Use the below line for remote debugging and to active dev profile
 #ENTRYPOINT ["/bin/entrypoint", "java", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=0.0.0.0:9912,suspend=y", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-jar", "/shanoir-ng-studies.jar"]

--- a/docker-compose/users/Dockerfile
+++ b/docker-compose/users/Dockerfile
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 RUN mkdir -pv /var/log/shanoir-ng-logs
 COPY --link shanoir-ng-users.jar shanoir-ng-users.jar
-COPY --link entrypoint entrypoint_common oneshot /bin/
+COPY --link entrypoint entrypoint_common oneshot /usr/bin/
 
 # Use the below line for remote debugging and development profile purpose
 #ENTRYPOINT ["/bin/entrypoint", "java", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=0.0.0.0:9911,suspend=y", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-Dspring.profiles.active=dev", "-jar", "/shanoir-ng-users.jar", "--syncAllUsersToKeycloak=true"]

--- a/docker-compose/users/Dockerfile
+++ b/docker-compose/users/Dockerfile
@@ -22,8 +22,8 @@ RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /e
 RUN apt-get update -qq && apt-get install -qqy openssl
 
 RUN mkdir -pv /var/log/shanoir-ng-logs
-ADD shanoir-ng-users.jar shanoir-ng-users.jar
-COPY entrypoint entrypoint_common oneshot /bin/
+COPY --link shanoir-ng-users.jar shanoir-ng-users.jar
+COPY --link entrypoint entrypoint_common oneshot /bin/
 
 # Use the below line for remote debugging and development profile purpose
 #ENTRYPOINT ["/bin/entrypoint", "java", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=0.0.0.0:9911,suspend=y", "-Djava.security.egd=file:/dev/./urandom", "-Djavax.net.ssl.trustStorePassword=changeit", "-Dspring.profiles.active=dev", "-jar", "/shanoir-ng-users.jar", "--syncAllUsersToKeycloak=true"]

--- a/docker-compose/users/Dockerfile
+++ b/docker-compose/users/Dockerfile
@@ -12,14 +12,19 @@
 
 #--------------- common jre base image -------------------------------------
 FROM debian:bookworm
-# NOTE: using bookworm-proposed-updates because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
-RUN echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
+# - disable the automatic "apt-get clean" command (because we mount
+#   /var/cache/apt from an external volume to speed-up the build)
+# - NOTE: using bookworm-proposed-updates because of
+#         https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039472
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    rm /etc/apt/apt.conf.d/docker-clean \
+    && echo "deb http://deb.debian.org/debian bookworm-proposed-updates main" >> /etc/apt/sources.list \
     && apt-get update -qq \
     && apt-get install -qqy openjdk-17-jre-headless ca-certificates-java
 #----------------------------------------------------------------------------
 
-
-RUN apt-get update -qq && apt-get install -qqy openssl
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    apt-get update -qq && apt-get install -qqy openssl
 
 RUN mkdir -pv /var/log/shanoir-ng-logs
 COPY --link shanoir-ng-users.jar shanoir-ng-users.jar


### PR DESCRIPTION
Here is a series of optimisations to reduce the build time and image sizes thanks to various buildkit features. I documented them in `docker-compose/README.md`

With these optimisations, building the images with *docker buildx bake* on the github runners roughly takes: 
- 10 minutes for the initial build
   ```
  468.1s  [nifti-conversion]
  142.3s  [datasets]
   84.2s  [keycloak]
   81.3s  [preclinical]
   59.0s  [studies]
   51.6s  [import]
   48.2s  [users]
   38.3s  [keycloak-database]
   35.3s  [solr]
    8.9s  [nginx]
    2.0s  [database]
   ```
- 50 seconds for the next builds (minimum time when the dockerfile are unchanged)
   ```
   33.4s  [nifti-conversion]
   31.2s  [keycloak]
   30.2s  [preclinical]
   23.0s  [datasets]
   20.9s  [studies]
   18.3s  [users]
    5.9s  [import]
    3.6s  [solr]
    1.7s  [nginx]
    0.8s  [database]
    0.0s  [keycloak-database]
   ```

Now the new bottleneck is the maven build (around 2m30).

