### PR TITLE
Correct right check on update dataset tags endpoint

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/controler/DatasetApi.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/controler/DatasetApi.java
@@ -327,7 +327,7 @@ public interface DatasetApi {
 			@RequestParam(value = "datasetIds", required = true) List<Long> datasetIds);
 
 	@Operation(summary = "", description = "Updates the study tags of a dataset")
-	@ApiResponses(value = { @ApiResponse(responseCode = "204", description = "dataset study tags updated"),
+	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "dataset study tags updated"),
 			@ApiResponse(responseCode = "401", description = "unauthorized"),
 			@ApiResponse(responseCode = "403", description = "forbidden"),
 			@ApiResponse(responseCode = "404", description = "dataset does not exists"),

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/controler/DatasetApi.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/controler/DatasetApi.java
@@ -335,7 +335,7 @@ public interface DatasetApi {
 			@ApiResponse(responseCode = "500", description = "unexpected error") })
 	@PutMapping(value = "/{datasetId}/tags", produces = { "application/json" }, consumes = {
 			"application/json" })
-	@PreAuthorize("hasRole('ADMIN') or (hasRole('EXPERT') and @datasetSecurityService.hasUpdateRightOnDataset(#dataset, 'CAN_ADMINISTRATE'))")
+	@PreAuthorize("hasRole('ADMIN') or (hasRole('EXPERT') and @datasetSecurityService.hasRightOnDataset(#datasetId, 'CAN_ADMINISTRATE'))")
 	ResponseEntity<Void> updateDatasetTags(
 			@Parameter(description = "id of the dataset", required = true) @PathVariable("datasetId") Long datasetId,
 			@io.swagger.v3.oas.annotations.parameters.RequestBody(description = "array of study tag ids", required = true) @RequestBody List<Long> studyTagIds,


### PR DESCRIPTION
# Changes
- Correct "Dataset cannot be null here" error when updating dataset tags

# How to test

## Set dataset tags

**Use datasets swagger**, or :

This cURL example set study tags 8, 9, 10 to dataset 2
(Change `[TOKEN]` before executing, copy it from browser console)

``` shell
curl --insecure -X 'PUT' 'https://shanoir-ng-nginx/shanoir-ng/datasets/datasets/2/tags' \
-H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0' \
-H 'Accept: application/json, text/plain, */*' \
-H 'Accept-Language: fr,fr-FR;q=0.8,en-US;q=0.5,en;q=0.3' \
-H 'Accept-Encoding: gzip, deflate, br' \
-H 'Authorization: Bearer [TOKEN]' \
-H 'Content-Type: application/json' \
-H 'Connection: keep-alive' \
-H 'Sec-Fetch-Dest: empty' \
-H 'Sec-Fetch-Mode: cors' \
-H 'Sec-Fetch-Site: same-origin' \
-d '[
  8, 9, 10
]'
```
- Check that new dataset tag is indexed into Solr
- Check that study tag can't be deleted if linked to dataset(s)
- Check that tags and datasets that are not on the same study can't be associated