### PR TITLE
Correct Cohorte VHD datasets naming

### DIFF
--- a/docker-compose/database/oneshot-updates/correct_Cohort_VHD_datasets_naming.sql
+++ b/docker-compose/database/oneshot-updates/correct_Cohort_VHD_datasets_naming.sql
@@ -1,0 +1,6 @@
+UPDATE dataset_metadata mtd SET mtd.name = mtd.comment
+WHERE mtd.id IN (
+SELECT ds.updated_metadata_id FROM dataset ds 
+INNER JOIN dataset_acquisition acq ON ds.dataset_acquisition_id = acq.id
+INNER JOIN examination ex ON acq.examination_id = ex.id AND ex.study_id = 66
+INNER JOIN dataset_property prop ON ds.id = prop.dataset_id AND prop.name = 'volume.name');


### PR DESCRIPTION
Datasets from the `Cohorte VHD` study (id 66) were included by mistake in the executions of OSFEP Sequence Identifier pipeline.

This oneshot script correct this by reverting `dataset_metadata.name` to their old value, stored in `dataset_metadat.comment`. Only datasets associated to a dataset_property (i.e. concerned by the executions) will be included in the query.