### PR TITLE
Fix for GitHub issue #2606  related to Spring Boot 3.4.0 update

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dicom/web/service/DICOMWebService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dicom/web/service/DICOMWebService.java
@@ -187,7 +187,9 @@ public class DICOMWebService {
 				if (entity != null) {
 					ByteArrayResource byteArrayResource = new ByteArrayResource(EntityUtils.toByteArray(entity));
 					HttpHeaders responseHeaders = new HttpHeaders();
-					responseHeaders.setContentLength(entity.getContentLength());
+					if (!entity.isChunked() && entity.getContentLength() >= 0) {
+						responseHeaders.setContentLength(entity.getContentLength());
+					}					
 					return new ResponseEntity(byteArrayResource, responseHeaders, HttpStatus.OK);
 				} else {
 					LOG.error("DICOMWeb: findFrameOfStudyOfSerieOfInstance: empty response entity.");				


### PR DESCRIPTION
Spring Boot 3.4.0 and Apache Http Client Release 5.4  are probably more restrictive on setContentLength(x smaller than 0), so we set it only in case of existing value to avoid the exception