### PR TITLE
shanoir-issue#2228: remove condition 'is admin' to make a study a challenge

### DIFF
--- a/shanoir-ng-front/src/app/studies/study/study.component.html
+++ b/shanoir-ng-front/src/app/studies/study/study.component.html
@@ -206,7 +206,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 							</ng-template>
 						</span>
 					</li>
-					<li *ngIf="keycloakService.isUserAdmin()">
+					<li>
 						<label i18n="Study detail|Challenge label@@studyDetailChalenge">Challenge</label>
 						<span class="right-col" [ngSwitch]="mode">
 							<ng-template [ngSwitchCase]="'view'">

--- a/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/service/StudyServiceImpl.java
+++ b/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/service/StudyServiceImpl.java
@@ -257,9 +257,7 @@ public class StudyServiceImpl implements StudyService {
 		studyDb.setClinical(study.isClinical());
 		studyDb.setDownloadableByDefault(study.isDownloadableByDefault());
 		studyDb.setEndDate(study.getEndDate());
-		if (KeycloakUtil.getTokenRoles().contains("ROLE_ADMIN")) {
-			studyDb.setChallenge(study.isChallenge());
-		}
+		studyDb.setChallenge(study.isChallenge());
 		studyDb.setName(study.getName());
 		studyDb.setProfile(study.getProfile());
 		studyDb.setDescription(study.getDescription());


### PR DESCRIPTION
How to test:
As an expert, create a study
Make sure to have the admin rights
Edit study
Check the "challenge" checkbox and save

Before this PR, we had to be an admin to make it a challenge, now an expert can do it.