### PR TITLE
Remote debugging

### DIFF
--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -103,8 +103,8 @@ COPY --link --from=datasets-download /target/. /
 COPY --link datasets/entrypoint /usr/bin/
 COPY --link datasets/shanoir-ng-datasets.jar shanoir-ng-datasets.jar
 
-# Use the below line for remote debugging and to active dev profile
-#CMD ["-jar", "/shanoir-ng-datasets.jar", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=0.0.0.0:9914,suspend=y"]
+# Use the below line for remote debugging
+#CMD ["-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:9914", "-jar", "/shanoir-ng-datasets.jar"]
 CMD ["-jar", "/shanoir-ng-datasets.jar"]
 
 
@@ -116,8 +116,8 @@ FROM base-microservice as import
 COPY --link import/entrypoint /usr/bin/
 COPY --link import/shanoir-ng-import.jar shanoir-ng-import.jar
 
-# Use the below line for remote debugging and to active dev profile
-#CMD ["-jar", "/shanoir-ng-import.jar", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=0.0.0.0:9913,suspend=y"]
+# Use the below line for remote debugging
+#CMD ["-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:9913", "-jar", "/shanoir-ng-import.jar"]
 CMD ["-jar", "/shanoir-ng-import.jar"]
 
 
@@ -224,7 +224,7 @@ COPY --link preclinical/shanoir-ng-preclinical.jar shanoir-ng-preclinical.jar
 COPY --link preclinical/entrypoint /usr/bin/
 
 # Use the below line for remote debugging
-#CMD ["-jar", "/shanoir-ng-preclinical.jar", "-Xmx6g", "-Xms1g", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=0.0.0.0:9915,suspend=y", "-Dspring.profiles.active=dev"]
+#CMD ["-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:9915", "-jar", "/shanoir-ng-preclinical.jar", "-Xmx6g", "-Xms1g"]
 CMD ["-jar", "/shanoir-ng-preclinical.jar", "-Xmx6g", "-Xms1g"]
 
 
@@ -236,8 +236,8 @@ FROM base-microservice as studies
 COPY --link studies/shanoir-ng-studies.jar shanoir-ng-studies.jar
 COPY --link studies/entrypoint /usr/bin/
 
-# Use the below line for remote debugging and to active dev profile
-#CMD ["-jar", "/shanoir-ng-studies.jar", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=0.0.0.0:9912,suspend=y"]
+# Use the below line for remote debugging
+#CMD ["-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:9912", "-jar", "/shanoir-ng-studies.jar"]
 CMD ["-jar", "/shanoir-ng-studies.jar"]
 
 
@@ -257,8 +257,8 @@ ENV	\
 	kc.admin.client.client.id="admin-cli"	\
 	kc.admin.client.realm="master"
 
-# Use the below line for remote debugging and development profile purpose
-#CMD ["-jar", "/shanoir-ng-users.jar", "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,address=0.0.0.0:9911,suspend=y", "-Dspring.profiles.active=dev", "--syncAllUsersToKeycloak=true"]
+# Use the below line for remote debugging
+#CMD ["-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:9911", "-jar", "/shanoir-ng-users.jar", "--syncAllUsersToKeycloak=true"]
 CMD ["-jar", "/shanoir-ng-users.jar"]
 
 


### PR DESCRIPTION
Hi, for 5 microservices, this code brings back the remote debugging option.
Comment back #CMD for the desired microservice
Launch a remote debug in your dev IDE and connect it to the port 991x, x depending on the microservice.
There is no need anymore for the dev-profile, as we run the ms inside docker compose (all in its network) and we "just" run the code in our IDE, as it were inside docker compose, so prod profile is perfect and the most close anyway.