### PR TITLE
#2293-updated-exam-bug

### DIFF
--- a/docker-compose/database/db-changes/datasets/0050_examination_update_bug
+++ b/docker-compose/database/db-changes/datasets/0050_examination_update_bug
@@ -1,0 +1,8 @@
+# List of datasets not correctly updated
+
+UPDATE dataset d SET d.subject_id =
+    (SELECT e.subject_id FROM examination e WHERE e.id =
+        (SELECT examination_id FROM dataset_acquisition da WHERE da.id = d.dataset_acquisition_id))
+WHERE d.subject_id !=
+    (SELECT e.subject_id from examination e WHERE e.id =
+        (SELECT examination_id from dataset_acquisition da WHERE da.id = d.dataset_acquisition_id));

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/examination/ExaminationServiceTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/examination/ExaminationServiceTest.java
@@ -35,7 +35,6 @@ import org.shanoir.ng.study.rights.StudyRightsService;
 import org.shanoir.ng.utils.ModelsUtil;
 import org.shanoir.ng.utils.usermock.WithMockKeycloakUser;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -131,7 +130,7 @@ public class ExaminationServiceTest {
 	public void updateAsAdminTest() throws ShanoirException {
 		// We update the subject -> admin -> SUCCESS
 		Examination updatedExam = createExamination();
-		updatedExam.setSubject(null);
+		updatedExam.setSubject(new Subject(5L, "new name"));
 		final Examination updatedExamination = examinationService.update(updatedExam);
 
 		Assertions.assertNotNull(updatedExamination);


### PR DESCRIPTION
- SQL script to correct updated exams's datasets
- Correct exam update logic

Closes #2293 

How to test:
- Datasets are now downloadable (see [507770](https://shanoir-qualif.irisa.fr/shanoir-ng/dataset/details/507770))
- Update an examination to change subject -> datasets subject are also updated.
