### PR TITLE
dicom vr ds & di better vm management (slice thickness is float array bug)

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/controler/StudyCardApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/controler/StudyCardApiController.java
@@ -184,8 +184,8 @@ public class StudyCardApiController implements StudyCardApi {
                     if (field.getType().getName() == "int") {
                         int tagCode = field.getInt(null);
                         VR tagVr = StandardElementDictionary.INSTANCE.vrOf(tagCode);
-                        DicomTagType tagType = DicomTagType.valueOf(tagVr);
                         VM tagVm = VM.of(tagCode);
+                        DicomTagType tagType = DicomTagType.valueOf(tagVr, tagVm);
                         dicomTags.add(new DicomTag(tagCode, field.getName(), tagType, tagVm));
                     }
                     // longs actually code a date and a time, see Tag.class
@@ -196,10 +196,12 @@ public class StudyCardApiController implements StudyCardApi {
                         String timeStr = hexStr.substring(8);
                         int dateTagCode = Integer.parseInt(dateStr, 16);
                         int timeTagCode = Integer.parseInt(timeStr, 16);
-                        DicomTagType dateTagType = DicomTagType.valueOf(StandardElementDictionary.INSTANCE.vrOf(dateTagCode));
-                        DicomTagType timeTagType = DicomTagType.valueOf(StandardElementDictionary.INSTANCE.vrOf(timeTagCode));
-                        dicomTags.add(new DicomTag(dateTagCode, name + "Date", dateTagType, VM.of(dateTagCode)));
-                        dicomTags.add(new DicomTag(timeTagCode, name + "Time", timeTagType, VM.of(timeTagCode)));
+                        VM dateVm = VM.of(dateTagCode);
+                        VM timeVm = VM.of(timeTagCode);
+                        DicomTagType dateTagType = DicomTagType.valueOf(StandardElementDictionary.INSTANCE.vrOf(dateTagCode), dateVm);
+                        DicomTagType timeTagType = DicomTagType.valueOf(StandardElementDictionary.INSTANCE.vrOf(timeTagCode), timeVm);
+                        dicomTags.add(new DicomTag(dateTagCode, name + "Date", dateTagType, dateVm));
+                        dicomTags.add(new DicomTag(timeTagCode, name + "Time", timeTagType, timeVm));
                     }
                 }
             }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/controler/StudyCardApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/controler/StudyCardApiController.java
@@ -27,6 +27,7 @@ import org.shanoir.ng.shared.error.FieldErrorMap;
 import org.shanoir.ng.shared.exception.*;
 import org.shanoir.ng.solr.service.SolrService;
 import org.shanoir.ng.studycard.dto.DicomTag;
+import org.shanoir.ng.studycard.model.Cardinality;
 import org.shanoir.ng.studycard.model.DicomTagType;
 import org.shanoir.ng.studycard.model.StudyCard;
 import org.shanoir.ng.studycard.model.StudyCardApply;

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/model/Cardinality.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/model/Cardinality.java
@@ -26,6 +26,8 @@ public class Cardinality {
 
 	boolean isMultiplier; 
 
+	public static Cardinality ONE = new Cardinality(1); 
+
 	Cardinality(String str) {
 		String strCopy = new String(str);
 		if ("n".equals(str)) {

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/model/Cardinality.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/model/Cardinality.java
@@ -65,6 +65,18 @@ public class Cardinality {
 		this.isMultiplier = isMultiplier;
 	}
 
+	@Override
+	public boolean equals(Object obj) {
+		return obj != null && obj instanceof Cardinality 
+			&& ((Cardinality) obj).isMultiplier() == this.isMultiplier()
+			&& ((Cardinality) obj).getNumber() == this.getNumber();
+	}
+
+	@Override
+	public String toString() {
+		return getNumber() + (isMultiplier() ? "N" : "");
+	}
+
 }
 
 

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/model/DicomTagType.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/model/DicomTagType.java
@@ -24,7 +24,7 @@ public enum DicomTagType {
 	 */
 	String, Long, Float, Double, Integer, Binary, Date, FloatArray, IntArray;
 	
-	public static DicomTagType valueOf(VR vr) {
+	public static DicomTagType valueOf(VR vr, VM vm) {
 		if (	   vr.equals(VR.AE)
 				|| vr.equals(VR.AS) // Age special format
 				|| vr.equals(VR.CS)
@@ -53,7 +53,8 @@ public enum DicomTagType {
 			return DicomTagType.Date;
 			
 		} else if (vr.equals(VR.FL)
-				|| vr.equals(VR.OF)) {
+				|| vr.equals(VR.OF)
+				|| (vr.equals(VR.DS) && Cardinality.ONE.equals(vm.getMax()))) {
 			return DicomTagType.Float;
 			
 		} else if (vr.equals(VR.FD)
@@ -61,7 +62,8 @@ public enum DicomTagType {
 			return DicomTagType.Double;
 			
 		} else if (vr.equals(VR.SS)
-				|| vr.equals(VR.US)) {
+				|| vr.equals(VR.US)
+				|| (vr.equals(VR.IS) && Cardinality.ONE.equals(vm.getMax()))) {
 			return DicomTagType.Integer;
 		
 		} else if (vr.equals(VR.OL)

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/model/VM.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/model/VM.java
@@ -57,6 +57,11 @@ public class VM {
 	public void setMax(Cardinality max) {
 		this.max = max;
 	}
+
+	@Override
+	public String toString() {
+		return getMin() + "-" + getMax().toString();
+	}
 	
 	public static VM of(int tag) {
 		if (Tag.OffendingElement == tag) return new VM("1-n");

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/model/condition/StudyCardDICOMConditionOnDatasets.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/model/condition/StudyCardDICOMConditionOnDatasets.java
@@ -33,6 +33,7 @@ import org.shanoir.ng.download.WADODownloaderService;
 import org.shanoir.ng.shared.exception.PacsException;
 import org.shanoir.ng.studycard.model.DicomTagType;
 import org.shanoir.ng.studycard.model.Operation;
+import org.shanoir.ng.studycard.model.VM;
 import org.shanoir.ng.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -171,7 +172,8 @@ public class StudyCardDICOMConditionOnDatasets extends StudyCardCondition {
             throw new IllegalArgumentException("dicomAttributes can't be null");
         }
         VR tagVr = StandardElementDictionary.INSTANCE.vrOf(dicomTag);
-        DicomTagType tagType = DicomTagType.valueOf(tagVr);
+        VM tagVm = VM.of(dicomTag);
+        DicomTagType tagType = DicomTagType.valueOf(tagVr, tagVm);
         if (!this.getOperation().compatibleWith(tagType)) {
             if (errorMsg != null) errorMsg.append("\ncondition [" + toString() 
                     + "] failed on dataset " + datasetId + " because the operation " + this.getOperation() + " is not compatible with dicom tag " 


### PR DESCRIPTION
in study cards & quality cards conditions, Slice Thickness (and others) dicom tag should not be <FloatArray> but just <Float>.

The problem was that the dicom Value Representation (VR) named Decimal String (DS) can be arrays or single values so I changed the conversion rules.