### PR TITLE
fix keycloak startup time

### DIFF
--- a/docker-compose/keycloak/entrypoint
+++ b/docker-compose/keycloak/entrypoint
@@ -66,7 +66,7 @@ auto|dev)
 	#       (the realm has to be reimported manually)
 	mkdir -p /opt/keycloak/data/import
 	cp /tmp/import/shanoir-ng-realm.json /opt/keycloak/data/import/
-	extra+=(start --import-realm)
+	extra+=(start --optimized --import-realm)
 	;;
 init)
 	# wipe out the shanoir-ng realm and recreate it
@@ -76,7 +76,15 @@ never)
 	# FIXME: should we provide a facade for these too
 	# TODO: ensure that the realm config is up-to-date
 	#-> add an optional data volume to store the config of the imported realm
-	extra+=(start)
+
+	# NOTE: we force using the optimized image because quarkus gets
+	#       confused by our plugin mtime being rounded (possibly somewhere
+	#       in the docker build)
+	# ex: (from "kc.sh show-config")
+	# 	kc.provider.file.shanoir-ng-keycloak-auth.jar.last-modified =  1721751809614
+	#   vs:
+	# 	kc.provider.file.shanoir-ng-keycloak-auth.jar.last-modified =  1721751809000
+	extra+=(start --optimized)
 	;;
 
 import)


### PR DESCRIPTION
we have a rounding issue which makes quarkus fail to detect that the shanoir-ng-keycloak-auth.jar plugin is not modified and rebuild the server at every startup.