### PR TITLE
[fli-iam#2285] Dataset tags optimisations & corrections

### DIFF
--- a/docker-compose/database/oneshot-updates/tag_ofsep_organs.sql
+++ b/docker-compose/database/oneshot-updates/tag_ofsep_organs.sql
@@ -1,21 +1,42 @@
+-- Remove all volume.organ dataset_tags
+
+DELETE FROM datasets.dataset_tag
+WHERE study_tag_id IN (SELECT id FROM datasets.study_tag WHERE name LIKE 'volume.organ:%');
+
+-- Remove all volume.organ study_tags in datasets and studies MS
+
+DELETE FROM studies.study_tag
+WHERE name LIKE 'volume.organ:%';
+
+DELETE FROM datasets.study_tag
+WHERE name LIKE 'volume.organ:%';
+
+-- Correct study_id of dataset_processings
+
+UPDATE dataset_processing dp SET dp.study_id = (SELECT e.study_id FROM examination e
+INNER JOIN dataset_acquisition da ON da.examination_id = e.id
+INNER JOIN dataset ds ON ds.dataset_acquisition_id = da.id
+WHERE ds.id = (SELECT iddp.dataset_id FROM input_of_dataset_processing iddp WHERE dp.id = iddp.processing_id LIMIT 1))
+WHERE dp.parent_id IS NOT NULL;
+
 -- Create study_tags in studies for all relevant studies
 
 INSERT INTO studies.study_tag (color, name, study_id)
 SELECT DISTINCT '#e74c3c', 'volume.organ:brain', proc.study_id 
 FROM datasets.dataset_property prop
-INNER JOIN datasets.dataset_processing proc ON proc.id = prop.dataset_processing_id
+INNER JOIN datasets.dataset_processing proc ON proc.parent_id = prop.dataset_processing_id
 WHERE prop.name = 'volume.organ' AND prop.value = 'brain';
 
 INSERT INTO studies.study_tag (color, name, study_id)
 SELECT DISTINCT '#27ae60', 'volume.organ:spine', proc.study_id 
 FROM datasets.dataset_property prop
-INNER JOIN datasets.dataset_processing proc ON proc.id = prop.dataset_processing_id
+INNER JOIN datasets.dataset_processing proc ON proc.parent_id = prop.dataset_processing_id
 WHERE prop.name = 'volume.organ' AND prop.value = 'spine';
 
 INSERT INTO studies.study_tag (color, name, study_id)
 SELECT DISTINCT '#198bda', 'volume.organ:null', proc.study_id 
 FROM datasets.dataset_property prop
-INNER JOIN datasets.dataset_processing proc ON proc.id = prop.dataset_processing_id
+INNER JOIN datasets.dataset_processing proc ON proc.parent_id = prop.dataset_processing_id
 WHERE prop.name = 'volume.organ' AND prop.value = 'null';
 
 -- Copy studies study_tags to datasets study_tags
@@ -26,23 +47,23 @@ FROM studies.study_tag;
 
 -- Create dataset_tag for all relevant dataset
 
-INSERT INTO dataset_tag (dataset_id, study_tag_id)
+INSERT INTO datasets.dataset_tag (dataset_id, study_tag_id)
 SELECT DISTINCT prop.dataset_id, tag.id 
-FROM dataset_property prop
-INNER JOIN dataset_processing proc ON proc.id = prop.dataset_processing_id
-INNER JOIN study_tag tag ON tag.study_id = proc.study_id AND tag.name = 'volume.organ:brain'
+FROM datasets.dataset_property prop
+INNER JOIN datasets.dataset_processing proc ON proc.id = prop.dataset_processing_id
+INNER JOIN datasets.study_tag tag ON tag.study_id = proc.study_id AND tag.name = 'volume.organ:brain'
 WHERE prop.name = 'volume.organ' AND prop.value = 'brain';
 
-INSERT INTO dataset_tag (dataset_id, study_tag_id)
+INSERT INTO datasets.dataset_tag (dataset_id, study_tag_id)
 SELECT DISTINCT prop.dataset_id, tag.id 
-FROM dataset_property prop
-INNER JOIN dataset_processing proc ON proc.id = prop.dataset_processing_id
-INNER JOIN study_tag tag ON tag.study_id = proc.study_id AND tag.name = 'volume.organ:spine'
+FROM datasets.dataset_property prop
+INNER JOIN datasets.dataset_processing proc ON proc.parent_id = prop.dataset_processing_id
+INNER JOIN datasets.study_tag tag ON tag.study_id = proc.study_id AND tag.name = 'volume.organ:spine'
 WHERE prop.name = 'volume.organ' AND prop.value = 'spine';
 
-INSERT INTO dataset_tag (dataset_id, study_tag_id)
+INSERT INTO datasets.dataset_tag (dataset_id, study_tag_id)
 SELECT DISTINCT prop.dataset_id, tag.id
-FROM dataset_property prop
-INNER JOIN dataset_processing proc ON proc.id = prop.dataset_processing_id
-INNER JOIN study_tag tag ON tag.study_id = proc.study_id AND tag.name = 'volume.organ:null'
+FROM datasets.dataset_property prop
+INNER JOIN datasets.dataset_processing proc ON proc.parent_id = prop.dataset_processing_id
+INNER JOIN datasets.study_tag tag ON tag.study_id = proc.study_id AND tag.name = 'volume.organ:null'
 WHERE prop.name = 'volume.organ' AND prop.value = 'null';

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/configuration/amqp/RabbitMQDatasetsService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/configuration/amqp/RabbitMQDatasetsService.java
@@ -186,14 +186,8 @@ public class RabbitMQDatasetsService {
 			}
 
 			studyService.updateStudy(updated, current);
-
-			List<Long> subjectIds = current.getSubjectStudyList()
-					.stream().map(subStu ->
-							subStu.getSubject().getId()
-					).collect(Collectors.toList()
-				);
-
-			solrService.updateSubjects(subjectIds);
+			
+			solrService.updateStudy(current.getId());
 
 		} catch (Exception ex) {
 			LOG.error("An error occured while processing study update", ex);

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/model/Dataset.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/model/Dataset.java
@@ -133,7 +133,7 @@ public abstract class Dataset extends AbstractEntity {
 	@OneToOne(cascade = CascadeType.ALL)
 	private DatasetMetadata updatedMetadata;
 
-	@ManyToMany
+	@ManyToMany(fetch = FetchType.LAZY)
 	@JoinTable(name = "DATASET_TAG", joinColumns = @JoinColumn(name = "DATASET_ID"), inverseJoinColumns = @JoinColumn(name = "STUDY_TAG_ID"))
 	private List<StudyTag> tags;
 

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/repository/DatasetRepository.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/repository/DatasetRepository.java
@@ -53,9 +53,7 @@ public interface DatasetRepository extends PagingAndSortingRepository<Dataset, L
 	List<Long> findIdsByStudyId(Long studyId);
 
 	@Query(value = "SELECT ds.id FROM dataset ds " +
-			"INNER JOIN dataset_acquisition acq ON ds.dataset_acquisition_id = acq.id " +
-			"INNER JOIN examination ex ON acq.examination_id = ex.id " +
-			"WHERE ex.subject_id IN (?1)", nativeQuery = true)
+			"WHERE ds.subject_id IN (?1)", nativeQuery = true)
 	List<Long> findIdsBySubjectIdIn(List<Long> subjectIds);
 
 	Iterable<Dataset> findByDatasetAcquisitionId(Long acquisitionId);

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/repository/DatasetRepository.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/repository/DatasetRepository.java
@@ -45,7 +45,19 @@ public interface DatasetRepository extends PagingAndSortingRepository<Dataset, L
 	Iterable<Dataset> findByDatasetAcquisition_Examination_Study_Id(Long studyId);
 
 	int countByDatasetAcquisition_Examination_Study_Id(Long studyId);
-	
+
+	@Query(value = "SELECT ds.id FROM dataset ds " +
+			"INNER JOIN dataset_acquisition acq ON ds.dataset_acquisition_id = acq.id " +
+			"INNER JOIN examination ex ON acq.examination_id = ex.id " +
+			"WHERE ex.study_id = ?1", nativeQuery = true)
+	List<Long> findIdsByStudyId(Long studyId);
+
+	@Query(value = "SELECT ds.id FROM dataset ds " +
+			"INNER JOIN dataset_acquisition acq ON ds.dataset_acquisition_id = acq.id " +
+			"INNER JOIN examination ex ON acq.examination_id = ex.id " +
+			"WHERE ex.subject_id IN (?1)", nativeQuery = true)
+	List<Long> findIdsBySubjectIdIn(List<Long> subjectIds);
+
 	Iterable<Dataset> findByDatasetAcquisitionId(Long acquisitionId);
 	
 	Iterable<Dataset> findBydatasetAcquisitionStudyCardId(Long studycardId);

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/shared/model/Study.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/shared/model/Study.java
@@ -22,6 +22,7 @@ import org.shanoir.ng.tag.model.StudyTag;
 import org.shanoir.ng.tag.model.Tag;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author yyao
@@ -56,7 +57,7 @@ public class Study extends IdName {
     private List<Examination> examinations;
 
 	@OneToMany(fetch = FetchType.LAZY, mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<StudyTag> studyTags;
+	private Set<StudyTag> studyTags;
 	
 
 	/**
@@ -140,11 +141,11 @@ public class Study extends IdName {
         this.examinations = examinations;
     }
 
-	public List<StudyTag> getStudyTags() {
+	public Set<StudyTag> getStudyTags() {
 		return studyTags;
 	}
 
-	public void setStudyTags(List<StudyTag> studyTags) {
+	public void setStudyTags(Set<StudyTag> studyTags) {
 		this.studyTags = studyTags;
 	}
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/solr/repository/ShanoirMetadataRepositoryImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/solr/repository/ShanoirMetadataRepositoryImpl.java
@@ -304,14 +304,14 @@ public class ShanoirMetadataRepositoryImpl implements ShanoirMetadataRepositoryC
 
 	public static final String SUBJECT_TAG_QUERY = "SELECT d.id AS dataset_id, tag.name AS tag" +
 			" FROM dataset d" +
-			" LEFT JOIN subject_study substu ON d.subject_id = substu.subject_id" +
-			" LEFT JOIN subject_study_tag substutag ON substu.id = substutag.subject_study_id" +
-			" LEFT JOIN tag ON substutag.tags_id = tag.id";
+			" INNER JOIN subject_study substu ON d.subject_id = substu.subject_id" +
+			" INNER JOIN subject_study_tag substutag ON substu.id = substutag.subject_study_id" +
+			" INNER JOIN tag ON substutag.tags_id = tag.id";
 
 	public static final String STUDY_TAG_QUERY = "SELECT d.id AS dataset_id, tag.name AS tag" +
 			" FROM dataset d " +
-			" LEFT JOIN dataset_tag dstag ON d.id = dstag.dataset_id " +
-			" LEFT JOIN study_tag tag ON dstag.study_tag_id = tag.id";
+			" INNER JOIN dataset_tag dstag ON d.id = dstag.dataset_id " +
+			" INNER JOIN study_tag tag ON dstag.study_tag_id = tag.id";
 
 	@PersistenceContext
 	private EntityManager em;

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/solr/service/SolrService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/solr/service/SolrService.java
@@ -62,4 +62,6 @@ public interface SolrService {
 
 	void updateSubjects(List<Long> subjectIds) throws SolrServerException, IOException;
 
+	void updateStudy(Long studyId) throws SolrServerException, IOException;
+
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/solr/service/SolrService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/solr/service/SolrService.java
@@ -20,14 +20,13 @@
 package org.shanoir.ng.solr.service;
 
 import org.apache.solr.client.solrj.SolrServerException;
-import org.shanoir.ng.shared.event.ShanoirEvent;
 import org.shanoir.ng.shared.exception.RestServiceException;
 import org.shanoir.ng.solr.model.ShanoirSolrDocument;
 import org.shanoir.ng.solr.model.ShanoirSolrQuery;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.solr.core.query.result.SolrResultPage;
-import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.security.access.prepost.PreAuthorize;
 
 import java.io.IOException;
@@ -60,8 +59,10 @@ public interface SolrService {
 
 	void updateDatasets(List<Long> datasetIds) throws SolrServerException, IOException;
 
-	void updateSubjects(List<Long> subjectIds) throws SolrServerException, IOException;
+	void updateDatasetsAsync(List<Long> datasetIds) throws SolrServerException, IOException;
 
-	void updateStudy(Long studyId) throws SolrServerException, IOException;
+	void updateSubjectsAsync(List<Long> subjectIds) throws SolrServerException, IOException;
+
+	void updateStudyAsync(Long studyId) throws SolrServerException, IOException;
 
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/solr/service/SolrServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/solr/service/SolrServiceImpl.java
@@ -297,17 +297,14 @@ public class SolrServiceImpl implements SolrService {
 	@Override
 	@Transactional
 	public void updateSubjects(List<Long> subjectIds) throws SolrServerException, IOException {
-		Set<Long> datasetsToUpdate = new HashSet<>();
-		for (Examination exam : examRepository.findBySubjectIdIn(subjectIds)) {
-			for (DatasetAcquisition acq : exam.getDatasetAcquisitions()) {
-				for (Dataset ds : acq.getDatasets()) {
-					datasetsToUpdate.add(ds.getId());
-				}
-			}
-		}
-		if (!CollectionUtils.isEmpty(datasetsToUpdate)) {
-			this.indexDatasets(new ArrayList<>(datasetsToUpdate));
-		}
+		List<Long> ids = this.dsRepository.findIdsBySubjectIdIn(subjectIds);
+		this.updateDatasets(ids);
+	}
+
+	@Override
+	public void updateStudy(Long studyId) throws SolrServerException, IOException {
+		List<Long> ids = this.dsRepository.findIdsByStudyId(studyId);
+		this.updateDatasets(ids);
 	}
 
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/solr/service/SolrServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/solr/service/SolrServiceImpl.java
@@ -24,10 +24,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.solr.client.solrj.SolrServerException;
-import org.shanoir.ng.dataset.model.Dataset;
 import org.shanoir.ng.dataset.repository.DatasetRepository;
-import org.shanoir.ng.datasetacquisition.model.DatasetAcquisition;
-import org.shanoir.ng.examination.model.Examination;
 import org.shanoir.ng.examination.repository.ExaminationRepository;
 import org.shanoir.ng.shared.dateTime.DateTimeUtils;
 import org.shanoir.ng.shared.event.ShanoirEvent;
@@ -295,14 +292,22 @@ public class SolrServiceImpl implements SolrService {
 	}
 
 	@Override
+	@Async
+	public void updateDatasetsAsync(List<Long> datasetIds) throws SolrServerException, IOException {
+		this.updateDatasets(datasetIds);
+	}
+
+	@Override
+	@Async
 	@Transactional
-	public void updateSubjects(List<Long> subjectIds) throws SolrServerException, IOException {
+	public void updateSubjectsAsync(List<Long> subjectIds) throws SolrServerException, IOException {
 		List<Long> ids = this.dsRepository.findIdsBySubjectIdIn(subjectIds);
 		this.updateDatasets(ids);
 	}
 
 	@Override
-	public void updateStudy(Long studyId) throws SolrServerException, IOException {
+	@Async
+	public void updateStudyAsync(Long studyId) throws SolrServerException, IOException {
 		List<Long> ids = this.dsRepository.findIdsByStudyId(studyId);
 		this.updateDatasets(ids);
 	}

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/controler/StudyCardApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/controler/StudyCardApiController.java
@@ -252,7 +252,7 @@ public class StudyCardApiController implements StudyCardApi {
         }
         
         // Update solr metadata
-        solrService.updateDatasets(datasetIds);
+        solrService.updateDatasetsAsync(datasetIds);
         
         return new ResponseEntity<Void>(HttpStatus.OK);
     }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/tag/model/StudyTag.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/tag/model/StudyTag.java
@@ -86,11 +86,11 @@ public class StudyTag extends IdName {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         StudyTag studyTag = (StudyTag) o;
-        return Objects.equals(id, studyTag.id) && Objects.equals(name, studyTag.name) && Objects.equals(color, studyTag.color) && Objects.equals(study, studyTag.study);
+        return Objects.equals(id, studyTag.id) && Objects.equals(name, studyTag.name) && Objects.equals(color, studyTag.color);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, color, study);
+        return Objects.hash(id, name, color);
     }
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/tag/model/StudyTag.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/tag/model/StudyTag.java
@@ -20,7 +20,7 @@ public class StudyTag extends IdName {
     private String color;
 
     @JsonIgnore
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "study_id")
     private Study study;
 
@@ -86,11 +86,11 @@ public class StudyTag extends IdName {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         StudyTag studyTag = (StudyTag) o;
-        return Objects.equals(id, studyTag.id);
+        return Objects.equals(id, studyTag.id) && Objects.equals(name, studyTag.name) && Objects.equals(color, studyTag.color) && Objects.equals(study, studyTag.study);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(id, name, color, study);
     }
 }


### PR DESCRIPTION
# Changes
- Optimize tags indexation when updating a study
- Make Solr indexation async when :
  - applying study cards
  - updating subject
  - updating study
- Correct `volume.organ` dataset tags creation

# How to test
- Deploy on OFSEP qualif
- Execute `tag_ofsep_organs.sql`
- Reindex Solr
- Check that study update time is reasonable
- Check that processings are linked to datasets of the same study
- Check that created datasets tags are linked to tags of the same study 
- Check that update of subject is OK
- Check that reapplying study cards is OK