### PR TITLE
#1874 : import job working properly with eeg (logged as jobs)

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/EegImporterService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/EegImporterService.java
@@ -33,6 +33,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 public class EegImporterService {
@@ -67,7 +68,12 @@ public class EegImporterService {
     public void createEegDataset(final EegImportJob importJob) throws IOException {
 
         Long userId = KeycloakUtil.getTokenUserId();
-        ShanoirEvent event = new ShanoirEvent(ShanoirEventType.IMPORT_DATASET_EVENT, importJob.getExaminationId().toString(), userId, "Starting import...", ShanoirEvent.IN_PROGRESS, 0f, importJob.getStudyId());
+        ShanoirEvent event;
+        if(Objects.isNull(importJob.getShanoirEvent())){
+            event = new ShanoirEvent(ShanoirEventType.IMPORT_DATASET_EVENT, importJob.getExaminationId().toString(), userId, "Starting import...", ShanoirEvent.IN_PROGRESS, 0f, importJob.getStudyId());
+        } else {
+            event = importJob.getShanoirEvent();
+        }
         eventService.publishEvent(event);
 
         if (importJob == null || importJob.getDatasets() == null || importJob.getDatasets().isEmpty()) {

--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/ImporterApiController.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/ImporterApiController.java
@@ -610,6 +610,8 @@ public class ImporterApiController implements ImporterApi {
 		// Comment: Anonymisation is not necessary for pure brainvision EEGs data
 		try {
 			importJob.setUsername(KeycloakUtil.getTokenUserName());
+			ShanoirEvent event = new ShanoirEvent(ShanoirEventType.IMPORT_DATASET_EVENT, importJob.getExaminationId().toString(), KeycloakUtil.getTokenUserId(), "Starting import...", ShanoirEvent.IN_PROGRESS, 0f, importJob.getStudyId());
+			importJob.setShanoirEvent(event);
 			Integer integg = (Integer) rabbitTemplate.convertSendAndReceive(RabbitMQConfiguration.IMPORT_EEG_QUEUE,  objectMapper.writeValueAsString(importJob));
 			return new ResponseEntity<Void>(HttpStatusCode.valueOf(integg.intValue()));			
 		} catch (Exception e) {

--- a/shanoir-ng-import/src/test/java/org/shanoir/ng/importer/ImporterApiControllerTest.java
+++ b/shanoir-ng-import/src/test/java/org/shanoir/ng/importer/ImporterApiControllerTest.java
@@ -137,6 +137,7 @@ public class ImporterApiControllerTest {
 
 		EegImportJob importJob = new EegImportJob();
 		EegDataset dataset = new EegDataset();
+		importJob.setExaminationId(1L);
 		importJob.setDatasets(Collections.singletonList(dataset));
 		dataset.setName("Ceci est un nom bien particulier");
 


### PR DESCRIPTION
Import job was creating in dataset module, which was used locally inside it. It had to be created earlier in import module, for being used properly by the module import and rabbitmq which would managed it. I let a if ... else clause, because i'm not sure about the side effect and every use case.

Tested locally and in remote.