### PR TITLE
shanoir-issue#2332: add focus when creating a tag + validate with enter

### DIFF
--- a/shanoir-ng-front/src/app/tags/tag.creator.component.html
+++ b/shanoir-ng-front/src/app/tags/tag.creator.component.html
@@ -19,7 +19,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
         </span>
         {{dtag.tag.name}}
     </span>
-    <span *ngIf="!addTagVisible && mode != 'view'" (click)="addTagVisible = true" class="clickable new">
+    <span *ngIf="!addTagVisible && mode != 'view'" (click)="addTagVisible = true; focus();" class="clickable new">
         <i class="fas fa-plus"></i>
     </span>
     <span *ngIf="addTagVisible" class="tag edit-new" [style.background-color]="selectedColor" [class.dark]="newTagDarkFont">
@@ -30,7 +30,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
             <i class="fa-solid fa-palette"></i>
             <input type="color" [(ngModel)]="selectedColor" (ngModelChange)="onColorChange()"/>
         </span>
-        <input type="text" [(ngModel)]="text" placeholder="enter tag label..."/>
+        <input #input type="text" [(ngModel)]="text" (keyup.enter)="addTag()" placeholder="enter tag label..."/>
         <span (click)="addTag()" class="save" [class.disabled]="text == null || selectedColor == null">
             <i class="fas fa-save"></i>
         </span>

--- a/shanoir-ng-front/src/app/tags/tag.creator.component.ts
+++ b/shanoir-ng-front/src/app/tags/tag.creator.component.ts
@@ -11,7 +11,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
  */
-import { Component, EventEmitter, forwardRef, Input, Output } from '@angular/core';
+import {Component, EventEmitter, forwardRef, Input, Output, ViewChild} from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { ConfirmDialogService } from '../shared/components/confirm-dialog/confirm-dialog.service';
@@ -19,6 +19,8 @@ import { AbstractInput } from '../shared/form/input.abstract';
 import { Study } from '../studies/shared/study.model';
 import { isDarkColor } from '../utils/app.utils';
 import { Tag } from './tag.model';
+import {TableComponent} from "../shared/components/table/table.component";
+import {TagInputComponent} from "./tag.input.component";
 
 
 export type Mode =  "view" | "edit" | "create";
@@ -36,6 +38,7 @@ export type Mode =  "view" | "edit" | "create";
 })
 
 export class TagCreatorComponent extends AbstractInput<Tag[]> {
+    @ViewChild('input', { static: false }) input: any;
     @Input() study: Study;
     @Input() mode: Mode;
     @Output() onChange: EventEmitter<any> = new EventEmitter();
@@ -55,6 +58,9 @@ export class TagCreatorComponent extends AbstractInput<Tag[]> {
     ngOnChanges() {
     }
 
+    focus() {
+        setTimeout(() => this.input.nativeElement.focus());
+    }
     public addTag() {
         if (this.text != null && this.selectedColor != null) {
             let newTag = new Tag();


### PR DESCRIPTION
How to test:
Open a study and "Subject" or "Tag" tab
Click the "+" to create a new tag: focus is on the input (no need to click on the input text to start writing)
Press "enter" to validate the tag creation

![image](https://github.com/user-attachments/assets/e7b9c08e-302d-4467-9e69-407a35562299)
