### PR TITLE
shanoir-issue#2389: allow 'view dicom' with exams or acquisition from one exam

### DIFF
--- a/shanoir-ng-front/src/app/examinations/examination/examination.component.html
+++ b/shanoir-ng-front/src/app/examinations/examination/examination.component.html
@@ -23,8 +23,8 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 					(cancel)="goToView()"
 					(back)="goBack()">
 				<button *ngIf="mode == 'view' && hasDownloadRight" class="right-icon dl-button" type="button" (click)="downloadAll()" [disabled]="downloadState.isActive() || noDatasets">Download<i class="fas fa-download"></i></button>
-                <button type="button" class="right-icon" i18n="Buttons|Download button label@@downloadButton" (click)="openViewer()">View DICOM<i class="fa fa-eye"></i></button>
-                <button type="button" class="right-icon" i18n="Buttons|Download button label@@downloadButton" (click)="openSegmentationViewer()">View for segmentation<i class="fa fa-eye"></i></button>
+                <button *ngIf="mode == 'view'" type="button" class="right-icon" i18n="Buttons|Download button label@@downloadButton" (click)="openViewer()">View DICOM<i class="fa fa-eye"></i></button>
+                <button *ngIf="mode == 'view'" type="button" class="right-icon" i18n="Buttons|Download button label@@downloadButton" (click)="openSegmentationViewer()">View for segmentation<i class="fa fa-eye"></i></button>
 			</form-footer>
 			<span [ngSwitch]="mode">
 				<ng-template [ngSwitchCase]="'view'">

--- a/shanoir-ng-front/src/app/studies/study/study-tree.component.html
+++ b/shanoir-ng-front/src/app/studies/study/study-tree.component.html
@@ -13,8 +13,8 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 -->
 <div class="commands">
     <button class="right-icon dl-button" type="button" (click)="downloadSelected()" [disabled]="!(selectedDatasetNodes?.length > 0)">Download selection<i class="fas fa-download"></i></button>
-    <button class="right-icon dl-button" type="button" (click)="openInViewer()" [disabled]="!canOpenDicom" [title]="'Select examinations or acquisition from one exam to compare DICOM files in viewer'">View DICOM<i class="fas fa-eye"></i></button>
     <button class="right-icon dl-button" type="button" (click)="goToProcessing()" [disabled]="!(selectedDatasetNodes?.length > 0)">Process selection<i class="fas fa-rocket"></i></button>
+    <button class="right-icon dl-button" type="button" (click)="openInViewer()" [disabled]="!canOpenDicom" [title]="'Select examinations or acquisition from one exam to compare DICOM files in viewer'">View DICOM<i class="fas fa-eye"></i></button>
 </div>
 
 <study-node *ngIf="treeService.studyNode"

--- a/shanoir-ng-front/src/app/studies/study/study-tree.component.html
+++ b/shanoir-ng-front/src/app/studies/study/study-tree.component.html
@@ -13,7 +13,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 -->
 <div class="commands">
     <button class="right-icon dl-button" type="button" (click)="downloadSelected()" [disabled]="!(selectedDatasetNodes?.length > 0)">Download selection<i class="fas fa-download"></i></button>
-    <button class="right-icon dl-button" type="button" (click)="openInViewer()" [disabled]="!(selectedExaminationNodes?.length > 0 && selectedExaminationNodes.length <= 10) && !(selectedAcquisitionNodes?.length > 0 && selectedAcquisitionNodes.length <= 10)" [title]="'Select examinations to compare DICOM files in viewer'">View DICOM<i class="fas fa-eye"></i></button>
+    <button class="right-icon dl-button" type="button" (click)="openInViewer()" [disabled]="!canOpenDicom" [title]="'Select examinations or acquisition from one exam to compare DICOM files in viewer'">View DICOM<i class="fas fa-eye"></i></button>
     <button class="right-icon dl-button" type="button" (click)="goToProcessing()" [disabled]="!(selectedDatasetNodes?.length > 0)">Process selection<i class="fas fa-rocket"></i></button>
 </div>
 

--- a/shanoir-ng-front/src/app/studies/study/study-tree.component.ts
+++ b/shanoir-ng-front/src/app/studies/study/study-tree.component.ts
@@ -18,12 +18,13 @@ import { TaskState } from 'src/app/async-tasks/task.model';
 import { MassDownloadService } from 'src/app/shared/mass-download/mass-download.service';
 import { ExecutionDataService } from 'src/app/vip/execution.data-service';
 import { TreeService } from './tree.service';
-import {DatasetAcquisitionNode, DatasetNode, ExaminationNode, StudyNode} from 'src/app/tree/tree.model';
+import {DatasetAcquisitionNode, DatasetNode, ExaminationNode, ShanoirNode, StudyNode} from 'src/app/tree/tree.model';
 import { MsgBoxService } from 'src/app/shared/msg-box/msg-box.service';
 import { ConfirmDialogService } from 'src/app/shared/components/confirm-dialog/confirm-dialog.service';
 import {Examination} from "../../examinations/shared/examination.model";
 import {environment} from "../../../environments/environment";
 import {ConsoleService} from "../../shared/console/console.service";
+import {Dataset} from "../../datasets/shared/dataset.model";
 
 
 @Component({
@@ -35,9 +36,10 @@ import {ConsoleService} from "../../shared/console/console.service";
 export class StudyTreeComponent {
 
     _selectedDatasetNodes: DatasetNode[] = [];
-    selectedExaminationNodes: number[] = [];
-    selectedAcquisitionNodes: number[] = [];
+    selectedExaminationNodes: ShanoirNode[] = [];
+    selectedAcquisitionNodes: ShanoirNode[] = [];
     protected downloadState: TaskState;
+    canOpenDicom: boolean = false;
 
     constructor(
             protected treeService: TreeService,
@@ -74,18 +76,16 @@ export class StudyTreeComponent {
         let studies = "";
         let series = "";
         if (this.selectedExaminationNodes?.length > 0) {
-            studies = this.selectedExaminationNodes.map(id => `1.4.9.12.34.1.8527.${id}`).join(',');
+            studies = this.selectedExaminationNodes.map(exam => '1.4.9.12.34.1.8527.' + exam.id).join(',');
 
         }
         if (this.selectedAcquisitionNodes?.length > 0) {
-            series = this.selectedAcquisitionNodes.map(id => `1.4.9.12.34.1.8527.${id}`).join(',');
+            series = this.selectedAcquisitionNodes.map(acq => '1.4.9.12.34.1.8527.' + acq.id).join(',');
         }
         console.log("studies : " + studies);
         console.log("series : " + series);
         if (series.length == 0)
             window.open(environment.viewerUrl + '/viewer?StudyInstanceUIDs=' + studies, '_blank');
-        if (studies.length == 0)
-            window.open(environment.viewerUrl + '/viewer?SeriesInstanceUIDs=' + series, '_blank');
         if (series.length > 0 && studies.length > 0) {
             window.open(environment.viewerUrl + '/viewer?StudyInstanceUIDs=' + studies + '&SeriesInstanceUIDs=' + series, '_blank');
         }
@@ -113,26 +113,56 @@ export class StudyTreeComponent {
 
     checkSelectedExams(exam : ExaminationNode) {
         // Exam selected
-        if (exam.selected && this.selectedExaminationNodes.length <= 10 && !this.selectedExaminationNodes.includes(exam.id))
-            this.selectedExaminationNodes.push(exam.id);
+        if (exam.selected && this.selectedExaminationNodes.length <= 10 && !this.selectedExaminationNodes.includes(exam)) {
+            this.selectedExaminationNodes.push(exam);
+            this.canOpenDicom = true;
+        }
         // Exam unselected
-        if (!exam.selected && this.selectedExaminationNodes.includes(exam.id))
-            this.selectedExaminationNodes.splice(this.selectedExaminationNodes.indexOf(exam.id), 1);
+        if (!exam.selected && this.selectedExaminationNodes.includes(exam)) {
+            this.selectedExaminationNodes.splice(this.selectedExaminationNodes.indexOf(exam), 1);
+            if (this.selectedExaminationNodes.length == 0) {
+                this.canOpenDicom = false;
+            }
+            if (this.selectedExaminationNodes.length > 0 && this.selectedExaminationNodes.length <= 10) {
+                this.canOpenDicom = true;
+            }
+        }
+
         // More than 10 exam selected
-        if (this.selectedExaminationNodes.length > 10)
+        if (this.selectedExaminationNodes.length > 10) {
+            this.canOpenDicom = false;
             this.consoleService.log('warn', 'For performance reasons, you cannot open more than 10 examinations in the viewer at the same time.')
+        }
     }
 
     checkSelectedAcquisition(acq: DatasetAcquisitionNode) {
-        // Exam selected
-        if (acq.selected && this.selectedAcquisitionNodes.length <= 10 && !this.selectedAcquisitionNodes.includes(acq.id))
-            this.selectedAcquisitionNodes.push(acq.id);
-        // Exam unselected
-        if (!acq.selected && this.selectedAcquisitionNodes.includes(acq.id))
-            this.selectedAcquisitionNodes.splice(this.selectedAcquisitionNodes.indexOf(acq.id), 1);
-        // More than 10 exam selected
-        if (this.selectedAcquisitionNodes.length > 10)
-            this.consoleService.log('warn', 'For performance reasons, you cannot open more than 10 acquisition in the viewer at the same time.')
+        // Acquisition selected
+        if (acq.selected && this.selectedAcquisitionNodes.length <= 10 && !this.selectedAcquisitionNodes.includes(acq)) {
+            this.selectedAcquisitionNodes.push(acq);
+            if (!this.selectedExaminationNodes.includes(acq.parent))
+                this.selectedExaminationNodes.push(acq.parent);
+            acq.parent.selected = true;
+        }
+        // Acquisition unselected
+        if (!acq.selected && this.selectedAcquisitionNodes.includes(acq))
+            this.selectedAcquisitionNodes.splice(this.selectedAcquisitionNodes.indexOf(acq), 1);
+
+        // If multiple exam are selected, can't open viewer if any acquisition is also selected
+        if (this.selectedExaminationNodes.length > 1) {
+            if (this.selectedAcquisitionNodes.length > 0)
+                this.canOpenDicom = false;
+            if (this.selectedAcquisitionNodes.length == 0)
+                this.canOpenDicom = true;
+        }
+        // Can only open viewer if all selected acquisition belong to the same exam
+        if (this.selectedExaminationNodes.length == 1) {
+            if (this.selectedAcquisitionNodes.every(val => val.parent == this.selectedExaminationNodes[0])) {
+                this.canOpenDicom = true;
+            } else {
+                this.canOpenDicom = false;
+            }
+        }
+
     }
 
     private searchSelectedInDatasetNodes(dsNodes: DatasetNode[] | 'UNLOADED'): DatasetNode[] {

--- a/shanoir-ng-front/src/app/studies/study/study-tree.component.ts
+++ b/shanoir-ng-front/src/app/studies/study/study-tree.component.ts
@@ -82,8 +82,7 @@ export class StudyTreeComponent {
         if (this.selectedAcquisitionNodes?.length > 0) {
             series = this.selectedAcquisitionNodes.map(acq => '1.4.9.12.34.1.8527.' + acq.id).join(',');
         }
-        console.log("studies : " + studies);
-        console.log("series : " + series);
+        
         if (series.length == 0)
             window.open(environment.viewerUrl + '/viewer?StudyInstanceUIDs=' + studies, '_blank');
         if (series.length > 0 && studies.length > 0) {

--- a/shanoir-ng-front/src/app/tree/tree.model.ts
+++ b/shanoir-ng-front/src/app/tree/tree.model.ts
@@ -40,6 +40,8 @@ export abstract class ShanoirNode {
         public label: string
     ) {}
 
+    public selected: boolean = false;
+
     open(): Promise<void> {
         if (this.parent) {
             this.parent.open();


### PR DESCRIPTION
How to test:
Open a study
Select exams or acquisition and click the "View DICOM" button
This button should be enabled only if: 
- only exams are selected
- acquisitions from a single exam are selected

![image](https://github.com/user-attachments/assets/07983cb0-a834-445e-9653-c6d2914f7a2f)
![image](https://github.com/user-attachments/assets/8a33e6a1-a8f9-4ac0-9991-2eacc95a0d9b)
![image](https://github.com/user-attachments/assets/435434fd-8dbf-4b38-88a9-b908121009b7)

This is happening because when the viewer is opened, if there are multiple series (acquisition) and studies (exam) selected, the viewer can't know which series belong to which study. In the same way, if there are only series selected, the viewer won't be able to know from which study they are from.