### PR TITLE
CI: fix docker bake invocation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -143,4 +143,7 @@ jobs:
       - name: Build docker images
         uses: docker/bake-action@v4
         with:
+          files:
+            - docker-compose-dev.yml
+            - docker-bake.json
           push: true


### PR DESCRIPTION
the fix in #2461 was incomplete

since our config is no longer in the default 'docker-compose.yml' we need to set our bake files explicitly
https://docs.docker.com/build/bake/reference/

