### PR TITLE
update java version installed on nifti conversion container

### DIFF
--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -180,7 +180,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     locales-all \
     jq \
     libgtk2.0-0 \
-    openjdk-17-jre \
+    temurin-21-jre \
     pigz \
     xvfb
 


### PR DESCRIPTION
java 17 jre was specified on docker file for the nifty-conversion ms.