### PR TITLE
Index MeasurementDataset to Solr +  fix for bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -144,7 +144,7 @@ if [ -n "$deploy" ] ; then
 
 		step "start: keycloak"
 		docker compose up -d keycloak
-		utils/oneshot --pgrp '\| *'				\
+		docker-compose/common/oneshot --pgrp '\| *'				\
 				' INFO  \[io.quarkus\] .* Keycloak .* started in [0-9]*'	\
 				-- docker compose logs --no-color --follow keycloak >/dev/null
 

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/modality/MrDataset.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/modality/MrDataset.java
@@ -14,16 +14,23 @@
 
 package org.shanoir.ng.dataset.modality;
 
-import jakarta.persistence.*;
-import org.shanoir.ng.dataset.model.Dataset;
-import org.shanoir.ng.datasetacquisition.model.mr.MrDatasetAcquisition;
-import org.shanoir.ng.datasetacquisition.model.mr.MrProtocol;
-import org.shanoir.ng.shared.model.*;
-import org.xmlunit.diff.Diff;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.shanoir.ng.dataset.model.Dataset;
+import org.shanoir.ng.shared.model.DiffusionGradient;
+import org.shanoir.ng.shared.model.EchoTime;
+import org.shanoir.ng.shared.model.FlipAngle;
+import org.shanoir.ng.shared.model.InversionTime;
+import org.shanoir.ng.shared.model.RepetitionTime;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Transient;
 
 /**
  * MR dataset.

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dicom/web/StowRSMultipartRelatedRequestFilter.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dicom/web/StowRSMultipartRelatedRequestFilter.java
@@ -8,7 +8,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
-import org.shanoir.ng.importer.service.DicomSRImporterService;
+import org.shanoir.ng.importer.service.DicomSEGAndSRImporterService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,7 +60,7 @@ public class StowRSMultipartRelatedRequestFilter extends GenericFilterBean {
 	private static final String DICOMWEB_STUDIES = "/dicomweb/studies";
 
 	@Autowired
-	private DicomSRImporterService dicomSRImporterService;
+	private DicomSEGAndSRImporterService dicomSRImporterService;
 	
     @Override
     public void doFilter(
@@ -78,8 +78,8 @@ public class StowRSMultipartRelatedRequestFilter extends GenericFilterBean {
     			for (int i = 0; i < count; i++) {
     				BodyPart bodyPart = multipart.getBodyPart(i);
     				if (bodyPart.isMimeType(CONTENT_TYPE_DICOM)) {
-    					if(!dicomSRImporterService.importDicomSR(bodyPart.getInputStream())) {
-    						throw new ServletException("Error in importDicomSR.");
+    					if(!dicomSRImporterService.importDicomSEGAndSR(bodyPart.getInputStream())) {
+    						throw new ServletException("Error in importDicomSEGAndSR.");
     					}
     				} else {
     					throw new IOException("StowRSMultipartRelatedRequestFilter: exception sending dicom file to pacs (stow-sr).");

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/DicomSRImporterService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/DicomSRImporterService.java
@@ -22,6 +22,7 @@ import org.shanoir.ng.examination.model.Examination;
 import org.shanoir.ng.examination.repository.ExaminationRepository;
 import org.shanoir.ng.shared.model.Subject;
 import org.shanoir.ng.shared.repository.SubjectRepository;
+import org.shanoir.ng.solr.service.SolrService;
 import org.shanoir.ng.utils.KeycloakUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,6 +68,9 @@ public class DicomSRImporterService {
 
 	@Autowired
 	private ExaminationRepository examinationRepository;
+
+	@Autowired
+    private SolrService solrService;
 	
 	@Autowired
 	private DatasetService datasetService;
@@ -250,7 +254,8 @@ public class DicomSRImporterService {
 //		completeDatasetFromDicomSR(datasetAttributes, measurementDataset);
 		createMetadata(measurementDataset);
 		createDatasetExpression(datasetAttributes, measurementDataset);
-		datasetService.create(measurementDataset);
+		Dataset created = datasetService.create(measurementDataset);
+		solrService.indexDataset(created.getId());
 	}
 
 	/**

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/ImporterService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/ImporterService.java
@@ -318,7 +318,7 @@ public class ImporterService {
 
     private boolean hasQualityChecksAtImport(List<QualityCard> qualityCards) {
         if (qualityCards == null || qualityCards.isEmpty()) {
-            LOG.warn("No qualitycard given for this import");
+            LOG.warn("No qualitycard given for this import.");
             return false;
         }
         for (QualityCard qualityCard : qualityCards) {
@@ -334,7 +334,7 @@ public class ImporterService {
             StudyCard studyCard = getStudyCard(importJob.getStudyCardId());
             return studyCard;
         } else {
-            LOG.warn("No studycard given for this import");
+            LOG.warn("No studycard given for this import.");
             return null;
         }
     }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/solr/repository/ShanoirMetadataRepositoryImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/solr/repository/ShanoirMetadataRepositoryImpl.java
@@ -287,6 +287,38 @@ public class ShanoirMetadataRepositoryImpl implements ShanoirMetadataRepositoryC
 			+ " LEFT JOIN center c ON c.id = e.center_id"
 			+ " LEFT JOIN subject su ON su.id = d.subject_id, measurement_dataset md, dataset_metadata dm"
 			+ " WHERE d.updated_metadata_id = dm.id AND md.id = d.id";
+	public static final String SEGMENTATION_QUERY = "SELECT d.id as datasetId, " +
+			"dm.name as datasetName, " +
+			"dm.dataset_modality_type as datasetType, " +
+			"null as datasetNature, "
+			+ "d.creation_date as datasetCreationDate, " +
+			"e.id as examinationId, " +
+			"e.comment as examinationComment, " +
+			"e.examination_date as examinationDate, " +
+			"ae.name as acquisitionEquipmentName,"
+			+ "su.name as subjectName, " +
+			"sust.subject_type as subjectType, " +
+			"su.id as subjectId, " +
+			"st.name as studyName, " +
+			"e.study_id as studyId, " +
+			"c.name as centerName, " +
+			"c.id as centerId, "
+			+ "null as sliceThickness, " +
+			"null as pixelBandwidth, " +
+			"null as magneticFieldStrength, " +
+			"da.import_date as importDate, " +
+			"da.username as username, " +
+			"0 as processed"
+			+ " FROM dataset d"
+			+ " LEFT JOIN dataset refd ON refd.id = d.referenced_dataset_for_superimposition_id"
+			+ " LEFT JOIN dataset_acquisition da on da.id = refd.dataset_acquisition_id"
+			+ " LEFT JOIN examination e ON e.id = da.examination_id"
+			+ " LEFT JOIN acquisition_equipment ae ON ae.id = da.acquisition_equipment_id"
+			+ " LEFT JOIN study st ON st.id = e.study_id"
+			+ " LEFT JOIN subject_study sust ON sust.subject_id = d.subject_id AND sust.study_id = e.study_id"
+			+ " LEFT JOIN center c ON c.id = e.center_id"
+			+ " LEFT JOIN subject su ON su.id = d.subject_id, segmentation_dataset sd, dataset_metadata dm"
+			+ " WHERE d.updated_metadata_id = dm.id AND sd.id = d.id";
 	public static final String XA_QUERY = "SELECT d.id as datasetId, " +
 			"dm.name as datasetName, " +
 			"dm.dataset_modality_type as datasetType, " +
@@ -405,6 +437,9 @@ public class ShanoirMetadataRepositoryImpl implements ShanoirMetadataRepositoryC
 
 		Query measurementQuery = em.createNativeQuery(MEASUREMENT_QUERY + clause, RESULTSET_MAPPING);
 		result.addAll(measurementQuery.getResultList());
+
+		Query segmentationQuery = em.createNativeQuery(SEGMENTATION_QUERY + clause, RESULTSET_MAPPING);
+		result.addAll(segmentationQuery.getResultList());
 
 		return result;
 	}

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/dataset/DatasetApiControllerTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/dataset/DatasetApiControllerTest.java
@@ -38,7 +38,7 @@ import org.shanoir.ng.datasetacquisition.model.mr.MrDatasetAcquisition;
 import org.shanoir.ng.download.WADODownloaderService;
 import org.shanoir.ng.examination.model.Examination;
 import org.shanoir.ng.examination.service.ExaminationService;
-import org.shanoir.ng.importer.service.DicomSRImporterService;
+import org.shanoir.ng.importer.service.DicomSEGAndSRImporterService;
 import org.shanoir.ng.importer.service.ImporterService;
 import org.shanoir.ng.shared.event.ShanoirEventService;
 import org.shanoir.ng.shared.exception.RestServiceException;
@@ -147,7 +147,7 @@ public class DatasetApiControllerTest {
 	private ImporterService importerService;
 	
 	@MockBean
-	private DicomSRImporterService dicomSRImporterService;
+	private DicomSEGAndSRImporterService dicomSRImporterService;
 	
 	@MockBean
 	private DatasetDownloaderServiceImpl datasetDownloaderService;

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/dataset/DatasetDownloaderServiceTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/dataset/DatasetDownloaderServiceTest.java
@@ -26,7 +26,7 @@ import org.shanoir.ng.datasetfile.DatasetFile;
 import org.shanoir.ng.download.WADODownloaderService;
 import org.shanoir.ng.examination.model.Examination;
 import org.shanoir.ng.examination.service.ExaminationService;
-import org.shanoir.ng.importer.service.DicomSRImporterService;
+import org.shanoir.ng.importer.service.DicomSEGAndSRImporterService;
 import org.shanoir.ng.importer.service.ImporterService;
 import org.shanoir.ng.shared.event.ShanoirEvent;
 import org.shanoir.ng.shared.event.ShanoirEventService;
@@ -108,7 +108,7 @@ public class DatasetDownloaderServiceTest {
 	private ImporterService importerService;
 	
 	@MockBean
-	private DicomSRImporterService dicomSRImporterService;
+	private DicomSEGAndSRImporterService dicomSRImporterService;
 
 	private Subject subject = new Subject(3L, "name");
 	private Study study = new Study(1L, "studyName");

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/datasetacquisition/DatasetAcquisitionApiControllerTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/datasetacquisition/DatasetAcquisitionApiControllerTest.java
@@ -12,7 +12,7 @@ import org.shanoir.ng.datasetacquisition.dto.mapper.DatasetAcquisitionMapper;
 import org.shanoir.ng.datasetacquisition.dto.mapper.ExaminationDatasetAcquisitionMapper;
 import org.shanoir.ng.datasetacquisition.service.DatasetAcquisitionService;
 import org.shanoir.ng.importer.dto.EegImportJob;
-import org.shanoir.ng.importer.service.DicomSRImporterService;
+import org.shanoir.ng.importer.service.DicomSEGAndSRImporterService;
 import org.shanoir.ng.importer.service.EegImporterService;
 import org.shanoir.ng.importer.service.ImporterService;
 import org.shanoir.ng.shared.event.ShanoirEventService;
@@ -42,7 +42,7 @@ public class DatasetAcquisitionApiControllerTest {
 	private EegImporterService eegImporterService;
 
 	@MockBean
-	private DicomSRImporterService dicomSRImporterService;
+	private DicomSEGAndSRImporterService dicomSRImporterService;
 	
 	@MockBean 
 	private DatasetAcquisitionService datasetAcquisitionService;

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/dicom/web/DICOMJsonApiControllerTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/dicom/web/DICOMJsonApiControllerTest.java
@@ -23,7 +23,7 @@ import org.mockito.Mockito;
 import org.shanoir.ng.dicom.web.dto.mapper.ExaminationToStudyDTOMapper;
 import org.shanoir.ng.examination.model.Examination;
 import org.shanoir.ng.examination.service.ExaminationService;
-import org.shanoir.ng.importer.service.DicomSRImporterService;
+import org.shanoir.ng.importer.service.DicomSEGAndSRImporterService;
 import org.shanoir.ng.shared.exception.RestServiceException;
 import org.shanoir.ng.shared.exception.ShanoirException;
 import org.shanoir.ng.shared.paging.PageImpl;
@@ -70,7 +70,7 @@ public class DICOMJsonApiControllerTest {
 	private ExaminationService examinationServiceMock;
 	
 	@MockBean
-	private DicomSRImporterService dicomSRImporterService;
+	private DicomSEGAndSRImporterService dicomSRImporterService;
 
 	@BeforeEach
 	public void setup() throws ShanoirException, SolrServerException, IOException, RestServiceException {

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/examination/ExaminationApiControllerTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/examination/ExaminationApiControllerTest.java
@@ -28,7 +28,7 @@ import org.shanoir.ng.examination.dto.mapper.ExaminationMapper;
 import org.shanoir.ng.examination.model.Examination;
 import org.shanoir.ng.examination.repository.ExaminationRepository;
 import org.shanoir.ng.examination.service.ExaminationService;
-import org.shanoir.ng.importer.service.DicomSRImporterService;
+import org.shanoir.ng.importer.service.DicomSEGAndSRImporterService;
 import org.shanoir.ng.shared.event.ShanoirEvent;
 import org.shanoir.ng.shared.event.ShanoirEventService;
 import org.shanoir.ng.shared.event.ShanoirEventType;
@@ -88,7 +88,7 @@ public class ExaminationApiControllerTest {
 	public String tempFolderPath;
 
 	@MockBean
-	private DicomSRImporterService dicomSRImporterService;
+	private DicomSEGAndSRImporterService dicomSRImporterService;
 
 	@BeforeEach
 	public void beforeClass() {

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/exporter/controller/BidsApiControllerTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/exporter/controller/BidsApiControllerTest.java
@@ -5,7 +5,7 @@ import org.mockito.Mockito;
 import org.shanoir.ng.bids.BidsDeserializer;
 import org.shanoir.ng.bids.controller.BidsApiController;
 import org.shanoir.ng.bids.service.BIDSService;
-import org.shanoir.ng.importer.service.DicomSRImporterService;
+import org.shanoir.ng.importer.service.DicomSEGAndSRImporterService;
 import org.shanoir.ng.shared.repository.StudyRepository;
 import org.shanoir.ng.utils.usermock.WithMockKeycloakUser;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,7 +48,7 @@ public class BidsApiControllerTest {
 	private MockMvc mvc;
 
 	@MockBean
-	private DicomSRImporterService dicomSRImporterService;
+	private DicomSEGAndSRImporterService dicomSRImporterService;
 
 	@Test
 	@WithMockKeycloakUser(id = 3, username = "jlouis", authorities = { "ROLE_ADMIN" })

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/studycard/StudyCardApiControllerTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/studycard/StudyCardApiControllerTest.java
@@ -22,7 +22,7 @@ import org.mockito.Mockito;
 import org.shanoir.ng.dataset.security.DatasetSecurityService;
 import org.shanoir.ng.datasetacquisition.service.DatasetAcquisitionService;
 import org.shanoir.ng.download.WADODownloaderService;
-import org.shanoir.ng.importer.service.DicomSRImporterService;
+import org.shanoir.ng.importer.service.DicomSEGAndSRImporterService;
 import org.shanoir.ng.shared.exception.EntityNotFoundException;
 import org.shanoir.ng.shared.exception.MicroServiceCommunicationException;
 import org.shanoir.ng.shared.validation.FindByRepository;
@@ -93,7 +93,7 @@ public class StudyCardApiControllerTest {
 	private DatasetSecurityService datasetSecurityService;
 
 	@MockBean
-	private DicomSRImporterService dicomSRImporterService;
+	private DicomSEGAndSRImporterService dicomSRImporterService;
 	
 	@MockBean
 	private SolrService solrService;


### PR DESCRIPTION
This code fixes the store-issues with measurements and segmentations, created by ohif-viewer
and index them to Solr. It fixes a rights issue, by attaching it to the original
dataset acquisition, which is the dicom serie, that has been used to create
the measurement, what is correct from the model point of view. So, the user
that has access to the original serie has access to the created measurement
today.