### PR TITLE
#2491 : HashMap -> LinkedHashMap for sorting preservation

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/ImporterMailService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/ImporterMailService.java
@@ -46,7 +46,7 @@ public class ImporterMailService {
     public void sendImportEmail(ImportJob importJob, Long userId, Examination examination, Set<DatasetAcquisition> generatedAcquisitions) {
         EmailDatasetsImported generatedMail = new EmailDatasetsImported();
 
-        Map<Long, String> datasets = new HashMap<>();
+        LinkedHashMap<Long, String> datasets = new LinkedHashMap<>();
         if (CollectionUtils.isEmpty(generatedAcquisitions)) {
             return;
         }


### PR DESCRIPTION
It's a following of that PR (https://github.com/fli-iam/shanoir-ng/pull/2528) which was not enough, HashMap have their own sorting which is not linked to the input order. Change to LinkedHashMap was needed. 