### PR TITLE
shanoir-issue#2542: test ohif viewer v3.10.0-beta.22

### DIFF
--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -311,7 +311,7 @@ CMD []
 
 ################ nginx #####################################################
 
-FROM ohif/app:v3.9.0-beta.76 AS nginx-viewer
+FROM ohif/app:v3.10.0-beta.22 AS nginx-viewer
 
 FROM nginx as nginx
 


### PR DESCRIPTION
How to test:
Open solr > click on 'view dicom' icon (far right column)
The dataset is visible in the viewer without issues