### PR TITLE
Fix for GitHub issue #2345

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/DicomPersisterService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/DicomPersisterService.java
@@ -58,47 +58,46 @@ public class DicomPersisterService {
 	private DICOMWebService dicomWebService;
 
 	/**
-	 * This method reads the datasets for each serie from the json (String), gets
-	 * the dicom expression format and sends the images to the PACS.
+	 * This method reads the datasets for each serie from the json (String),
+	 * gets the dicom expression format and sends the images to the PACS.
 	 * 
 	 * @param serie
 	 * @throws Exception
 	 */
 	public void persistAllForSerie(Serie serie) throws Exception {
-		if (serie != null) {
-			for (Dataset dataset : serie.getDatasets()) {
-				for (ExpressionFormat expressionFormat : dataset.getExpressionFormats()) {
-					if (expressionFormat.getType().equals("dcm")) {
-						List<DatasetFile> datasetFiles = expressionFormat.getDatasetFiles();
-						if (datasetFiles != null && !datasetFiles.isEmpty()) {
-							// Iterate over all dataset files (DICOM files), in case all files might be
-							// distributed over multiple parent directories and therefore require multiple
-							// calls to sendDicomFilesToPacs (advantage: do not create to big multiparts)
-							File lastParentFile = null;
-							for (DatasetFile datasetFile : datasetFiles) {
-								String path = datasetFile.getPath();
-								if (path != null && !path.isEmpty()) {
-									File dicomFile = new File(path);
-									if (dicomFile.exists()) {
-										File parentFile = dicomFile.getParentFile();
-										if (lastParentFile == null || !parentFile.equals(lastParentFile)) {
-											if (dicomWeb) {
-												dicomWebService.sendDicomFilesToPacs(parentFile);
-											} else {
-												dimseService.sendDicomFilesToPacs(parentFile);
-											}
-											lastParentFile = parentFile;	
-										}
-									} else {
-										throw new ShanoirException("Send Dicoms to Pacs: dicomFile not existing on disk.");
-									}
-								} else {
-									throw new ShanoirException("Send Dicoms to Pacs: DatasetFile with empty path found in db.");
-								}
-							}
+		if (serie == null) {
+			return;
+		}
+		for (Dataset dataset : serie.getDatasets()) {
+			for (ExpressionFormat expressionFormat : dataset.getExpressionFormats()) {
+				if (!expressionFormat.getType().equals("dcm")) {
+					continue;
+				}
+				List<DatasetFile> datasetFiles = expressionFormat.getDatasetFiles();
+				if (datasetFiles == null || datasetFiles.isEmpty()) {
+					throw new ShanoirException("Send Dicoms to Pacs: DatasetFiles null or empty.");
+				}
+				// Iterate over all dataset files (DICOM files), in case all files might be
+				// distributed over multiple parent directories and therefore require multiple
+				// calls to sendDicomFilesToPacs (advantage: do not create to big multiparts)
+				File lastParentFile = null;
+				for (DatasetFile datasetFile : datasetFiles) {
+					String path = datasetFile.getPath();
+					if (path == null || path.isEmpty()) {
+						throw new ShanoirException("Send Dicoms to Pacs: DatasetFile with null or empty path found.");
+					}
+					File dicomFile = new File(path);
+					if (!dicomFile.exists()) {
+						throw new ShanoirException("Send Dicoms to Pacs: dicomFile from DatasetFile.path not existing on disk.");
+					}
+					File parentFile = dicomFile.getParentFile();
+					if (!parentFile.equals(lastParentFile)) {
+						if (dicomWeb) {
+							dicomWebService.sendDicomFilesToPacs(parentFile);
 						} else {
-							throw new ShanoirException("Send Dicoms to Pacs: DatasetFiles null or empty.");
+							dimseService.sendDicomFilesToPacs(parentFile);
 						}
+						lastParentFile = parentFile;	
 					}
 				}
 			}


### PR DESCRIPTION
Problem: some series, e.g. QSM_3DMULTIGRE_B contain up to 960 DICOM files.
They are organized in multiple directory and packaged by 500 per directory.
MS Datasets searched until this fix the parent directory of the first DICOM file
as reference and sends all containing DICOM files to the server. In the above
case as the DICOM files were distributed over 3 directories only a part of the
files has been send to the PACS. The problem is vendor dependent, as normally
all is structured per serie and concerns only the web import via file, not ShUp,
as in ShUp all DICOM files are queried in only one serie specific folder.

Testing: use serie above and verify, that preview + download work.