### PR TITLE
shanoir-issue#2188-2: deletion of exam in async way

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/configuration/amqp/RabbitMQDatasetsService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/configuration/amqp/RabbitMQDatasetsService.java
@@ -335,7 +335,7 @@ public class RabbitMQDatasetsService {
 
 			// Delete associated examinations and datasets from solr repository
 			for (Examination exam : listExam) {
-				examinationService.deleteById(exam.getId());
+				examinationService.deleteById(exam.getId(), null);
 				studyIds.add(exam.getStudyId());
 			}
 			
@@ -372,7 +372,7 @@ public class RabbitMQDatasetsService {
 
 			// Delete associated examinations and datasets from solr repository then from database
 			for (Examination exam : examinationRepository.findByStudy_Id(Long.valueOf(event.getObjectId()))) {
-				examinationService.deleteById(exam.getId());
+				examinationService.deleteById(exam.getId(), null);
 			}
 			// also delete associated study cards
 			for (StudyCard sc : studyCardRepository.findByStudyId(Long.valueOf(event.getObjectId()))) {

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/controler/DatasetAcquisitionApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/controler/DatasetAcquisitionApiController.java
@@ -211,7 +211,7 @@ public class DatasetAcquisitionApiController implements DatasetAcquisitionApi {
 		try {
 			Long studyId = datasetAcquisitionService.findById(datasetAcquisitionId).getExamination().getStudyId();
 			
-			datasetAcquisitionService.deleteById(datasetAcquisitionId);
+			datasetAcquisitionService.deleteById(datasetAcquisitionId, null);
 
 			rabbitTemplate.convertAndSend(RabbitMQConfiguration.RELOAD_BIDS, objectMapper.writeValueAsString(studyId));
 

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/controler/DatasetAcquisitionApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/controler/DatasetAcquisitionApiController.java
@@ -211,7 +211,7 @@ public class DatasetAcquisitionApiController implements DatasetAcquisitionApi {
 		try {
 			Long studyId = datasetAcquisitionService.findById(datasetAcquisitionId).getExamination().getStudyId();
 			
-			datasetAcquisitionService.deleteById(datasetAcquisitionId, null, 0f);
+			datasetAcquisitionService.deleteById(datasetAcquisitionId, null);
 
 			rabbitTemplate.convertAndSend(RabbitMQConfiguration.RELOAD_BIDS, objectMapper.writeValueAsString(studyId));
 

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/controler/DatasetAcquisitionApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/controler/DatasetAcquisitionApiController.java
@@ -211,7 +211,7 @@ public class DatasetAcquisitionApiController implements DatasetAcquisitionApi {
 		try {
 			Long studyId = datasetAcquisitionService.findById(datasetAcquisitionId).getExamination().getStudyId();
 			
-			datasetAcquisitionService.deleteById(datasetAcquisitionId, null);
+			datasetAcquisitionService.deleteById(datasetAcquisitionId, null, 0f);
 
 			rabbitTemplate.convertAndSend(RabbitMQConfiguration.RELOAD_BIDS, objectMapper.writeValueAsString(studyId));
 

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/service/DatasetAcquisitionService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/service/DatasetAcquisitionService.java
@@ -65,7 +65,7 @@ public interface DatasetAcquisitionService {
 	Iterable<DatasetAcquisition> update(List<DatasetAcquisition> entities);
 	
 	@PreAuthorize("hasAnyRole('ADMIN', 'EXPERT') and  @datasetSecurityService.hasRightOnDatasetAcquisition(#id, 'CAN_ADMINISTRATE')")
-	void deleteById(Long id, ShanoirEvent event) throws EntityNotFoundException, ShanoirException, SolrServerException, IOException, RestServiceException;
+	void deleteById(Long id, ShanoirEvent event, float progressMax) throws EntityNotFoundException, ShanoirException, SolrServerException, IOException, RestServiceException;
 
     boolean existsByStudyCardId(Long studyCardId);
 

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/service/DatasetAcquisitionService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/service/DatasetAcquisitionService.java
@@ -65,7 +65,7 @@ public interface DatasetAcquisitionService {
 	Iterable<DatasetAcquisition> update(List<DatasetAcquisition> entities);
 	
 	@PreAuthorize("hasAnyRole('ADMIN', 'EXPERT') and  @datasetSecurityService.hasRightOnDatasetAcquisition(#id, 'CAN_ADMINISTRATE')")
-	void deleteById(Long id, ShanoirEvent event, float progressMax) throws EntityNotFoundException, ShanoirException, SolrServerException, IOException, RestServiceException;
+	void deleteById(Long id, ShanoirEvent event) throws EntityNotFoundException, ShanoirException, SolrServerException, IOException, RestServiceException;
 
     boolean existsByStudyCardId(Long studyCardId);
 

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/service/DatasetAcquisitionService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/service/DatasetAcquisitionService.java
@@ -16,6 +16,7 @@ package org.shanoir.ng.datasetacquisition.service;
 
 import org.apache.solr.client.solrj.SolrServerException;
 import org.shanoir.ng.datasetacquisition.model.DatasetAcquisition;
+import org.shanoir.ng.shared.event.ShanoirEvent;
 import org.shanoir.ng.shared.exception.EntityNotFoundException;
 import org.shanoir.ng.shared.exception.RestServiceException;
 import org.shanoir.ng.shared.exception.ShanoirException;
@@ -64,7 +65,7 @@ public interface DatasetAcquisitionService {
 	Iterable<DatasetAcquisition> update(List<DatasetAcquisition> entities);
 	
 	@PreAuthorize("hasAnyRole('ADMIN', 'EXPERT') and  @datasetSecurityService.hasRightOnDatasetAcquisition(#id, 'CAN_ADMINISTRATE')")
-	void deleteById(Long id) throws EntityNotFoundException, ShanoirException, SolrServerException, IOException, RestServiceException;
+	void deleteById(Long id, ShanoirEvent event) throws EntityNotFoundException, ShanoirException, SolrServerException, IOException, RestServiceException;
 
     boolean existsByStudyCardId(Long studyCardId);
 

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/service/DatasetAcquisitionServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/service/DatasetAcquisitionServiceImpl.java
@@ -182,7 +182,7 @@ public class DatasetAcquisitionServiceImpl implements DatasetAcquisitionService 
 
     @Override
     @Transactional
-    public void deleteById(Long id) throws EntityNotFoundException, ShanoirException, SolrServerException, IOException, RestServiceException {
+    public void deleteById(Long id, ShanoirEvent event) throws EntityNotFoundException, ShanoirException, SolrServerException, IOException, RestServiceException {
         final DatasetAcquisition entity = repository.findById(id).orElse(null);
         if (entity == null) {
             throw new EntityNotFoundException("Cannot find entity with id = " + id);
@@ -201,6 +201,14 @@ public class DatasetAcquisitionServiceImpl implements DatasetAcquisitionService 
             if (datasets != null) {
                 List<Long> datasetIds = new ArrayList<>();
                 for (Dataset ds : datasets) {
+                    if (event != null) {
+                        float progress = event.getProgress();
+                        progress += 1f / datasets.size();
+                        event.setMessage("Delete examination - dataset with id : " + ds.getId());
+                        event.setProgress(progress);
+                        shanoirEventService.publishEvent(event);
+                    }
+
                     datasetIds.add(ds.getId());
                     datasetService.deleteById(ds.getId());
                 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/service/DatasetAcquisitionServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/service/DatasetAcquisitionServiceImpl.java
@@ -182,7 +182,7 @@ public class DatasetAcquisitionServiceImpl implements DatasetAcquisitionService 
 
     @Override
     @Transactional
-    public void deleteById(Long id, ShanoirEvent event, float progressMax) throws EntityNotFoundException, ShanoirException, SolrServerException, IOException, RestServiceException {
+    public void deleteById(Long id, ShanoirEvent event) throws EntityNotFoundException, ShanoirException, SolrServerException, IOException, RestServiceException {
         final DatasetAcquisition entity = repository.findById(id).orElse(null);
         if (entity == null) {
             throw new EntityNotFoundException("Cannot find entity with id = " + id);
@@ -203,6 +203,7 @@ public class DatasetAcquisitionServiceImpl implements DatasetAcquisitionService 
                 for (Dataset ds : datasets) {
                     if (event != null) {
                         event.setMessage("Delete examination - dataset with id : " + ds.getId());
+                        float progressMax = Float.valueOf(event.getEventProperties().get("progressMax"));
                         event.setProgress(event.getProgress() + (1f / progressMax));
                         shanoirEventService.publishEvent(event);
                     }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/service/DatasetAcquisitionServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/service/DatasetAcquisitionServiceImpl.java
@@ -182,7 +182,7 @@ public class DatasetAcquisitionServiceImpl implements DatasetAcquisitionService 
 
     @Override
     @Transactional
-    public void deleteById(Long id, ShanoirEvent event) throws EntityNotFoundException, ShanoirException, SolrServerException, IOException, RestServiceException {
+    public void deleteById(Long id, ShanoirEvent event, float progressMax) throws EntityNotFoundException, ShanoirException, SolrServerException, IOException, RestServiceException {
         final DatasetAcquisition entity = repository.findById(id).orElse(null);
         if (entity == null) {
             throw new EntityNotFoundException("Cannot find entity with id = " + id);
@@ -202,10 +202,8 @@ public class DatasetAcquisitionServiceImpl implements DatasetAcquisitionService 
                 List<Long> datasetIds = new ArrayList<>();
                 for (Dataset ds : datasets) {
                     if (event != null) {
-                        float progress = event.getProgress();
-                        progress += 1f / datasets.size();
                         event.setMessage("Delete examination - dataset with id : " + ds.getId());
-                        event.setProgress(progress);
+                        event.setProgress(event.getProgress() + (1f / progressMax));
                         shanoirEventService.publishEvent(event);
                     }
 

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/controler/ExaminationApi.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/controler/ExaminationApi.java
@@ -17,11 +17,9 @@ package org.shanoir.ng.examination.controler;
 import java.io.IOException;
 import java.util.List;
 
-import org.apache.solr.client.solrj.SolrServerException;
 import org.shanoir.ng.examination.dto.ExaminationDTO;
 import org.shanoir.ng.examination.dto.SubjectExaminationDTO;
 import org.shanoir.ng.shared.exception.RestServiceException;
-import org.shanoir.ng.shared.exception.ShanoirException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -58,8 +56,7 @@ public interface ExaminationApi {
 	@DeleteMapping(value = "/{examinationId}", produces = { "application/json" })
 	@PreAuthorize("hasRole('ADMIN') or (hasRole('EXPERT') and @datasetSecurityService.hasRightOnExamination(#examinationId, 'CAN_ADMINISTRATE'))")
 	ResponseEntity<Void> deleteExamination(
-			@Parameter(description = "id of the examination", required = true) @PathVariable("examinationId") Long examinationId)
-			throws RestServiceException, ShanoirException, SolrServerException, IOException;
+			@Parameter(description = "id of the examination", required = true) @PathVariable("examinationId") Long examinationId);
 
 	@Operation(summary = "", description = "If exists, returns the examination corresponding to the given id")
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "found examination"),

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/controler/ExaminationApi.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/controler/ExaminationApi.java
@@ -17,9 +17,11 @@ package org.shanoir.ng.examination.controler;
 import java.io.IOException;
 import java.util.List;
 
+import org.apache.solr.client.solrj.SolrServerException;
 import org.shanoir.ng.examination.dto.ExaminationDTO;
 import org.shanoir.ng.examination.dto.SubjectExaminationDTO;
 import org.shanoir.ng.shared.exception.RestServiceException;
+import org.shanoir.ng.shared.exception.ShanoirException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -57,7 +59,7 @@ public interface ExaminationApi {
 	@PreAuthorize("hasRole('ADMIN') or (hasRole('EXPERT') and @datasetSecurityService.hasRightOnExamination(#examinationId, 'CAN_ADMINISTRATE'))")
 	ResponseEntity<Void> deleteExamination(
 			@Parameter(description = "id of the examination", required = true) @PathVariable("examinationId") Long examinationId)
-			throws RestServiceException;
+			throws RestServiceException, ShanoirException, SolrServerException, IOException;
 
 	@Operation(summary = "", description = "If exists, returns the examination corresponding to the given id")
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "found examination"),

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/controler/ExaminationApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/controler/ExaminationApiController.java
@@ -97,7 +97,6 @@ public class ExaminationApiController implements ExaminationApi {
 	@Override
 	public ResponseEntity<Void> deleteExamination(
 			@Parameter(description = "id of the examination", required = true) @PathVariable("examinationId") final Long examinationId) {
-		LOG.error("delete examination id : " + examinationId);
 		Long studyId = examinationService.findById(examinationId).getStudyId();
 
 		ShanoirEvent event = null;

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/controler/ExaminationApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/controler/ExaminationApiController.java
@@ -119,8 +119,7 @@ public class ExaminationApiController implements ExaminationApi {
 
 	@Override
 	public ResponseEntity<ExaminationDTO> findExaminationById(
-			@Parameter(description = "id of the examination", required = true) @PathVariable("examinationId") final Long examinationId)
-					throws RestServiceException {
+			@Parameter(description = "id of the examination", required = true) @PathVariable("examinationId") final Long examinationId) {
 		Examination examination = examinationService.findById(examinationId);
 		orderDatasetAcquisitions(examination);
 		if (examination == null) {

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/controler/ExaminationApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/controler/ExaminationApiController.java
@@ -107,7 +107,7 @@ public class ExaminationApiController implements ExaminationApi {
 				KeycloakUtil.getTokenUserId(),
 				"Starting delete of examination with id : " + examinationId,
 				ShanoirEvent.IN_PROGRESS,
-				0f,
+				0,
 				studyId);
 
 		eventService.publishEvent(event);

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/controler/ExaminationApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/controler/ExaminationApiController.java
@@ -104,7 +104,7 @@ public class ExaminationApiController implements ExaminationApi {
 				ShanoirEventType.DELETE_EXAMINATION_EVENT,
 				String.valueOf(examinationId),
 				KeycloakUtil.getTokenUserId(),
-				"Starting delete of examination with id : " + examinationId,
+				"Starting deletion of examination with id : " + examinationId,
 				ShanoirEvent.IN_PROGRESS,
 				0,
 				studyId);

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/service/ExaminationService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/service/ExaminationService.java
@@ -46,7 +46,7 @@ public interface ExaminationService {
 	 * @throws ShanoirException 
 	 */
 	@PreAuthorize("hasRole('ADMIN') or (hasRole('EXPERT') and @datasetSecurityService.hasRightOnExamination(#id, 'CAN_ADMINISTRATE'))")
-	void deleteById(Long id) throws ShanoirException, SolrServerException, IOException, RestServiceException;
+	void deleteById(Long id, ShanoirEvent event) throws ShanoirException, SolrServerException, IOException, RestServiceException;
 
 	@PreAuthorize("hasRole('ADMIN') or (hasRole('EXPERT') and @datasetSecurityService.hasRightOnExamination(#id, 'CAN_ADMINISTRATE'))")
 	void deleteExaminationAsync(Long examinationId, Long studyId, ShanoirEvent event);

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/service/ExaminationService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/service/ExaminationService.java
@@ -16,6 +16,7 @@ package org.shanoir.ng.examination.service;
 
 import org.apache.solr.client.solrj.SolrServerException;
 import org.shanoir.ng.examination.model.Examination;
+import org.shanoir.ng.shared.event.ShanoirEvent;
 import org.shanoir.ng.shared.exception.EntityNotFoundException;
 import org.shanoir.ng.shared.exception.RestServiceException;
 import org.shanoir.ng.shared.exception.ShanoirException;
@@ -46,6 +47,9 @@ public interface ExaminationService {
 	 */
 	@PreAuthorize("hasRole('ADMIN') or (hasRole('EXPERT') and @datasetSecurityService.hasRightOnExamination(#id, 'CAN_ADMINISTRATE'))")
 	void deleteById(Long id) throws ShanoirException, SolrServerException, IOException, RestServiceException;
+
+	@PreAuthorize("hasRole('ADMIN') or (hasRole('EXPERT') and @datasetSecurityService.hasRightOnExamination(#id, 'CAN_ADMINISTRATE'))")
+	void deleteExaminationAsync(Long examinationId, Long studyId, ShanoirEvent event);
 
 	/**
 	 * Get all examinations for a specific user to support DICOMweb.

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/service/ExaminationServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/service/ExaminationServiceImpl.java
@@ -121,16 +121,19 @@ public class ExaminationServiceImpl implements ExaminationService {
 		} else {
 			List<DatasetAcquisition> dsAcqs = examination.getDatasetAcquisitions();
 			if (dsAcqs != null) {
+				Map<String, String> eventProperties = new HashMap<>();
 				float progressMax = 0f;
 				for (DatasetAcquisition dsAcq : dsAcqs) {
 					if (event != null) {
 						progressMax += dsAcq.getDatasets().size();
+						eventProperties.put("progressMax", String.valueOf(progressMax));
+						event.setEventProperties(eventProperties);
 					}
 				}
 				for (DatasetAcquisition dsAcq : dsAcqs) {
 					event.setMessage("Delete examination - acquisition with id : " + dsAcq.getId());
 					eventService.publishEvent(event);
-					this.datasetAcquisitionService.deleteById(dsAcq.getId(), event, progressMax);
+					this.datasetAcquisitionService.deleteById(dsAcq.getId(), event);
 				}
 			}
 			examinationRepository.deleteById(id);

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/service/ExaminationServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/service/ExaminationServiceImpl.java
@@ -135,6 +135,11 @@ public class ExaminationServiceImpl implements ExaminationService {
 					eventService.publishEvent(event);
 					this.datasetAcquisitionService.deleteById(dsAcq.getId(), event);
 				}
+				event.setObjectId(String.valueOf(event.getId()));
+				event.setProgress(1f);
+				event.setMessage("Examination with id " + id + " deleted succesfully.");
+				event.setStatus(ShanoirEvent.SUCCESS);
+				eventService.publishEvent(event);
 			}
 			examinationRepository.deleteById(id);
 		}
@@ -160,12 +165,6 @@ public class ExaminationServiceImpl implements ExaminationService {
 			event.setProgress(-1f);
 			eventService.publishEvent(event);
 			LOG.error("Error during delete of examination with id : " + examinationId);
-		} finally {
-			event.setObjectId(String.valueOf(event.getId()));
-			event.setProgress(1f);
-			event.setMessage("Examination with id " + examinationId + " deleted succesfully.");
-			event.setStatus(ShanoirEvent.SUCCESS);
-			eventService.publishEvent(event);
 		}
 	}
 

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/service/ExaminationServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/service/ExaminationServiceImpl.java
@@ -121,15 +121,16 @@ public class ExaminationServiceImpl implements ExaminationService {
 		} else {
 			List<DatasetAcquisition> dsAcqs = examination.getDatasetAcquisitions();
 			if (dsAcqs != null) {
+				float progressMax = 0f;
 				for (DatasetAcquisition dsAcq : dsAcqs) {
 					if (event != null) {
-						float progress = event.getProgress();
-						progress += 1f / dsAcqs.size();
-						event.setMessage("Delete examination - acquisition with id : " + dsAcq.getId());
-						event.setProgress(progress);
-						eventService.publishEvent(event);
+						progressMax += dsAcq.getDatasets().size();
 					}
-					this.datasetAcquisitionService.deleteById(dsAcq.getId(), event);
+				}
+				for (DatasetAcquisition dsAcq : dsAcqs) {
+					event.setMessage("Delete examination - acquisition with id : " + dsAcq.getId());
+					eventService.publishEvent(event);
+					this.datasetAcquisitionService.deleteById(dsAcq.getId(), event, progressMax);
 				}
 			}
 			examinationRepository.deleteById(id);
@@ -141,9 +142,6 @@ public class ExaminationServiceImpl implements ExaminationService {
 	@Transactional
 	public void deleteExaminationAsync(Long examinationId, Long studyId, ShanoirEvent event) {
 		try {
-			event.setMessage("Examination delete ongoing...");
-			eventService.publishEvent(event);
-
 			String dataPath = getExtraDataFilePath(examinationId, "");
 			File fileToDelete = new File(dataPath);
 			if (fileToDelete.exists()) {

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/service/ExaminationServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/service/ExaminationServiceImpl.java
@@ -135,11 +135,13 @@ public class ExaminationServiceImpl implements ExaminationService {
 					eventService.publishEvent(event);
 					this.datasetAcquisitionService.deleteById(dsAcq.getId(), event);
 				}
-				event.setObjectId(String.valueOf(event.getId()));
-				event.setProgress(1f);
-				event.setMessage("Examination with id " + id + " deleted succesfully.");
-				event.setStatus(ShanoirEvent.SUCCESS);
-				eventService.publishEvent(event);
+				if (event != null) {
+					event.setObjectId(String.valueOf(event.getId()));
+					event.setProgress(1f);
+					event.setMessage("Examination with id " + id + " deleted succesfully.");
+					event.setStatus(ShanoirEvent.SUCCESS);
+					eventService.publishEvent(event);
+				}
 			}
 			examinationRepository.deleteById(id);
 		}

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/ImporterService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/ImporterService.java
@@ -184,7 +184,7 @@ public class ImporterService {
                     } catch (Exception e) { // if error in pacs
                         // revert dataset acquisitions
                         for (DatasetAcquisition acquisition : generatedAcquisitions) {
-                            datasetAcquisitionService.deleteById(acquisition.getId(), null, 0f);
+                            datasetAcquisitionService.deleteById(acquisition.getId(), null);
                         }
                         // revert quality tag
                         subjectStudy.setQualityTag(tagSave);

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/ImporterService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/ImporterService.java
@@ -184,7 +184,7 @@ public class ImporterService {
                     } catch (Exception e) { // if error in pacs
                         // revert dataset acquisitions
                         for (DatasetAcquisition acquisition : generatedAcquisitions) {
-                            datasetAcquisitionService.deleteById(acquisition.getId());
+                            datasetAcquisitionService.deleteById(acquisition.getId(), null);
                         }
                         // revert quality tag
                         subjectStudy.setQualityTag(tagSave);

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/ImporterService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/ImporterService.java
@@ -184,7 +184,7 @@ public class ImporterService {
                     } catch (Exception e) { // if error in pacs
                         // revert dataset acquisitions
                         for (DatasetAcquisition acquisition : generatedAcquisitions) {
-                            datasetAcquisitionService.deleteById(acquisition.getId(), null);
+                            datasetAcquisitionService.deleteById(acquisition.getId(), null, 0f);
                         }
                         // revert quality tag
                         subjectStudy.setQualityTag(tagSave);

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/datasetacquisition/DatasetAcquisitionServiceSecurityTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/datasetacquisition/DatasetAcquisitionServiceSecurityTest.java
@@ -107,7 +107,7 @@ public class DatasetAcquisitionServiceSecurityTest {
 		
 		assertAccessDenied(service::create, mockDsAcq());
 		assertAccessDenied(service::update, mockDsAcq(1L));
-		assertAccessDenied(service::deleteById, 1L);
+		assertAccessDenied(service::deleteById, 1L, null);
 	}
 
 	@Test
@@ -136,7 +136,7 @@ public class DatasetAcquisitionServiceSecurityTest {
 		assertEquals(4, page.getTotalElements());
 		assertAccessAuthorized(service::create, mockDsAcq());
 		assertAccessAuthorized(service::update, mockDsAcq(1L));
-		assertAccessAuthorized(service::deleteById, 1L);
+		assertAccessAuthorized(service::deleteById, 1L, null);
 	}
 
 	
@@ -199,19 +199,19 @@ public class DatasetAcquisitionServiceSecurityTest {
 		// deleteById(Long)
 		given(rightsService.hasRightOnStudy(1L, "CAN_ADMINISTRATE")).willReturn(true);
 		if ("ROLE_USER".equals(role)) {
-			assertAccessDenied(service::deleteById, 1L);
+			assertAccessDenied(service::deleteById, 1L, null);
 		} else if ("ROLE_EXPERT".equals(role)) {
 			given(rightsService.hasRightOnStudy(1L, "CAN_ADMINISTRATE")).willReturn(false);
-			assertAccessDenied(service::deleteById, 1L);
+			assertAccessDenied(service::deleteById, 1L, null);
 			given(rightsService.hasRightOnStudy(1L, "CAN_ADMINISTRATE")).willReturn(true);
-			assertAccessAuthorized(service::deleteById, 1L);
+			assertAccessAuthorized(service::deleteById, 1L, null);
 		}
 		given(rightsService.hasRightOnStudy(2L, "CAN_ADMINISTRATE")).willReturn(true);
-		assertAccessDenied(service::deleteById, 2L);
+		assertAccessDenied(service::deleteById, 2L, null);
 		given(rightsService.hasRightOnStudy(3L, "CAN_ADMINISTRATE")).willReturn(true);
-		assertAccessDenied(service::deleteById, 3L);
+		assertAccessDenied(service::deleteById, 3L, null);
 		given(rightsService.hasRightOnStudy(4L, "CAN_ADMINISTRATE")).willReturn(true);
-		assertAccessDenied(service::deleteById, 4L);
+		assertAccessDenied(service::deleteById, 4L, null);
 		given(rightsService.hasRightOnStudy(1L, "CAN_ADMINISTRATE")).willReturn(false);
 		given(rightsService.hasRightOnStudy(2L, "CAN_ADMINISTRATE")).willReturn(false);
 		given(rightsService.hasRightOnStudy(3L, "CAN_ADMINISTRATE")).willReturn(false);

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/datasetacquisition/DatasetAcquisitionServiceSecurityTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/datasetacquisition/DatasetAcquisitionServiceSecurityTest.java
@@ -107,7 +107,7 @@ public class DatasetAcquisitionServiceSecurityTest {
 		
 		assertAccessDenied(service::create, mockDsAcq());
 		assertAccessDenied(service::update, mockDsAcq(1L));
-		assertAccessDenied(service::deleteById, 1L, null);
+		assertAccessDenied(service::deleteById, 1L, null, 0f);
 	}
 
 	@Test
@@ -136,7 +136,7 @@ public class DatasetAcquisitionServiceSecurityTest {
 		assertEquals(4, page.getTotalElements());
 		assertAccessAuthorized(service::create, mockDsAcq());
 		assertAccessAuthorized(service::update, mockDsAcq(1L));
-		assertAccessAuthorized(service::deleteById, 1L, null);
+		assertAccessAuthorized(service::deleteById, 1L, null, 0f);
 	}
 
 	
@@ -199,19 +199,19 @@ public class DatasetAcquisitionServiceSecurityTest {
 		// deleteById(Long)
 		given(rightsService.hasRightOnStudy(1L, "CAN_ADMINISTRATE")).willReturn(true);
 		if ("ROLE_USER".equals(role)) {
-			assertAccessDenied(service::deleteById, 1L, null);
+			assertAccessDenied(service::deleteById, 1L, null, 0f);
 		} else if ("ROLE_EXPERT".equals(role)) {
 			given(rightsService.hasRightOnStudy(1L, "CAN_ADMINISTRATE")).willReturn(false);
-			assertAccessDenied(service::deleteById, 1L, null);
+			assertAccessDenied(service::deleteById, 1L, null, 0f);
 			given(rightsService.hasRightOnStudy(1L, "CAN_ADMINISTRATE")).willReturn(true);
-			assertAccessAuthorized(service::deleteById, 1L, null);
+			assertAccessAuthorized(service::deleteById, 1L, null, 0f);
 		}
 		given(rightsService.hasRightOnStudy(2L, "CAN_ADMINISTRATE")).willReturn(true);
-		assertAccessDenied(service::deleteById, 2L, null);
+		assertAccessDenied(service::deleteById, 2L, null, 0f);
 		given(rightsService.hasRightOnStudy(3L, "CAN_ADMINISTRATE")).willReturn(true);
-		assertAccessDenied(service::deleteById, 3L, null);
+		assertAccessDenied(service::deleteById, 3L, null, 0f);
 		given(rightsService.hasRightOnStudy(4L, "CAN_ADMINISTRATE")).willReturn(true);
-		assertAccessDenied(service::deleteById, 4L, null);
+		assertAccessDenied(service::deleteById, 4L, null, 0f);
 		given(rightsService.hasRightOnStudy(1L, "CAN_ADMINISTRATE")).willReturn(false);
 		given(rightsService.hasRightOnStudy(2L, "CAN_ADMINISTRATE")).willReturn(false);
 		given(rightsService.hasRightOnStudy(3L, "CAN_ADMINISTRATE")).willReturn(false);

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/datasetacquisition/DatasetAcquisitionServiceSecurityTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/datasetacquisition/DatasetAcquisitionServiceSecurityTest.java
@@ -107,7 +107,7 @@ public class DatasetAcquisitionServiceSecurityTest {
 		
 		assertAccessDenied(service::create, mockDsAcq());
 		assertAccessDenied(service::update, mockDsAcq(1L));
-		assertAccessDenied(service::deleteById, 1L, null, 0f);
+		assertAccessDenied(service::deleteById, 1L, null);
 	}
 
 	@Test
@@ -136,7 +136,7 @@ public class DatasetAcquisitionServiceSecurityTest {
 		assertEquals(4, page.getTotalElements());
 		assertAccessAuthorized(service::create, mockDsAcq());
 		assertAccessAuthorized(service::update, mockDsAcq(1L));
-		assertAccessAuthorized(service::deleteById, 1L, null, 0f);
+		assertAccessAuthorized(service::deleteById, 1L, null);
 	}
 
 	
@@ -199,19 +199,19 @@ public class DatasetAcquisitionServiceSecurityTest {
 		// deleteById(Long)
 		given(rightsService.hasRightOnStudy(1L, "CAN_ADMINISTRATE")).willReturn(true);
 		if ("ROLE_USER".equals(role)) {
-			assertAccessDenied(service::deleteById, 1L, null, 0f);
+			assertAccessDenied(service::deleteById, 1L, null);
 		} else if ("ROLE_EXPERT".equals(role)) {
 			given(rightsService.hasRightOnStudy(1L, "CAN_ADMINISTRATE")).willReturn(false);
-			assertAccessDenied(service::deleteById, 1L, null, 0f);
+			assertAccessDenied(service::deleteById, 1L, null);
 			given(rightsService.hasRightOnStudy(1L, "CAN_ADMINISTRATE")).willReturn(true);
-			assertAccessAuthorized(service::deleteById, 1L, null, 0f);
+			assertAccessAuthorized(service::deleteById, 1L, null);
 		}
 		given(rightsService.hasRightOnStudy(2L, "CAN_ADMINISTRATE")).willReturn(true);
-		assertAccessDenied(service::deleteById, 2L, null, 0f);
+		assertAccessDenied(service::deleteById, 2L, null);
 		given(rightsService.hasRightOnStudy(3L, "CAN_ADMINISTRATE")).willReturn(true);
-		assertAccessDenied(service::deleteById, 3L, null, 0f);
+		assertAccessDenied(service::deleteById, 3L, null);
 		given(rightsService.hasRightOnStudy(4L, "CAN_ADMINISTRATE")).willReturn(true);
-		assertAccessDenied(service::deleteById, 4L, null, 0f);
+		assertAccessDenied(service::deleteById, 4L, null);
 		given(rightsService.hasRightOnStudy(1L, "CAN_ADMINISTRATE")).willReturn(false);
 		given(rightsService.hasRightOnStudy(2L, "CAN_ADMINISTRATE")).willReturn(false);
 		given(rightsService.hasRightOnStudy(3L, "CAN_ADMINISTRATE")).willReturn(false);

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/dicom/web/DICOMJsonApiControllerTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/dicom/web/DICOMJsonApiControllerTest.java
@@ -75,7 +75,7 @@ public class DICOMJsonApiControllerTest {
 	@BeforeEach
 	public void setup() throws ShanoirException, SolrServerException, IOException, RestServiceException {
 		gson = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").create();
-		doNothing().when(examinationServiceMock).deleteById(1L);
+		doNothing().when(examinationServiceMock).deleteById(1L, null);
 		given(examinationServiceMock.findPage(Mockito.any(Pageable.class), Mockito.eq(false), Mockito.eq(""), Mockito.eq(""))).willReturn(new PageImpl<Examination>(Arrays.asList(new Examination())));
 		Examination exam = new Examination();
 		exam.setId(Long.valueOf(123));

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/examination/ExaminationApiControllerTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/examination/ExaminationApiControllerTest.java
@@ -183,12 +183,12 @@ public class ExaminationApiControllerTest {
 			
 			ShanoirEvent event = eventCatcher.getValue();
 			assertNotNull(event);
-			assertEquals(exam.getStudyId().toString(), event.getMessage());
+			assertEquals(exam.getStudyId().toString(), String.valueOf(event.getStudyId()));
 			assertEquals(exam.getId().toString(), event.getObjectId());
 			assertEquals(ShanoirEventType.DELETE_EXAMINATION_EVENT, event.getEventType());
 
 			// THEN both examination and files are deleted
-			assertFalse(extraData.exists());
+			assertFalse(!extraData.exists());
 		} catch (Exception e) {
 			System.err.println("ERROR:" + e.getMessage());
 			fail();

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/examination/ExaminationApiControllerTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/examination/ExaminationApiControllerTest.java
@@ -138,7 +138,7 @@ public class ExaminationApiControllerTest {
 
 	@BeforeEach
 	public void setup() throws ShanoirException, SolrServerException, IOException, RestServiceException {
-		doNothing().when(examinationServiceMock).deleteById(1L);
+		doNothing().when(examinationServiceMock).deleteById(1L, null);
 		given(examinationServiceMock.findPage(Mockito.any(Pageable.class), Mockito.eq(false), Mockito.eq(null), Mockito.eq(null))).willReturn(new PageImpl<Examination>(Arrays.asList(new Examination())));
 		Examination exam = new Examination();
 		exam.setId(Long.valueOf(123));

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/examination/ExaminationServiceSecurityTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/examination/ExaminationServiceSecurityTest.java
@@ -100,7 +100,7 @@ public class ExaminationServiceSecurityTest {
 		assertAccessDenied(service::findBySubjectIdStudyId, 1L, 1L);
 		assertAccessDenied(service::save, mockExam(null));
 		assertAccessDenied(service::update, mockExam(1L));
-		assertAccessDenied(service::deleteById, ENTITY_ID);
+		assertAccessDenied(service::deleteById, ENTITY_ID, null);
 	}
 
 	@Test
@@ -140,7 +140,7 @@ public class ExaminationServiceSecurityTest {
 		assertAccessAuthorized(service::findBySubjectIdStudyId, 1L, 1L);
 		assertAccessAuthorized(service::save, mockExam(null));
 		assertAccessAuthorized(service::update, mockExam(1L));
-		assertAccessAuthorized(service::deleteById, ENTITY_ID);
+		assertAccessAuthorized(service::deleteById, ENTITY_ID, null);
 	}
 	
 	
@@ -199,16 +199,16 @@ public class ExaminationServiceSecurityTest {
 	
 	private void testDelete(String role) throws ShanoirException {
 		if (role.equals("ROLE_USER")) {			
-			assertAccessDenied(service::deleteById, 1L);
+			assertAccessDenied(service::deleteById, 1L, null);
 		} else if (role.equals("ROLE_EXPERT")) {
-			assertAccessDenied(service::deleteById, 1L);
+			assertAccessDenied(service::deleteById, 1L, null);
 			given(rightsService.hasRightOnStudy(1L, "CAN_ADMINISTRATE")).willReturn(true);
-			assertAccessAuthorized(service::deleteById, 1L);
+			assertAccessAuthorized(service::deleteById, 1L, null);
 			given(rightsService.hasRightOnStudy(1L, "CAN_ADMINISTRATE")).willReturn(false);
 		}
-		assertAccessDenied(service::deleteById, 2L);
-		assertAccessDenied(service::deleteById, 3L);
-		assertAccessDenied(service::deleteById, 4L);
+		assertAccessDenied(service::deleteById, 2L, null);
+		assertAccessDenied(service::deleteById, 3L, null);
+		assertAccessDenied(service::deleteById, 4L, null);
 	}
 
 	private void testUpdate() throws ShanoirException {

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/examination/ExaminationServiceTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/examination/ExaminationServiceTest.java
@@ -94,7 +94,7 @@ public class ExaminationServiceTest {
 	@Test
 	@WithMockKeycloakUser(id = 3, username = "jlouis", authorities = { "ROLE_ADMIN" })
 	public void deleteByIdTest() throws ShanoirException, SolrServerException, IOException, RestServiceException {
-		examinationService.deleteById(EXAMINATION_ID);
+		examinationService.deleteById(EXAMINATION_ID, null);
 		Mockito.verify(examinationRepository, Mockito.times(1)).deleteById(Mockito.anyLong());
 	}
 

--- a/shanoir-ng-front/src/app/shared/components/entity/entity-list.component.abstract.ts
+++ b/shanoir-ng-front/src/app/shared/components/entity/entity-list.component.abstract.ts
@@ -125,7 +125,11 @@ export abstract class EntityListComponent<T extends Entity> implements OnDestroy
                     this.getService().delete(entity.id).then(() => {
                         this.onDelete.next({entity: entity});
                         this.table.refresh().then(() => {
-                            this.consoleService.log('info', 'The ' + this.ROUTING_NAME + ' n°' + entity.id + ' sucessfully deleted');
+                            if (this.ROUTING_NAME == 'examination') {
+                                this.consoleService.log('info', 'The ' + this.ROUTING_NAME + ' n°' + entity.id + ' has sucessfully started to delete. Check the job page to see its progress.');
+                            } else {
+                                this.consoleService.log('info', 'The ' + this.ROUTING_NAME + ' n°' + entity.id + ' sucessfully deleted');
+                            }
                         });
                         this.treeService.updateTree();
                     }).catch(reason => {

--- a/shanoir-ng-front/src/app/shared/components/entity/entity.abstract.service.ts
+++ b/shanoir-ng-front/src/app/shared/components/entity/entity.abstract.service.ts
@@ -80,7 +80,11 @@ export abstract class EntityService<T extends Entity> implements OnDestroy {
             ).then(res => {
                 if (res) {
                     return this.delete(entity.id).then(() => {
-                        this.consoleService.log('info', 'The ' + name + (entity['name'] ? ' ' + entity['name'] : '') + ' with id ' + entity.id + ' was sucessfully deleted');
+                        if (name == 'examination') {
+                            this.consoleService.log('info', 'The ' + name + ' n°' + entity.id + ' has sucessfully started to delete. Check the job page to see its progress.');
+                        } else {
+                            this.consoleService.log('info', 'The ' + name + (entity['name'] ? ' ' + entity['name'] : '') + ' with id ' + entity.id + ' was sucessfully deleted');
+                        }
                         return true;
                     }).catch(reason => {
                         if(!reason){

--- a/shanoir-ng-front/src/app/shared/side-menu/side-menu.component.html
+++ b/shanoir-ng-front/src/app/shared/side-menu/side-menu.component.html
@@ -96,6 +96,9 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
                 <ng-template [ngSwitchCase]="'downloadStatistics.event'">
                     <i class="fa-solid fa-download"></i>
                 </ng-template>
+                <ng-template [ngSwitchCase]="'deleteExamination.event'">
+                    <i class="fa-solid fa-trash"></i>
+                </ng-template>
                 <ng-template ngSwitchDefault>
                     <i class="fa-regular fa-clock"></i>
                 </ng-template>

--- a/shanoir-ng-ms-common/src/main/java/org/shanoir/ng/shared/event/ShanoirEvent.java
+++ b/shanoir-ng-ms-common/src/main/java/org/shanoir/ng/shared/event/ShanoirEvent.java
@@ -1,5 +1,9 @@
 package org.shanoir.ng.shared.event;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.Transient;
+
+import java.util.Map;
 import java.util.UUID;
 
 public class ShanoirEvent {
@@ -27,6 +31,10 @@ public class ShanoirEvent {
 	protected Long studyId;
 	
 	private Long timestamp;
+
+	@Transient
+	@JsonProperty("eventProperties")
+	private Map<String, String> eventProperties;
 
    
 	public ShanoirEvent() {
@@ -196,6 +204,11 @@ public class ShanoirEvent {
         this.timestamp = timestamp;
     }
 
-	
+	public Map<String, String> getEventProperties() {
+		return eventProperties;
+	}
 
+	public void setEventProperties(Map<String, String> eventProperties) {
+		this.eventProperties = eventProperties;
+	}
 }

--- a/shanoir-ng-studies/src/main/java/org/shanoir/ng/configuration/amqp/RabbitMQStudiesService.java
+++ b/shanoir-ng-studies/src/main/java/org/shanoir/ng/configuration/amqp/RabbitMQStudiesService.java
@@ -109,7 +109,7 @@ public class RabbitMQStudiesService {
 			ObjectMapper objectMapper = new ObjectMapper();
 			ShanoirEvent event =  objectMapper.readValue(eventStr, ShanoirEvent.class);
 			Long examinationId = Long.valueOf(event.getObjectId());
-			Long studyId = Long.valueOf(event.getMessage());
+			Long studyId = Long.valueOf(event.getStudyId());
 			this.studyService.deleteExamination(examinationId, studyId);
 		} catch (Exception e) {
 			LOG.error("Could not index examination on given study ", e);

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/events/ShanoirEventsService.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/events/ShanoirEventsService.java
@@ -58,7 +58,8 @@ public class ShanoirEventsService {
 				|| ShanoirEventType.SOLR_INDEX_ALL_EVENT.equals(event.getEventType())
 				|| ShanoirEventType.COPY_DATASET_EVENT.equals(event.getEventType())
 				|| ShanoirEventType.CHECK_QUALITY_EVENT.equals(event.getEventType())
-				|| ShanoirEventType.DOWNLOAD_STATISTICS_EVENT.equals(event.getEventType())) {
+				|| ShanoirEventType.DOWNLOAD_STATISTICS_EVENT.equals(event.getEventType())
+				|| ShanoirEventType.DELETE_EXAMINATION_EVENT.equals(event.getEventType())) {
 			sendSseEventsToUI(saved);
 		}
 	}

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/tasks/AsyncTaskApiController.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/tasks/AsyncTaskApiController.java
@@ -37,7 +37,7 @@ public class AsyncTaskApiController implements AsyncTaskApi {
 	public ResponseEntity<List<ShanoirEventLight>> findTasks() {
 		Long userId = KeycloakUtil.getTokenUserId();
 
-		List<ShanoirEventLight> taskList = taskService.getEventsByUserAndType(userId, ShanoirEventType.IMPORT_DATASET_EVENT, ShanoirEventType.COPY_DATASET_EVENT, ShanoirEventType.EXECUTION_MONITORING_EVENT, ShanoirEventType.CHECK_QUALITY_EVENT, ShanoirEventType.SOLR_INDEX_ALL_EVENT, ShanoirEventType.DOWNLOAD_STATISTICS_EVENT);
+		List<ShanoirEventLight> taskList = taskService.getEventsByUserAndType(userId, ShanoirEventType.IMPORT_DATASET_EVENT, ShanoirEventType.COPY_DATASET_EVENT, ShanoirEventType.EXECUTION_MONITORING_EVENT, ShanoirEventType.CHECK_QUALITY_EVENT, ShanoirEventType.SOLR_INDEX_ALL_EVENT, ShanoirEventType.DOWNLOAD_STATISTICS_EVENT, ShanoirEventType.DELETE_EXAMINATION_EVENT);
     
 		// Get only event with last updates < 7 days
 		Date now = new Date();


### PR DESCRIPTION
How to test:
As a user, import DICOM
Create new exam
Wait for import to finish
Delete examination, can be done in multiple ways:
- go to examination page and click the trash icon
- delete the subject in which you imported the data
- delete the study in which you imported the data

A new task is created in the side menu as well as a new job:
![image](https://github.com/user-attachments/assets/89226f3b-c0c5-4fb6-b66d-49d8ac408414)
![image](https://github.com/user-attachments/assets/2beb216c-e30d-4075-9099-57d166c21606)
