### PR TITLE
Shanoir issue#2518

### DIFF
--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/bids/BidsImporterApiController.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/bids/BidsImporterApiController.java
@@ -317,7 +317,6 @@ public class BidsImporterApiController implements BidsImporterApi {
 		File sessionFile = sessionFiles[0];
 
 
-
 		// session_id;acq_time;pathology
 		// analyze date for every session
 		CsvMapper mapper = new CsvMapper();
@@ -326,31 +325,32 @@ public class BidsImporterApiController implements BidsImporterApi {
 
 		// Check File is not empty
 		if (sessionFile.length() > 0) {
-			LOG.debug("We found a non empty session.tsv file ");
+			LOG.error("We found a non empty session.tsv file ");
+			// Check that the list of column is known
+			List<String> columns = Arrays.asList(it.next()[0].split(CSV_SEPARATOR));
+			int sessionIdIndex = columns.indexOf("session_id");
+			int dateIndex = columns.indexOf("acq_time");
+
+			// If there is no date, just give up
+			if (dateIndex == -1) {
+				return examDates;
+			}
+
+			// Legal format in BIDS (are we up to date ? I don't think so)
+			DateTimeFormatter formatter = DateTimeFormatter.ofPattern("YYYY-MM-DDThh:mm:ss[.000000][Z]");
+
+			while (it.hasNext()) {
+				String[] row = it.next()[0].split(CSV_SEPARATOR);
+				String sessionLabel = row[sessionIdIndex];
+				String dateAsString = row[dateIndex];
+				TemporalAccessor date = formatter.parseBest(dateAsString, LocalDate::from);
+				examDates.put(sessionLabel, LocalDate.from(date));
+			}
 		} else {
-			LOG.debug("We found an empty session.tsv file ");
-			return examDates;
-		})
-		// Check that the list of column is known
-		List<String> columns = Arrays.asList(it.next()[0].split(CSV_SEPARATOR));
-		int sessionIdIndex = columns.indexOf("session_id");
-		int dateIndex = columns.indexOf("acq_time");
-
-		// If there is no date, just give up
-		if (dateIndex == -1) {
+			LOG.error("We found an empty session.tsv file ");
 			return examDates;
 		}
 
-		// Legal format in BIDS (are we up to date ? I don't think so)
-		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("YYYY-MM-DDThh:mm:ss[.000000][Z]");
-
-		while (it.hasNext()) {
-			String[] row = it.next()[0].split(CSV_SEPARATOR);
-			String sessionLabel = row[sessionIdIndex];
-			String dateAsString = row[dateIndex];
-			TemporalAccessor date = formatter.parseBest(dateAsString, LocalDate::from);
-			examDates.put(sessionLabel, LocalDate.from(date));
-		}
 		return examDates;
 	}
 

--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/bids/BidsImporterApiController.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/bids/BidsImporterApiController.java
@@ -134,7 +134,12 @@ public class BidsImporterApiController implements BidsImporterApi {
 
 		// STEP 2: Subject level, analyze and create the new subject if necessary
 		Long subjectId = null;
-		for (File subjectFile : importJobDir.listFiles()) {
+		// Exclude MACOSX automatically added hidden files
+		for (File subjectFile : importJobDir.listFiles(new FilenameFilter() {
+			@Override
+			public boolean accept(File arg0, String name) {
+				return !name.startsWith(".DS_Store") && !name.startsWith("__");
+			}})) {
 			String fileName = subjectFile.getName();
 			String subjectName = null;
 			if (fileName.startsWith("sub-")) {
@@ -152,7 +157,6 @@ public class BidsImporterApiController implements BidsImporterApi {
 				if (subjectId == null) {
 					throw new RestServiceException(new ErrorModel(HttpStatus.UNPROCESSABLE_ENTITY.value(), SUBJECT_CREATION_ERROR, null));
 				}
-
 				importJob.setSubjectName(subjectName);
 
 			} else {

--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/bids/BidsImporterApiController.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/bids/BidsImporterApiController.java
@@ -316,12 +316,21 @@ public class BidsImporterApiController implements BidsImporterApi {
 		}
 		File sessionFile = sessionFiles[0];
 
+
+
 		// session_id;acq_time;pathology
 		// analyze date for every session
 		CsvMapper mapper = new CsvMapper();
 		mapper.enable(CsvParser.Feature.WRAP_AS_ARRAY);
 		MappingIterator<String[]> it = mapper.readerFor(String[].class).readValues(sessionFile);
 
+		// Check File is not empty
+		if (sessionFile.length() > 0) {
+			LOG.debug("We found a non empty session.tsv file ");
+		} else {
+			LOG.debug("We found an empty session.tsv file ");
+			return examDates;
+		})
 		// Check that the list of column is known
 		List<String> columns = Arrays.asList(it.next()[0].split(CSV_SEPARATOR));
 		int sessionIdIndex = columns.indexOf("session_id");

--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/bids/BidsImporterApiController.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/bids/BidsImporterApiController.java
@@ -134,11 +134,11 @@ public class BidsImporterApiController implements BidsImporterApi {
 
 		// STEP 2: Subject level, analyze and create the new subject if necessary
 		Long subjectId = null;
-		// Exclude MACOSX automatically added hidden files
+		// Exclude MACOS automatically added metadata files and directories (AppleDouble and Finder)
 		for (File subjectFile : importJobDir.listFiles(new FilenameFilter() {
 			@Override
 			public boolean accept(File arg0, String name) {
-				return !name.startsWith(".DS_Store") && !name.startsWith("__");
+				return !name.startsWith(".DS_Store") && !name.startsWith("__MAC") && !name.startsWith("._") && !name.startsWith(".AppleDouble") ;
 			}})) {
 			String fileName = subjectFile.getName();
 			String subjectName = null;
@@ -170,7 +170,7 @@ public class BidsImporterApiController implements BidsImporterApi {
 			File[] examFiles = subjectFile.listFiles(new FilenameFilter() {
 				@Override
 				public boolean accept(File arg0, String name) {
-					return !name.endsWith("_scans.tsv") && !name.endsWith("_sessions.tsv");
+					return !name.endsWith("_scans.tsv") && !name.endsWith("_sessions.tsv") && !name.startsWith(".DS_Store") && !name.startsWith("__MAC") && !name.startsWith("._") && !name.startsWith(".AppleDouble");
 				}
 			});
 
@@ -209,7 +209,13 @@ public class BidsImporterApiController implements BidsImporterApi {
 					importJob.setExaminationId(examId);
 
 					// STEP 4: Finish import from every bids data folder
-					for (File dataTypeFile : sessionFile.listFiles()) {
+					for (File dataTypeFile : sessionFile.listFiles(
+							new FilenameFilter() {
+								@Override
+								public boolean accept(File arg0, String name) {
+									return !name.startsWith(".DS_Store") && !name.startsWith("__MAC") && !name.startsWith("._") && !name.startsWith(".AppleDouble") ;
+								}}
+					)) {
 						importSession(dataTypeFile, importJob);
 					}
 				} else {


### PR DESCRIPTION
This Pull Request aims at dealing with MAC OS added files within the BIDS data import. This PR solves issue #2518 
 ### MAC OS Hidden Files
There are several types of MAC Hidden files that are introduced either by Finder (and Zip) or by AppleDouble mechanism
see : 
+ [DS_store](https://en.wikipedia.org/wiki/.DS_Store#:~:text=DS_Store%20is%20a%20file%20that,Services%20Store%2C%20reflecting%20its%20purpose).
+ [AppleDouble](https://en.wikipedia.org/wiki/AppleSingle_and_AppleDouble_formats) 
### Incompatibility with BIDS import
    1. At the subject or session check level an file other than starting with sub- or sess- prefix was making the import crash
    2. At data level these files if present in the datatype folder could be imported as real data 
### Solution
+ Filtering of the MACOS Hidden file to exclude them at the subject, session and data level
+ Also added fix to deal with empty _sessions.tsv file that there making the process crash (dont know if its better now let me know) 
