### PR TITLE
upstream msg for over limit dl

### DIFF
--- a/shanoir-ng-front/src/app/shared/mass-download/mass-download.service.ts
+++ b/shanoir-ng-front/src/app/shared/mass-download/mass-download.service.ts
@@ -116,20 +116,20 @@ export class MassDownloadService {
     private downloadByDatasets(inputIds: DownloadInputIds, downloadState?: TaskState): Promise<void> {
         return this.openModal(inputIds).then(ret => {
             if (ret != 'cancel') {
-                return this._downloadDatasets(ret, downloadState).catch(error => {
-                    if (ret.datasets.length > this.datasetService.MAX_DATASETS_IN_ZIP_DL) {
-                        this.dialogService.error('Too many datasets', 'You are trying to download '
-                            + ret.datasets.length + ' datasets while Shanoir sets a limit to ' + this.datasetService.MAX_DATASETS_IN_ZIP_DL
-                            + ' in a single zip. Please confider using a browser compatible with the Shanoir unlimited download functionality. See link below.',
-                            "https://developer.mozilla.org/en-US/docs/Web/API/Window/showDirectoryPicker#browser_compatibility" );
-                    }
-                });
+                return this._downloadDatasets(ret, downloadState);
             } else return Promise.resolve();
         }).catch(error => {
             if (error == this.BROWSER_COMPAT_ERROR_MSG) {
                     return this.openAltModal(inputIds).then(ret => {
                         if (ret != 'cancel') {
-                            return this._downloadAlt(ret.datasets.map(ds => ds.id), ret.format, ret.converter, downloadState);
+                            return this._downloadAlt(ret.datasets.map(ds => ds.id), ret.format, ret.converter, downloadState).catch(error => {
+                                if (ret.datasets.length > this.datasetService.MAX_DATASETS_IN_ZIP_DL) {
+                                    this.dialogService.error('Too many datasets', 'You are trying to download '
+                                        + ret.datasets.length + ' datasets while Shanoir sets a limit to ' + this.datasetService.MAX_DATASETS_IN_ZIP_DL
+                                        + ' in a single zip. Please confider using a browser compatible with the Shanoir unlimited download functionality. See link below.',
+                                        "https://developer.mozilla.org/en-US/docs/Web/API/Window/showDirectoryPicker#browser_compatibility" );
+                                }
+                            });
                         } else return Promise.resolve();
                     });
             } else throw error;
@@ -142,13 +142,13 @@ export class MassDownloadService {
     }
 
     // This method is used to download in
-    private _downloadAlt(datasetIds: number[], format: Format, converter? : number, downloadState?: TaskState): any {
+    private _downloadAlt(datasetIds: number[], format: Format, converter? : number, downloadState?: TaskState): Promise<void> {
         let task: Task = this.createTask(datasetIds.length);
-
+        
         downloadState = new TaskState();
         downloadState.status = task.status;
         downloadState.progress = 0;
-
+        
         return this.downloadQueue.waitForTurn().then(releaseQueue => {
             try {
                 task.status = 2;
@@ -439,7 +439,6 @@ export class MassDownloadService {
                 if (error instanceof ShanoirError) {
                     throw error;
                 } else {
-                    console.error(filename);
                     throw new ShanoirError({error: {code: ShanoirError.FILE_PATH_TOO_LONG, message: 'Probable reason: directory path too long for Windows, max 260 characters (<your chosen directory>/' + path + ')', details: error + ''}});
                 }
             });


### PR DESCRIPTION
This msg was not displayed, it was bound to the "chrome" downloading but it actually concerns only the "firefox" one.

closes https://github.com/fli-iam/shanoir-ng/issues/2014