### PR TITLE
shanoir-issue#2475: add new validator to check empty subject name

### DIFF
--- a/shanoir-ng-front/src/app/studies/tree/study-node.component.ts
+++ b/shanoir-ng-front/src/app/studies/tree/study-node.component.ts
@@ -162,7 +162,7 @@ export class StudyNodeComponent implements OnChanges {
         this.subjectsOrder = sort;
         if (!(this.node.subjectsNode.subjects == 'UNLOADED')) {
             if (this.subjectsOrder.field == 'name') {
-                this.node.subjectsNode.subjects.sort((a, b) => a.label?.localeCompare(b.label));
+                this.node.subjectsNode.subjects.sort((a, b) => a.label?.trim().localeCompare(b.label.trim()));
             } else if (this.subjectsOrder.field == 'id') {
                 this.node.subjectsNode.subjects.sort((a, b) => b.id - a.id);
             }

--- a/shanoir-ng-front/src/app/subjects/subject/subject.component.html
+++ b/shanoir-ng-front/src/app/subjects/subject/subject.component.html
@@ -105,6 +105,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
                                 <label *ngIf="hasError('name', ['unique'])" class="form-validation-alert" i18n="Subject detail|Name unique error@@subjectDetailNameUniqueError">This name is already taken !</label>
                                 <label *ngIf="hasError('name', ['subjectNamePrefix'])" class="form-validation-alert" i18n="Subject detail|Name unique error@@subjectDetailNameUniqueError">The name should not be equal to the study prefix.</label>
                                 <label *ngIf="hasError('name', ['pattern'])" class="form-validation-alert" i18n="Subject detail|Name chars error@@subjectDetailNameCharsError">Forbidden characters</label>
+                                <label *ngIf="hasError('name', ['notEmptyValidator'])" class="form-validation-alert" i18n="Subject detail|Name empty error@@subjectDetailNameCharsError">Name must contain more than one character</label>
                             </ng-template>
                         </span>
 					</li>

--- a/shanoir-ng-front/src/app/subjects/subject/subject.component.ts
+++ b/shanoir-ng-front/src/app/subjects/subject/subject.component.ts
@@ -144,7 +144,7 @@ export class SubjectComponent extends EntityComponent<Subject> {
         let subjectForm = this.formBuilder.group({
             'imagedObjectCategory': [this.subject.imagedObjectCategory, [Validators.required]],
             'isAlreadyAnonymized': [],
-            'name': [this.subject.name, this.nameValidators.concat([this.registerOnSubmitValidator('unique', 'name')]).concat(this.forbiddenNameValidator([this.subjectNamePrefix]))],
+            'name': [this.subject.name, this.nameValidators.concat([this.registerOnSubmitValidator('unique', 'name')]).concat(this.forbiddenNameValidator([this.subjectNamePrefix])).concat([this.notEmptyValidator()])],
             'firstName': [this.firstName],
             'lastName': [this.lastName],
             'birthDate': [this.subject.birthDate],
@@ -179,6 +179,15 @@ export class SubjectComponent extends EntityComponent<Subject> {
         }
         return null;
       };
+    }
+
+    private notEmptyValidator(): ValidatorFn {
+        return (c: AbstractControl): { [key: string]: boolean } | null => {
+            if (!c.value || c.value.trim().length < 2) {
+                return { 'notEmptyValidator': true };
+            }
+            return null;
+        };
     }
 
     private updateFormControl(formGroup: UntypedFormGroup) {


### PR DESCRIPTION
How to test:
Open subject-list > New
Fill the form (firstname, lastname, date of birth, add a study) and fill the name: if the input after trim (remove starting and ending spaces) is less than 2 char, an error is shown:
![image](https://github.com/user-attachments/assets/82440fd2-8aeb-4d1a-8340-b6f13117e161)
![image](https://github.com/user-attachments/assets/fa3ba6ef-8650-491f-819d-e34a3a7996ac)
![image](https://github.com/user-attachments/assets/f44db339-c39b-4633-b7f7-2440aeb1a388)

Also test during subject creation at import