### PR TITLE
#2488 : API for in/out download from a list of processingIds

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/controler/DatasetApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/controler/DatasetApiController.java
@@ -60,6 +60,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.data.domain.Page;
@@ -139,8 +140,9 @@ public class DatasetApiController implements DatasetApi {
 	@Autowired
 	private SolrService solrService;
 
-	@Autowired
-	DatasetDownloaderServiceImpl datasetDownloaderService;
+    @Qualifier("datasetDownloaderServiceImpl")
+    @Autowired
+	protected DatasetDownloaderServiceImpl datasetDownloaderService;
 
 	@Autowired
 	private ObjectMapper objectMapper;

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/repository/DatasetRepository.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/repository/DatasetRepository.java
@@ -79,4 +79,9 @@ public interface DatasetRepository extends PagingAndSortingRepository<Dataset, L
     List<Dataset> deleteByDatasetProcessingId(Long id);
 
 	boolean existsByTagsContains(StudyTag tag);
+
+	@Query(value="SELECT ds.id FROM dataset as ds " +
+			"INNER JOIN input_of_dataset_processing as input ON ds.id=input.dataset_id " +
+			"WHERE input.processing_id = :processingId or ds.dataset_processing_id = :processingId", nativeQuery = true)
+	List<Dataset> findDatasetsByProcessingId(Long processingId);
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/security/DatasetSecurityService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/security/DatasetSecurityService.java
@@ -466,28 +466,32 @@ public class DatasetSecurityService {
 		}
     	
     	Iterable<Dataset> datasets = datasetRepository.findAllById(datasetIds);
-    	 
-    	boolean hasRight = true;
-    	for (Dataset dataset : datasets) {
-            if (dataset.getDatasetAcquisition() == null 
-                    || dataset.getDatasetAcquisition().getExamination() == null
-                    || dataset.getDatasetAcquisition().getExamination().getStudyId() == null) {
-                
-                if (dataset.getDatasetProcessing() != null && dataset.getDatasetProcessing().getInputDatasets() != null) {
-                    for (Dataset inputDs : dataset.getDatasetProcessing().getInputDatasets()) {
-                    	hasRight &= hasRightOnTrustedDataset(inputDs, rightStr);
-                    }
-                } else {
-                    throw new IllegalStateException("Cannot check dataset n°" + dataset.getId() + " rights, this dataset has neither examination nor processing parent !");                
-                }
-            } else {
-            	hasRight &= this.hasRightOnStudyCenter(dataset.getDatasetAcquisition().getExamination().getCenterId(), dataset.getDatasetAcquisition().getExamination().getStudyId(), rightStr);
-            }
-    	}
-    	return hasRight;
-    }
 
-    /**
+		return hasRigthOnDatasets(datasets, rightStr);
+	}
+
+	private boolean hasRigthOnDatasets(Iterable<Dataset> datasets, String rightStr) {
+		boolean hasRight = true;
+		for (Dataset dataset : datasets) {
+			if (dataset.getDatasetAcquisition() == null
+					|| dataset.getDatasetAcquisition().getExamination() == null
+					|| dataset.getDatasetAcquisition().getExamination().getStudyId() == null) {
+
+				if (dataset.getDatasetProcessing() != null && dataset.getDatasetProcessing().getInputDatasets() != null) {
+					for (Dataset inputDs : dataset.getDatasetProcessing().getInputDatasets()) {
+						hasRight &= hasRightOnTrustedDataset(inputDs, rightStr);
+					}
+				} else {
+					throw new IllegalStateException("Cannot check dataset n°" + dataset.getId() + " rights, this dataset has neither examination nor processing parent !");
+				}
+			} else {
+				hasRight &= this.hasRightOnStudyCenter(dataset.getDatasetAcquisition().getExamination().getCenterId(), dataset.getDatasetAcquisition().getExamination().getStudyId(), rightStr);
+			}
+		}
+		return hasRight;
+	}
+
+	/**
      * Check that the connected user has the given right for the given dataset.
      * 
      * @param dataset the dataset
@@ -1113,22 +1117,7 @@ public class DatasetSecurityService {
 			}
 			Iterable<Dataset> datasets = datasetRepository.findDatasetsByProcessingId(processingId);
 
-			for (Dataset dataset : datasets) {
-				if (dataset.getDatasetAcquisition() == null
-						|| dataset.getDatasetAcquisition().getExamination() == null
-						|| dataset.getDatasetAcquisition().getExamination().getStudyId() == null) {
-
-					if (dataset.getDatasetProcessing() != null && dataset.getDatasetProcessing().getInputDatasets() != null) {
-						for (Dataset inputDs : dataset.getDatasetProcessing().getInputDatasets()) {
-							hasRight &= hasRightOnTrustedDataset(inputDs, rightStr);
-						}
-					} else {
-						throw new IllegalStateException("Cannot check dataset n°" + dataset.getId() + " rights, this dataset has neither examination nor processing parent !");
-					}
-				} else {
-					hasRight &= this.hasRightOnStudyCenter(dataset.getDatasetAcquisition().getExamination().getCenterId(), dataset.getDatasetAcquisition().getExamination().getStudyId(), rightStr);
-				}
-			}
+			hasRight &= hasRigthOnDatasets(datasets, rightStr);
 		}
 		return hasRight;
 	}

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/security/DatasetSecurityService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/security/DatasetSecurityService.java
@@ -1132,4 +1132,31 @@ public class DatasetSecurityService {
 		}
 		return hasRight;
 	}
+
+	/**
+	 * Check that the connected user has the given right for the given examination.
+	 *
+	 * @param examinationIds the examination ids
+	 * @param rightStr the right
+	 * @return true or false
+	 * @throws EntityNotFoundException
+	 */
+	public boolean hasRightOnExaminations(List<Long> examinationIds, String rightStr) throws EntityNotFoundException {
+		if (KeycloakUtil.getTokenRoles().contains(ROLE_ADMIN)) {
+			return true;
+		}
+		for (Long examinationId : examinationIds) {
+			Examination exam = examinationRepository.findById(examinationId).orElse(null);
+			if (exam == null) {
+				throw new EntityNotFoundException("Cannot find examination with id " + examinationId);
+			}
+			if (exam.getStudyId() == null) {
+				return false;
+			}
+			if(!this.hasRightOnStudyCenter(exam.getCenterId(), exam.getStudyId(), rightStr)){
+				return false;
+			}
+		}
+		return true;
+	}
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/controler/DatasetProcessingApi.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/controler/DatasetProcessingApi.java
@@ -19,11 +19,13 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.shanoir.ng.dataset.dto.DatasetDTO;
 import org.shanoir.ng.processing.dto.DatasetProcessingDTO;
 import org.shanoir.ng.processing.model.DatasetProcessing;
+import org.shanoir.ng.shared.exception.EntityNotFoundException;
 import org.shanoir.ng.shared.exception.RestServiceException;
 import org.shanoir.ng.shared.exception.ShanoirException;
 import org.springframework.http.ResponseEntity;
@@ -119,5 +121,20 @@ public interface DatasetProcessingApi {
 			@Parameter(description = "id of the dataset processing", required = true) @PathVariable("datasetProcessingId") Long datasetProcessingId,
 			@Parameter(description = "dataset processing to update", required = true) @Valid @RequestBody DatasetProcessing datasetProcessing, BindingResult result)
 			throws RestServiceException;
+
+	@Operation(summary = "massiveDownloadDatasetsByProcessingIds", description = "If exists, returns a zip file of the inputs/outputs per processing corresponding to the given processing IDs")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "zip file"),
+			@ApiResponse(responseCode = "401", description = "unauthorized"),
+			@ApiResponse(responseCode = "403", description = "forbidden"),
+			@ApiResponse(responseCode = "404", description = "no dataset found"),
+			@ApiResponse(responseCode = "500", description = "unexpected error") })
+	@GetMapping(value = "/massiveDownloadByProcessing")
+	@PreAuthorize("hasRole('ADMIN') or (hasAnyRole('EXPERT', 'USER') and @datasetSecurityService.HasRightOnEveryDatasetOfProcessings(#processingIds, 'CAN_DOWNLOAD'))")
+	void massiveDownloadByProcessingId(
+			@Parameter(description = "id of the processing", required=true) @Valid
+			@RequestParam(value = "processingIds") List<Long> processingIds,
+			@Parameter(description = "outputs to extract") @Valid
+			@RequestParam(value = "resultOnly") boolean resultOnly, HttpServletResponse response) throws RestServiceException;
 
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/controler/DatasetProcessingApi.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/controler/DatasetProcessingApi.java
@@ -150,7 +150,7 @@ public interface DatasetProcessingApi {
             @Parameter(description = "id of the examination", required = true) @Valid
             @RequestBody List<Long> examinationIds,
             @Parameter(description = "comment of the desired processings") @Valid
-            @RequestParam(value = "processingComment") String processingComment,
+            @RequestParam(value = "processingComment", required = false) String processingComment,
             @Parameter(description = "outputs to extract") @Valid
             @RequestParam(value = "resultOnly", defaultValue = "false") boolean resultOnly, HttpServletResponse response) throws RestServiceException;
 

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/controler/DatasetProcessingApi.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/controler/DatasetProcessingApi.java
@@ -2,12 +2,12 @@
  * Shanoir NG - Import, manage and share neuroimaging data
  * Copyright (C) 2009-2019 Inria - https://www.inria.fr/
  * Contact us on https://project.inria.fr/shanoir/
- * 
+ * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ * <p>
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
  */
@@ -40,116 +40,118 @@ import java.util.List;
 @RequestMapping("/datasetProcessing")
 public interface DatasetProcessingApi {
 
-	@Operation(summary = "", description = "Deletes a dataset processing")
-	@ApiResponses(value = { @ApiResponse(responseCode = "204", description = "dataset processing deleted"),
-			@ApiResponse(responseCode = "401", description = "unauthorized"),
-			@ApiResponse(responseCode = "403", description = "forbidden"),
-			@ApiResponse(responseCode = "404", description = "no dataset processing found"),
-			@ApiResponse(responseCode = "500", description = "unexpected error") })
-	@DeleteMapping(value = "/{datasetProcessingId}", produces = { "application/json" })
-	@PreAuthorize("hasAnyRole('ADMIN', 'EXPERT')")
-	ResponseEntity<Void> deleteDatasetProcessing(
-			@Parameter(description = "id of the dataset processing", required = true) @PathVariable("datasetProcessingId") Long datasetProcessingId)
+    @Operation(summary = "", description = "Deletes a dataset processing")
+    @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "dataset processing deleted"),
+            @ApiResponse(responseCode = "401", description = "unauthorized"),
+            @ApiResponse(responseCode = "403", description = "forbidden"),
+            @ApiResponse(responseCode = "404", description = "no dataset processing found"),
+            @ApiResponse(responseCode = "500", description = "unexpected error")})
+    @DeleteMapping(value = "/{datasetProcessingId}", produces = {"application/json"})
+    @PreAuthorize("hasAnyRole('ADMIN', 'EXPERT')")
+    ResponseEntity<Void> deleteDatasetProcessing(
+            @Parameter(description = "id of the dataset processing", required = true) @PathVariable("datasetProcessingId") Long datasetProcessingId)
             throws RestServiceException, ShanoirException, SolrServerException, IOException;
 
-	@Operation(summary = "", description = "If exists, returns the dataset processing corresponding to the given id")
-	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "found dataset processing"),
-			@ApiResponse(responseCode = "401", description = "unauthorized"),
-			@ApiResponse(responseCode = "403", description = "forbidden"),
-			@ApiResponse(responseCode = "404", description = "no dataset processing found"),
-			@ApiResponse(responseCode = "500", description = "unexpected error") })
-	@GetMapping(value = "/{datasetProcessingId}", produces = { "application/json" })
-	@PreAuthorize("hasAnyRole('ADMIN', 'EXPERT', 'USER')")
-	ResponseEntity<DatasetProcessingDTO> findDatasetProcessingById(
-			@Parameter(description = "id of the dataset processing", required = true) @PathVariable("datasetProcessingId") Long datasetProcessingId);
+    @Operation(summary = "", description = "If exists, returns the dataset processing corresponding to the given id")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "found dataset processing"),
+            @ApiResponse(responseCode = "401", description = "unauthorized"),
+            @ApiResponse(responseCode = "403", description = "forbidden"),
+            @ApiResponse(responseCode = "404", description = "no dataset processing found"),
+            @ApiResponse(responseCode = "500", description = "unexpected error")})
+    @GetMapping(value = "/{datasetProcessingId}", produces = {"application/json"})
+    @PreAuthorize("hasAnyRole('ADMIN', 'EXPERT', 'USER')")
+    ResponseEntity<DatasetProcessingDTO> findDatasetProcessingById(
+            @Parameter(description = "id of the dataset processing", required = true) @PathVariable("datasetProcessingId") Long datasetProcessingId);
 
-	@Operation(summary = "", description = "Returns the dataset processings with given study and subject")
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "found dataset processings"),
-			@ApiResponse(responseCode = "204", description = "no dataset processing found"),
-			@ApiResponse(responseCode = "401", description = "unauthorized"),
-			@ApiResponse(responseCode = "403", description = "forbidden"),
-			@ApiResponse(responseCode = "500", description = "unexpected error") })
-	@GetMapping(value = "", produces = { "application/json" })
-	@PreAuthorize("hasAnyRole('ADMIN', 'EXPERT', 'USER')")
-	ResponseEntity<List<DatasetProcessingDTO>> findDatasetProcessings();
+    @Operation(summary = "", description = "Returns the dataset processings with given study and subject")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "found dataset processings"),
+            @ApiResponse(responseCode = "204", description = "no dataset processing found"),
+            @ApiResponse(responseCode = "401", description = "unauthorized"),
+            @ApiResponse(responseCode = "403", description = "forbidden"),
+            @ApiResponse(responseCode = "500", description = "unexpected error")})
+    @GetMapping(value = "", produces = {"application/json"})
+    @PreAuthorize("hasAnyRole('ADMIN', 'EXPERT', 'USER')")
+    ResponseEntity<List<DatasetProcessingDTO>> findDatasetProcessings();
 
-	@Operation(summary = "", description = "Returns the input datasets of a processing")
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "found dataset processings"),
-			@ApiResponse(responseCode = "204", description = "no dataset processing found"),
-			@ApiResponse(responseCode = "401", description = "unauthorized"),
-			@ApiResponse(responseCode = "403", description = "forbidden"),
-			@ApiResponse(responseCode = "500", description = "unexpected error") })
-	@GetMapping(value = "/{datasetProcessingId}/inputDatasets/", produces = { "application/json" })
-	@PreAuthorize("hasAnyRole('ADMIN', 'EXPERT', 'USER')")
-	ResponseEntity<List<DatasetDTO>> getInputDatasets(@Parameter(description = "id of the dataset processing", required = true) @PathVariable("datasetProcessingId") Long datasetProcessingId);
+    @Operation(summary = "", description = "Returns the input datasets of a processing")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "found dataset processings"),
+            @ApiResponse(responseCode = "204", description = "no dataset processing found"),
+            @ApiResponse(responseCode = "401", description = "unauthorized"),
+            @ApiResponse(responseCode = "403", description = "forbidden"),
+            @ApiResponse(responseCode = "500", description = "unexpected error")})
+    @GetMapping(value = "/{datasetProcessingId}/inputDatasets/", produces = {"application/json"})
+    @PreAuthorize("hasAnyRole('ADMIN', 'EXPERT', 'USER')")
+    ResponseEntity<List<DatasetDTO>> getInputDatasets(@Parameter(description = "id of the dataset processing", required = true) @PathVariable("datasetProcessingId") Long datasetProcessingId);
 
-	@Operation(summary = "", description = "Returns the output datasets of a processing")
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "found dataset processings"),
-			@ApiResponse(responseCode = "204", description = "no dataset processing found"),
-			@ApiResponse(responseCode = "401", description = "unauthorized"),
-			@ApiResponse(responseCode = "403", description = "forbidden"),
-			@ApiResponse(responseCode = "500", description = "unexpected error") })
-	@GetMapping(value = "/{datasetProcessingId}/outputDatasets/", produces = { "application/json" })
-	@PreAuthorize("hasAnyRole('ADMIN', 'EXPERT', 'USER')")
-	ResponseEntity<List<DatasetDTO>> getOutputDatasets(@Parameter(description = "id of the dataset processing", required = true) @PathVariable("datasetProcessingId") Long datasetProcessingId);
+    @Operation(summary = "", description = "Returns the output datasets of a processing")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "found dataset processings"),
+            @ApiResponse(responseCode = "204", description = "no dataset processing found"),
+            @ApiResponse(responseCode = "401", description = "unauthorized"),
+            @ApiResponse(responseCode = "403", description = "forbidden"),
+            @ApiResponse(responseCode = "500", description = "unexpected error")})
+    @GetMapping(value = "/{datasetProcessingId}/outputDatasets/", produces = {"application/json"})
+    @PreAuthorize("hasAnyRole('ADMIN', 'EXPERT', 'USER')")
+    ResponseEntity<List<DatasetDTO>> getOutputDatasets(@Parameter(description = "id of the dataset processing", required = true) @PathVariable("datasetProcessingId") Long datasetProcessingId);
 
-	@Operation(summary = "", description = "Saves a new dataset processing")
-	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "created dataset processing"),
-			@ApiResponse(responseCode = "401", description = "unauthorized"),
-			@ApiResponse(responseCode = "403", description = "forbidden"),
-			@ApiResponse(responseCode = "422", description = "bad parameters"),
-			@ApiResponse(responseCode = "500", description = "unexpected error") })
-	@PostMapping(value = "", produces = { "application/json" }, consumes = {
-			"application/json" })
-	@PreAuthorize("hasAnyRole('ADMIN', 'EXPERT', 'USER')")
-	ResponseEntity<DatasetProcessingDTO> saveNewDatasetProcessing(@Parameter(description = "dataset processing to create", required = true) @Valid @RequestBody DatasetProcessing datasetProcessing,
-			BindingResult result) throws RestServiceException;
+    @Operation(summary = "", description = "Saves a new dataset processing")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "created dataset processing"),
+            @ApiResponse(responseCode = "401", description = "unauthorized"),
+            @ApiResponse(responseCode = "403", description = "forbidden"),
+            @ApiResponse(responseCode = "422", description = "bad parameters"),
+            @ApiResponse(responseCode = "500", description = "unexpected error")})
+    @PostMapping(value = "", produces = {"application/json"}, consumes = {
+            "application/json"})
+    @PreAuthorize("hasAnyRole('ADMIN', 'EXPERT', 'USER')")
+    ResponseEntity<DatasetProcessingDTO> saveNewDatasetProcessing(@Parameter(description = "dataset processing to create", required = true) @Valid @RequestBody DatasetProcessing datasetProcessing,
+                                                                  BindingResult result) throws RestServiceException;
 
-	@Operation(summary = "", description = "Updates a dataset processing")
-	@ApiResponses(value = { @ApiResponse(responseCode = "204", description = "dataset processing updated"),
-			@ApiResponse(responseCode = "401", description = "unauthorized"),
-			@ApiResponse(responseCode = "403", description = "forbidden"),
-			@ApiResponse(responseCode = "422", description = "bad parameters"),
-			@ApiResponse(responseCode = "500", description = "unexpected error") })
-	@PutMapping(value = "/{datasetProcessingId}", produces = { "application/json" }, consumes = {
-			"application/json" })
-	@PreAuthorize("hasAnyRole('ADMIN', 'EXPERT', 'USER') and @controlerSecurityService.idMatches(#datasetProcessingId, #datasetProcessing)")
-	ResponseEntity<Void> updateDatasetProcessing(
-			@Parameter(description = "id of the dataset processing", required = true) @PathVariable("datasetProcessingId") Long datasetProcessingId,
-			@Parameter(description = "dataset processing to update", required = true) @Valid @RequestBody DatasetProcessing datasetProcessing, BindingResult result)
-			throws RestServiceException;
+    @Operation(summary = "", description = "Updates a dataset processing")
+    @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "dataset processing updated"),
+            @ApiResponse(responseCode = "401", description = "unauthorized"),
+            @ApiResponse(responseCode = "403", description = "forbidden"),
+            @ApiResponse(responseCode = "422", description = "bad parameters"),
+            @ApiResponse(responseCode = "500", description = "unexpected error")})
+    @PutMapping(value = "/{datasetProcessingId}", produces = {"application/json"}, consumes = {
+            "application/json"})
+    @PreAuthorize("hasAnyRole('ADMIN', 'EXPERT', 'USER') and @controlerSecurityService.idMatches(#datasetProcessingId, #datasetProcessing)")
+    ResponseEntity<Void> updateDatasetProcessing(
+            @Parameter(description = "id of the dataset processing", required = true) @PathVariable("datasetProcessingId") Long datasetProcessingId,
+            @Parameter(description = "dataset processing to update", required = true) @Valid @RequestBody DatasetProcessing datasetProcessing, BindingResult result)
+            throws RestServiceException;
 
-	@Operation(summary = "massiveDownloadDatasetsByProcessingIds", description = "If exists, returns a zip file of the inputs/outputs per processing corresponding to the given processing IDs")
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "zip file"),
-			@ApiResponse(responseCode = "401", description = "unauthorized"),
-			@ApiResponse(responseCode = "403", description = "forbidden"),
-			@ApiResponse(responseCode = "404", description = "no dataset found"),
-			@ApiResponse(responseCode = "500", description = "unexpected error") })
-	@GetMapping(value = "/massiveDownloadByProcessing")
-	@PreAuthorize("hasRole('ADMIN') or (hasAnyRole('EXPERT', 'USER') and @datasetSecurityService.HasRightOnEveryDatasetOfProcessings(#processingIds, 'CAN_DOWNLOAD'))")
-	void massiveDownloadByProcessingId(
-			@Parameter(description = "id of the processing", required=true) @Valid
-			@RequestParam(value = "processingIds") List<Long> processingIds,
-			@Parameter(description = "outputs to extract") @Valid
-			@RequestParam(value = "resultOnly") boolean resultOnly, HttpServletResponse response) throws RestServiceException;
+    @Operation(summary = "massiveDownloadByProcessingIds", description = "If exists, returns a zip file of the inputs/outputs per processing corresponding to the given processing IDs.  Datas are in the http response body, it must be written in a zip file. Datas are sorted with folders according to their respective examination and processing.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "zip file"),
+            @ApiResponse(responseCode = "401", description = "unauthorized"),
+            @ApiResponse(responseCode = "403", description = "forbidden"),
+            @ApiResponse(responseCode = "404", description = "no dataset found"),
+            @ApiResponse(responseCode = "500", description = "unexpected error")})
+    @PostMapping(value = "/massiveDownloadByProcessingIds")
+    @PreAuthorize("hasRole('ADMIN') or (hasAnyRole('EXPERT', 'USER') and @datasetSecurityService.HasRightOnEveryDatasetOfProcessings(#processingIds, 'CAN_DOWNLOAD'))")
+    void massiveDownloadByProcessingIds(
+            @Parameter(description = "id of the processing", required = true) @Valid
+            @RequestBody List<Long> processingIds,
+            @Parameter(description = "outputs to extract") @Valid
+            @RequestParam(value = "resultOnly", defaultValue = "false") boolean resultOnly, HttpServletResponse response) throws RestServiceException;
 
-	@Operation(summary = "massiveDownloadProcessingDatasetsByExaminationIds", description = "If exists, returns a zip file of the inputs/outputs per processing corresponding to the given examination IDs")
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "zip file"),
-			@ApiResponse(responseCode = "401", description = "unauthorized"),
-			@ApiResponse(responseCode = "403", description = "forbidden"),
-			@ApiResponse(responseCode = "404", description = "no dataset found"),
-			@ApiResponse(responseCode = "500", description = "unexpected error") })
-	@GetMapping(value = "/massiveDownloadProcessingByExamination")
-	@PreAuthorize("hasRole('ADMIN') or (hasAnyRole('EXPERT', 'USER') and @datasetSecurityService.hasRightOnExaminations(#examinationIds, 'CAN_DOWNLOAD'))")
-	void massiveDownloadProcessingByExaminationId(
-			@Parameter(description = "id of the examination", required=true) @Valid
-			@RequestParam(value = "examiantionIds") List<Long> examinationIds,
-			@Parameter(description = "outputs to extract") @Valid
-			@RequestParam(value = "resultOnly") boolean resultOnly, HttpServletResponse response) throws RestServiceException;
+    @Operation(summary = "massiveDownloadProcessingByExaminationIds", description = "If exists, returns a zip file of the inputs/outputs per processing corresponding to the given examination IDs. Datas are in the http response body, it must be written in a zip file. Datas are sorted with folders according to their respective examination and processing.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "zip file"),
+            @ApiResponse(responseCode = "401", description = "unauthorized"),
+            @ApiResponse(responseCode = "403", description = "forbidden"),
+            @ApiResponse(responseCode = "404", description = "no dataset found"),
+            @ApiResponse(responseCode = "500", description = "unexpected error")})
+    @PostMapping(value = "/massiveDownloadProcessingByExaminationIds")
+    @PreAuthorize("hasRole('ADMIN') or (hasAnyRole('EXPERT', 'USER') and @datasetSecurityService.hasRightOnExaminations(#examinationIds, 'CAN_DOWNLOAD'))")
+    void massiveDownloadProcessingByExaminationIds(
+            @Parameter(description = "id of the examination", required = true) @Valid
+            @RequestBody List<Long> examinationIds,
+            @Parameter(description = "comment of the desired processings") @Valid
+            @RequestParam(value = "processingComment") String processingComment,
+            @Parameter(description = "outputs to extract") @Valid
+            @RequestParam(value = "resultOnly", defaultValue = "false") boolean resultOnly, HttpServletResponse response) throws RestServiceException;
 
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/controler/DatasetProcessingApi.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/controler/DatasetProcessingApi.java
@@ -137,4 +137,19 @@ public interface DatasetProcessingApi {
 			@Parameter(description = "outputs to extract") @Valid
 			@RequestParam(value = "resultOnly") boolean resultOnly, HttpServletResponse response) throws RestServiceException;
 
+	@Operation(summary = "massiveDownloadProcessingDatasetsByExaminationIds", description = "If exists, returns a zip file of the inputs/outputs per processing corresponding to the given examination IDs")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "zip file"),
+			@ApiResponse(responseCode = "401", description = "unauthorized"),
+			@ApiResponse(responseCode = "403", description = "forbidden"),
+			@ApiResponse(responseCode = "404", description = "no dataset found"),
+			@ApiResponse(responseCode = "500", description = "unexpected error") })
+	@GetMapping(value = "/massiveDownloadProcessingByExamination")
+	@PreAuthorize("hasRole('ADMIN') or (hasAnyRole('EXPERT', 'USER') and @datasetSecurityService.hasRightOnExaminations(#examinationIds, 'CAN_DOWNLOAD'))")
+	void massiveDownloadProcessingByExaminationId(
+			@Parameter(description = "id of the examination", required=true) @Valid
+			@RequestParam(value = "examiantionIds") List<Long> examinationIds,
+			@Parameter(description = "outputs to extract") @Valid
+			@RequestParam(value = "resultOnly") boolean resultOnly, HttpServletResponse response) throws RestServiceException;
+
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/controler/DatasetProcessingApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/controler/DatasetProcessingApiController.java
@@ -174,9 +174,9 @@ public class DatasetProcessingApiController implements DatasetProcessingApi {
 	}
 
 	@Override
-	public void massiveDownloadByProcessingId(
+	public void massiveDownloadByProcessingIds(
 			@Parameter(description = "ids of processing", required=true) @Valid
-			@RequestParam(value = "processingIds") List<Long> processingIds,
+			@RequestBody List<Long> processingIds,
 			@Parameter(description = "outputs to extract") @Valid
 			@RequestParam(value = "resultOnly") boolean resultOnly,
 			HttpServletResponse response) throws RestServiceException {
@@ -194,20 +194,16 @@ public class DatasetProcessingApiController implements DatasetProcessingApi {
 				throw new RestServiceException(
 						new ErrorModel(HttpStatus.FORBIDDEN.value(), processingId + " is not a valid processing id."));
 			}
-
-			if(!Objects.equals(processing.getComment(), "comete_moelle/0.1")){
-				throw new RestServiceException(
-						new ErrorModel(HttpStatus.FORBIDDEN.value(), "Processing " + processingId + " has not a valid processing type."));
-			}
 		}
-
 		processingDownloaderService.massiveDownload(processingList, resultOnly, "dcm" , response, false, null);
 	}
 
 	@Override
-	public void massiveDownloadProcessingByExaminationId(
+	public void massiveDownloadProcessingByExaminationIds(
 			@Parameter(description = "ids of examination", required=true) @Valid
-			@RequestParam(value = "examinationIds") List<Long> examinationIds,
+			@RequestBody List<Long> examinationIds,
+			@Parameter(description = "comment of the desired processings") @Valid
+			@RequestParam(value = "processingComment") String processingComment,
 			@Parameter(description = "outputs to extract") @Valid
 			@RequestParam(value = "resultOnly") boolean resultOnly,
 			HttpServletResponse response) throws RestServiceException {
@@ -230,6 +226,6 @@ public class DatasetProcessingApiController implements DatasetProcessingApi {
 						new ErrorModel(HttpStatus.FORBIDDEN.value(), examinationId + " is not a valid examination id."));
 			}
 		}
-		processingDownloaderService.massiveDownloadByExamination(examinationList, resultOnly, "dcm" , response, false, null);
+		processingDownloaderService.massiveDownloadByExaminations(examinationList, processingComment, resultOnly, "dcm" , response, false, null);
 	}
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/controler/DatasetProcessingApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/controler/DatasetProcessingApiController.java
@@ -195,7 +195,7 @@ public class DatasetProcessingApiController implements DatasetProcessingApi {
 						new ErrorModel(HttpStatus.FORBIDDEN.value(), processingId + " is not a valid processing id."));
 			}
 
-			if(!Objects.equals(processing.getDatasetProcessingType(), DatasetProcessingType.SEGMENTATION)){
+			if(!Objects.equals(processing.getComment(), "comete_moelle/0.1")){
 				throw new RestServiceException(
 						new ErrorModel(HttpStatus.FORBIDDEN.value(), "Processing " + processingId + " has not a valid processing type."));
 			}

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/controler/DatasetProcessingApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/controler/DatasetProcessingApiController.java
@@ -203,7 +203,7 @@ public class DatasetProcessingApiController implements DatasetProcessingApi {
 			@Parameter(description = "ids of examination", required=true) @Valid
 			@RequestBody List<Long> examinationIds,
 			@Parameter(description = "comment of the desired processings") @Valid
-			@RequestParam(value = "processingComment") String processingComment,
+			@RequestParam(value = "processingComment", required = false) String processingComment,
 			@Parameter(description = "outputs to extract") @Valid
 			@RequestParam(value = "resultOnly") boolean resultOnly,
 			HttpServletResponse response) throws RestServiceException {

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/repository/DatasetProcessingRepository.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/repository/DatasetProcessingRepository.java
@@ -51,7 +51,7 @@ public interface DatasetProcessingRepository extends CrudRepository<DatasetProce
 	 * @param examinationIds
 	 * @return
 	 */
-	@Query(value="SELECT processing.id FROM dataset_processing as processing " +
+	@Query(value="SELECT DISTINCT processing.id FROM dataset_processing as processing " +
 			"INNER JOIN input_of_dataset_processing as input ON processing.id=input.processing_id " +
 			"INNER JOIN dataset as dataset ON dataset.id=input.dataset_id " +
 			"INNER JOIN dataset_acquisition as acquisition ON acquisition.id=dataset.dataset_acquisition_id " +

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/repository/DatasetProcessingRepository.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/repository/DatasetProcessingRepository.java
@@ -17,6 +17,7 @@ package org.shanoir.ng.processing.repository;
 import java.util.List;
 import java.util.Optional;
 import org.shanoir.ng.processing.model.DatasetProcessing;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 /**
@@ -43,4 +44,17 @@ public interface DatasetProcessingRepository extends CrudRepository<DatasetProce
 	List<DatasetProcessing> findAllByInputDatasets_Id(Long datasetId);
 
     List<DatasetProcessing> findAllByParentId(Long id);
+	
+	/**
+	 * Find all processings that are linked to given examinations
+	 *
+	 * @param examinationIds
+	 * @return
+	 */
+	@Query(value="SELECT processing.id FROM dataset_processing as processing " +
+			"INNER JOIN input_of_dataset_processing as input ON processing.id=input.processing_id " +
+			"INNER JOIN dataset as dataset ON dataset.id=input.dataset_id " +
+			"INNER JOIN dataset_acquisition as acquisition ON acquisition.id=dataset.dataset_acquisition_id " +
+			"WHERE acquisition.examination_id IN (:examinationIds)", nativeQuery = true)
+	List<Long> findAllIdsByExaminationIds(List<Long> examinationIds);
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/service/DatasetProcessingServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/service/DatasetProcessingServiceImpl.java
@@ -84,6 +84,10 @@ public class DatasetProcessingServiceImpl implements DatasetProcessingService {
     public List<DatasetProcessing> findAll() {
         return Utils.toList(repository.findAll());
     }
+
+    public List<DatasetProcessing> findAllById(List<Long> idList) {
+        return idList.stream().flatMap(it -> findById(it).stream()).toList();
+    }
     
     @Override
     public DatasetProcessing create(final DatasetProcessing entity) {

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/service/ProcessingDownloaderServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/service/ProcessingDownloaderServiceImpl.java
@@ -76,9 +76,11 @@ public class ProcessingDownloaderServiceImpl extends DatasetDownloaderServiceImp
         for (DatasetProcessing processing : processingList) {
             String processingFilePath = getExecFilepath(processing.getId(), getExaminationDatas(processing.getInputDatasets()));
             String subjectName = getProcessingSubject(processing);
-            for (Dataset dataset : Stream.concat(processing.getInputDatasets().stream(), processing.getOutputDatasets().stream()).toList()) {
+            for (Dataset dataset : processing.getInputDatasets()) {
                 manageDatasetDownload(dataset, downloadResults, zipOutputStream, subjectName, processingFilePath  + "/" + shapeForPath(dataset.getName()), format, withManifest, filesByAcquisitionId, converterId);
-
+            }
+            for (Dataset dataset : processing.getOutputDatasets()) {
+                manageDatasetDownload(dataset, downloadResults, zipOutputStream, subjectName, processingFilePath  + "/output", format, withManifest, filesByAcquisitionId, converterId);
             }
         }
         if(!filesByAcquisitionId.isEmpty()){

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/service/ProcessingDownloaderServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/service/ProcessingDownloaderServiceImpl.java
@@ -1,0 +1,194 @@
+package org.shanoir.ng.processing.service;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.solr.common.util.Pair;
+import org.shanoir.ng.dataset.modality.BidsDataset;
+import org.shanoir.ng.dataset.modality.EegDataset;
+import org.shanoir.ng.dataset.model.Dataset;
+import org.shanoir.ng.dataset.model.DatasetExpressionFormat;
+import org.shanoir.ng.dataset.service.DatasetDownloaderServiceImpl;
+import org.shanoir.ng.datasetacquisition.model.DatasetAcquisition;
+import org.shanoir.ng.download.DatasetDownloadError;
+import org.shanoir.ng.download.WADODownloaderService;
+import org.shanoir.ng.examination.model.Examination;
+import org.shanoir.ng.processing.model.DatasetProcessing;
+import org.shanoir.ng.shared.event.ShanoirEvent;
+import org.shanoir.ng.shared.event.ShanoirEventType;
+import org.shanoir.ng.shared.exception.ErrorModel;
+import org.shanoir.ng.shared.exception.RestServiceException;
+import org.shanoir.ng.utils.DatasetFileUtils;
+import org.shanoir.ng.utils.KeycloakUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.net.URL;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+@Service
+public class ProcessingDownloaderServiceImpl extends DatasetDownloaderServiceImpl{
+
+    /** Number of downloadable datasets. */
+    private static final int DATASET_LIMIT = 500;
+
+    @Autowired
+    private WADODownloaderService downloader;
+
+    public void massiveDownload(List<DatasetProcessing> processingList, boolean resultOnly, String format, HttpServletResponse response, boolean withManifest, Long converterId) throws RestServiceException {
+        List<Dataset> inputs = processingList.stream().flatMap(processing -> processing.getInputDatasets().stream()).collect(Collectors.toList());
+        if(resultOnly){
+            processingList.forEach(it -> {it.setOutputDatasets(it.getOutputDatasets().stream().filter(file -> Objects.equals(file.getName(), "result.yaml")).toList()); it.setInputDatasets(new ArrayList<>());});
+        }
+        List<Dataset> outputs = processingList.stream().flatMap(processing -> processing.getOutputDatasets().stream()).collect(Collectors.toList());
+        checkSize(inputs, outputs);
+
+        response.setContentType("application/zip");
+        response.setHeader("Content-Disposition", "attachment;filename=Processings_" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")));
+        Map<Long, DatasetDownloadError> downloadResults = new HashMap<Long, DatasetDownloadError>();
+        Map<Long, List<String>> filesByAcquisitionId = new HashMap<>();
+
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(response.getOutputStream())) {
+            for (DatasetProcessing processing : processingList) {
+                String processingFilePath = getExecFilepath(processing.getId(), getExaminationDatas(processing.getInputDatasets()));
+                String subjectName = getProcessingSubject(processing);
+                for (Dataset dataset : Stream.concat(processing.getInputDatasets().stream(), processing.getOutputDatasets().stream()).toList()) {
+                    if (!dataset.isDownloadable()) {
+                        downloadResults.put(dataset.getId(), new DatasetDownloadError("Dataset not downloadable", DatasetDownloadError.ERROR));
+                        continue;
+                    }
+                    DatasetDownloadError downloadResult = new DatasetDownloadError();
+                    downloadResults.put(dataset.getId(), downloadResult);
+
+                    List<URL> pathURLs = new ArrayList<>();
+
+                    if (dataset.getDatasetProcessing() != null) {
+                        // DOWNLOAD PROCESSED DATASET
+                        DatasetFileUtils.getDatasetFilePathURLs(dataset, pathURLs, DatasetExpressionFormat.NIFTI_SINGLE_FILE, downloadResult);
+                        DatasetFileUtils.copyNiftiFilesForURLs(pathURLs, zipOutputStream, dataset, subjectName, true, processingFilePath);
+                    } else if (dataset instanceof EegDataset) {
+                        // DOWNLOAD EEG
+                        DatasetFileUtils.getDatasetFilePathURLs(dataset, pathURLs, DatasetExpressionFormat.EEG, downloadResult);
+                        DatasetFileUtils.copyNiftiFilesForURLs(pathURLs, zipOutputStream, dataset, subjectName, false, processingFilePath);
+                    } else if (dataset instanceof BidsDataset) {
+                        // DOWNLOAD BIDS
+                        DatasetFileUtils.getDatasetFilePathURLs(dataset, pathURLs, DatasetExpressionFormat.BIDS, downloadResult);
+                        DatasetFileUtils.copyNiftiFilesForURLs(pathURLs, zipOutputStream, dataset, subjectName, true, processingFilePath);
+                        // Manage errors here
+                    } else if (Objects.equals("dcm", format)) {
+                        // DOWNLOAD DICOM
+                        DatasetFileUtils.getDatasetFilePathURLs(dataset, pathURLs, DatasetExpressionFormat.DICOM, downloadResult);
+                        List<String> files = downloader.downloadDicomFilesForURLsAsZip(pathURLs, zipOutputStream, subjectName, dataset, processingFilePath  + "/" + shapeForPath(dataset.getName()), downloadResult);
+                        if (withManifest) {
+                            filesByAcquisitionId.putIfAbsent(dataset.getDatasetAcquisition().getId(), new ArrayList<>());
+                            filesByAcquisitionId.get(dataset.getDatasetAcquisition().getId()).addAll(files);
+                        }
+                    } else if (Objects.equals("nii", format)) {
+                        // Check if we have a specific converter -> nifti reconversion
+                        if (converterId != null) {
+                            reconvertToNifti(format, converterId, dataset, pathURLs, downloadResult, subjectName, zipOutputStream);
+                        } else {
+                            // Check that we have existing nifti, otherwise reconvert using dcm2niix by default.
+                            DatasetFileUtils.getDatasetFilePathURLs(dataset, pathURLs, DatasetExpressionFormat.NIFTI_SINGLE_FILE, downloadResult);
+                            if (!pathURLs.isEmpty()) {
+                                List<String> files = DatasetFileUtils.copyNiftiFilesForURLs(pathURLs, zipOutputStream, dataset, subjectName, false, processingFilePath + "/" + shapeForPath(dataset.getName()));
+                            } else {
+                                // Reconvert using dcm2niix by default.
+                                reconvertToNifti(format, DEFAULT_NIFTI_CONVERTER_ID, dataset, pathURLs, downloadResult, subjectName, zipOutputStream);
+                            }
+                        }
+                    } else {
+                        downloadResult.update("Dataset format was not adapted to dataset download choosen", DatasetDownloadError.ERROR);
+                    }
+
+                    if (downloadResult.getStatus() == null) {
+                        downloadResults.remove(dataset.getId());
+                    }
+                }
+            }
+            if(!filesByAcquisitionId.isEmpty()){
+                DatasetFileUtils.writeManifestForExport(zipOutputStream, filesByAcquisitionId);
+            }
+
+            // Write errors to the file
+            if (!downloadResults.isEmpty()) {
+                ZipEntry zipEntry = new ZipEntry(JSON_RESULT_FILENAME);
+                zipEntry.setTime(System.currentTimeMillis());
+                zipOutputStream.putNextEntry(zipEntry);
+                zipOutputStream.write(objectMapper.writeValueAsString(downloadResults).getBytes());
+                zipOutputStream.closeEntry();
+            }
+
+            String ids = String.join(",", Stream.concat(inputs.stream(), outputs.stream()).map(dataset -> dataset.getId().toString()).collect(Collectors.toList()));
+            ShanoirEvent event = new ShanoirEvent(ShanoirEventType.DOWNLOAD_DATASET_EVENT, ids,
+                    KeycloakUtil.getTokenUserId(), ids + "." + format, ShanoirEvent.IN_PROGRESS);
+            event.setStatus(ShanoirEvent.SUCCESS);
+            eventService.publishEvent(event);
+        } catch (Exception e) {
+            response.setContentType(null);
+            LOG.error("Unexpected error while downloading dataset files.", e);
+            throw new RestServiceException(
+                    new ErrorModel(HttpStatus.UNPROCESSABLE_ENTITY.value(),
+                            "Unexpected error while downloading dataset files"));
+        }
+    }
+
+    private String getProcessingSubject(DatasetProcessing processing) {
+        Examination exam = null;
+        for (Dataset dataset : processing.getInputDatasets()){
+            exam = Optional.ofNullable(dataset)
+                    .map(Dataset::getDatasetAcquisition)
+                    .map(DatasetAcquisition::getExamination)
+                    .orElse(null);
+            if (!Objects.isNull(exam)){
+                return exam.getSubject().getName();
+            }
+        }
+        return "noSubject";
+    }
+
+    private void checkSize(List<Dataset> inputs, List<Dataset> outputs) throws RestServiceException {
+        int size = inputs.size() + outputs.size();
+        if (size > DATASET_LIMIT) {
+            throw new RestServiceException(
+                    new ErrorModel(HttpStatus.FORBIDDEN.value(), "This processing has " + size + " datasets. You can't download more than " + DATASET_LIMIT + " datasets." ));
+        }
+    }
+
+    private Pair<Long, String> getExaminationDatas(List<Dataset> inputs) {
+        Examination exam = null;
+        for (Dataset dataset : inputs){
+            exam = Optional.ofNullable(dataset)
+                    .map(Dataset::getDatasetAcquisition)
+                    .map(DatasetAcquisition::getExamination)
+                    .orElse(null);
+            if (!Objects.isNull(exam)){
+                return new Pair<>(exam.getId(), exam.getComment());
+            }
+        }
+
+        return new Pair<>(0L, "");
+    }
+
+    private String getExecFilepath(Long processingId, Pair<Long, String> examDatas) {
+
+        String execFilePath = "processing_" + processingId +  "_exam_" + examDatas.first();
+        if (!Objects.equals(examDatas.second(), "")) {
+            execFilePath += "_" + examDatas.second();
+        }
+        return shapeForPath(execFilePath);
+    }
+
+    private String shapeForPath(String path){
+        path = path.replaceAll("[^a-zA-Z0-9_\\-]", "_");
+        if (path.length() > 255) {
+            path = path.substring(0, 254);
+        }
+        return path;
+    }
+}

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/service/ProcessingDownloaderServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/service/ProcessingDownloaderServiceImpl.java
@@ -99,7 +99,10 @@ public class ProcessingDownloaderServiceImpl extends DatasetDownloaderServiceImp
 
     public void massiveDownloadByExaminations(List<Examination> examinationList, String processingComment, boolean resultOnly, String format, HttpServletResponse response, boolean withManifest, Long converterId) throws RestServiceException {
         List<Long> processingIdsList = datasetProcessingRepository.findAllIdsByExaminationIds(examinationList.stream().map(Examination::getId).toList());
-        List<DatasetProcessing> processingList = datasetProcessingService.findAllById(processingIdsList).stream().filter(it -> Objects.equals(it.getComment(), processingComment)).toList();
+        List<DatasetProcessing> processingList = datasetProcessingService.findAllById(processingIdsList);
+        if(!Objects.isNull(processingComment)){
+            processingList = processingList.stream().filter(it -> Objects.equals(it.getComment(), processingComment)).toList();
+        };
         massiveDownload(processingList, resultOnly, format, response, withManifest, converterId);
     }
 

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/service/ProcessingDownloaderServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/service/ProcessingDownloaderServiceImpl.java
@@ -151,7 +151,7 @@ public class ProcessingDownloaderServiceImpl extends DatasetDownloaderServiceImp
 
     public void massiveDownloadByExamination(List<Examination> examinationList, boolean resultOnly, String format, HttpServletResponse response, boolean withManifest, Long converterId) throws RestServiceException {
         List<Long> processingIdsList = datasetProcessingRepository.findAllIdsByExaminationIds(examinationList.stream().map(Examination::getId).toList());
-        List<DatasetProcessing> processingList = datasetProcessingService.findAllById(processingIdsList).stream().filter(it -> Objects.equals(it.getDatasetProcessingType(), DatasetProcessingType.SEGMENTATION)).toList();
+        List<DatasetProcessing> processingList = datasetProcessingService.findAllById(processingIdsList).stream().filter(it -> Objects.equals(it.getComment(), "comete_moelle/0.1")).toList();
         massiveDownload(processingList, resultOnly, format, response, withManifest, converterId);
     }
 

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/service/ProcessingDownloaderServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/service/ProcessingDownloaderServiceImpl.java
@@ -149,9 +149,9 @@ public class ProcessingDownloaderServiceImpl extends DatasetDownloaderServiceImp
         }
     }
 
-    public void massiveDownloadByExamination(List<Examination> examinationList, boolean resultOnly, String format, HttpServletResponse response, boolean withManifest, Long converterId) throws RestServiceException {
+    public void massiveDownloadByExaminations(List<Examination> examinationList, String processingComment, boolean resultOnly, String format, HttpServletResponse response, boolean withManifest, Long converterId) throws RestServiceException {
         List<Long> processingIdsList = datasetProcessingRepository.findAllIdsByExaminationIds(examinationList.stream().map(Examination::getId).toList());
-        List<DatasetProcessing> processingList = datasetProcessingService.findAllById(processingIdsList).stream().filter(it -> Objects.equals(it.getComment(), "comete_moelle/0.1")).toList();
+        List<DatasetProcessing> processingList = datasetProcessingService.findAllById(processingIdsList).stream().filter(it -> Objects.equals(it.getComment(), processingComment)).toList();
         massiveDownload(processingList, resultOnly, format, response, withManifest, converterId);
     }
 

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/vip/controller/PathApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/vip/controller/PathApiController.java
@@ -9,6 +9,7 @@ import org.shanoir.ng.vip.resource.ProcessingResourceService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -23,6 +24,7 @@ public class PathApiController implements PathApi {
 
     private static final String DCM = "dcm";
 
+    @Qualifier("datasetDownloaderServiceImpl")
     @Autowired
     private DatasetDownloaderServiceImpl datasetDownloaderService;
 

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/dataset/DatasetApiControllerTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/dataset/DatasetApiControllerTest.java
@@ -56,6 +56,7 @@ import org.shanoir.ng.utils.ModelsUtil;
 import org.shanoir.ng.utils.usermock.WithMockKeycloakUser;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -154,6 +155,7 @@ public class DatasetApiControllerTest {
 	private DicomSEGAndSRImporterService dicomSRImporterService;
 	
 	@MockBean
+	@Qualifier("datasetDownloaderServiceImpl")
 	private DatasetDownloaderServiceImpl datasetDownloaderService;
 
 	@MockBean

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/dataset/DatasetDownloaderServiceTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/dataset/DatasetDownloaderServiceTest.java
@@ -40,6 +40,7 @@ import org.shanoir.ng.shared.repository.SubjectRepository;
 import org.shanoir.ng.shared.security.ControlerSecurityService;
 import org.shanoir.ng.utils.usermock.WithMockKeycloakUser;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -61,10 +62,11 @@ import static org.mockito.Mockito.times;
 @SpringBootTest
 @ActiveProfiles("test")
 public class DatasetDownloaderServiceTest {
-	
-	@Autowired
+
+    @Qualifier("datasetDownloaderServiceImpl")
+    @Autowired
 	DatasetDownloaderServiceImpl datasetDownloaderService;
-	
+
 	@MockBean
 	private DatasetService datasetServiceMock;
 


### PR DESCRIPTION
#2488 : API for in/out download from a list of processingIds

This PR  is only relative to the creation of an API, there isn't any Shanoir interface yet, and it's currently specific to CometeMoelle project. Please be aware of the [fli-iam](https://github.com/fli-iam/py_noir/issues/6) feature, which implements a python script for generating API calls to that new API

(Tested in local and in qualif)