### PR TITLE
RabbitMQ_missing_queue: Adding rabbitMQ listener method for animal subject deletion in preclinical ms

### DIFF
--- a/shanoir-ng-ms-common/src/main/java/org/shanoir/ng/shared/configuration/RabbitMQConfiguration.java
+++ b/shanoir-ng-ms-common/src/main/java/org/shanoir/ng/shared/configuration/RabbitMQConfiguration.java
@@ -315,6 +315,9 @@ public class RabbitMQConfiguration {
 	
 	@Bean
 	public static Queue deleteSubjectQueue() { return new Queue(DELETE_SUBJECT_QUEUE, true); }
+
+	@Bean
+	public static Queue deleteAnimalSubjectQueue() { return new Queue(DELETE_ANIMAL_SUBJECT_QUEUE, true); }
 	
 	@Bean
 	public static Queue importerQueue() {


### PR DESCRIPTION
Method for RabbitMQ listener. What is strange is that my preclinical container automatically shutted down when exception was raised, but it wasn't on my old laptop. Really suspicious.