### PR TITLE
Optimizations on instances == null (ShUp + server) + fix QC from pacs

### DIFF
--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/dicom/DicomSerieAndInstanceAnalyzer.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/dicom/DicomSerieAndInstanceAnalyzer.java
@@ -48,6 +48,7 @@ public class DicomSerieAndInstanceAnalyzer {
 			|| UID.DeformableSpatialRegistrationStorage.equals(sopClassUID)
 			|| UID.SegmentationStorage.equals(sopClassUID)
 			|| UID.SurfaceSegmentationStorage.equals(sopClassUID)) {
+			LOG.warn("Instance (image) ignored, because of SOPClassUID: " + sopClassUID);
 			return true;
 		}
 		final String referencedSOPClassUIDInFile = attributes.getString(Tag.ReferencedSOPClassUIDInFile);
@@ -57,10 +58,12 @@ public class DicomSerieAndInstanceAnalyzer {
 			|| UID.DeformableSpatialRegistrationStorage.equals(referencedSOPClassUIDInFile)
 			|| UID.SegmentationStorage.equals(referencedSOPClassUIDInFile)
 			|| UID.SurfaceSegmentationStorage.equals(referencedSOPClassUIDInFile)) {
+			LOG.warn("Instance (image) ignored, because of ReferencedSOPClassUIDInFile: " + referencedSOPClassUIDInFile);
 			return true;
 		}
 		final String burnedInAnnotation = attributes.getString(Tag.BurnedInAnnotation);
 		if (DICOM_VR_CODE_STRING_YES.equals(burnedInAnnotation)) {
+			LOG.warn("Instance (image) ignored, because of burnedInAnnotation: " + burnedInAnnotation);
 			return true;
 		}
 		return false;

--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/dicom/ImagesCreatorAndDicomFileAnalyzerService.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/dicom/ImagesCreatorAndDicomFileAnalyzerService.java
@@ -115,6 +115,13 @@ public class ImagesCreatorAndDicomFileAnalyzerService {
 					}
 					cpt++;
 				}
+				/*
+				 * We apply an additional sort here on the series list to base everything on seriesNumbers finally.
+				 * It might happen, while using ShanoirUploader, that some PACS will not share the seriesNumber, so
+				 * we can not correctly sort in ShanoirUploader without going into the files itself, what we do not
+				 * do, therefore we have the ImagesCreatorAndDicomFileAnalyzerService, that is called on the server.
+				 */
+				series.sort(new SeriesNumberOrDescriptionSorter());
 			}
 		}
 	}

--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/dicom/query/QueryPACSService.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/dicom/query/QueryPACSService.java
@@ -570,9 +570,15 @@ public class QueryPACSService {
 					}
 				}
 			});
-			instances.sort(new InstanceNumberSorter());
-			serie.setInstances(instances);
-			LOG.info(instances.size() + " instances found for serie " + serie.getSeriesDescription());
+			if (!instances.isEmpty()) {
+				instances.sort(new InstanceNumberSorter());
+				serie.setInstances(instances);
+				LOG.info(instances.size() + " instances found for serie " + serie.getSeriesDescription());
+			} else {
+				LOG.warn("Serie found with empty instances and therefore ignored (SeriesDescription: {}, SerieInstanceUID: {}).", serie.getSeriesDescription(), serie.getSeriesInstanceUID());
+				serie.setIgnored(true);
+				serie.setSelected(false);
+			}
 		}
 	}
 

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/ShUpConfig.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/ShUpConfig.java
@@ -20,7 +20,7 @@ public class ShUpConfig {
 	 */
 	public static final String SHANOIR_UPLOADER_VERSION = "v9.0.0";
 	
-	public static final String RELEASE_DATE = "2025-01-09";
+	public static final String RELEASE_DATE = "2025-02-03";
 	
 	public static final SimpleDateFormat formatter = new SimpleDateFormat("dd/MM/yyyy");
 	

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/action/ImportFinishActionListener.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/action/ImportFinishActionListener.java
@@ -50,9 +50,6 @@ public class ImportFinishActionListener implements ActionListener {
 	
 	private ImportStudyAndStudyCardCBItemListener importStudyAndStudyCardCBILNG;
 
-	// @Autowired
-	// private CurrentNominativeDataController currentNominativeDataController;
-
 	public ImportFinishActionListener(final MainWindow mainWindow, UploadJob uploadJob, File uploadFolder, Subject subjectREST,
 			ImportStudyAndStudyCardCBItemListener importStudyAndStudyCardCBILNG) {
 		this.mainWindow = mainWindow;
@@ -171,7 +168,7 @@ public class ImportFinishActionListener implements ActionListener {
 		
 		// Quality Check if the Study selected has Quality Cards to be checked at import
         try {
-			QualityCardResult qualityControlResult = QualityUtils.checkQualityAtImport(importJob);
+			QualityCardResult qualityControlResult = QualityUtils.checkQualityAtImport(importJob, mainWindow.isFromPACS);
 			// If quality check resulted in errors, show a message and do not start the import
 			if (!qualityControlResult.isEmpty() && (qualityControlResult.hasError())) {
 				JOptionPane.showMessageDialog(mainWindow.frame,  QualityUtils.getQualityControlreportScrollPane(qualityControlResult), 

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/action/ImportFinishActionListener.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/action/ImportFinishActionListener.java
@@ -167,30 +167,25 @@ public class ImportFinishActionListener implements ActionListener {
 		 * 3. Fill importJob, check quality if needed, start pseudo and prepare upload
 		 */
 		ImportUtils.prepareImportJob(importJob, subjectREST.getName(), subjectREST.getId(), examinationId, 
-		(Study) mainWindow.importDialog.studyCB.getSelectedItem(), (StudyCard) mainWindow.importDialog.studyCardCB.getSelectedItem());
+			(Study) mainWindow.importDialog.studyCB.getSelectedItem(), (StudyCard) mainWindow.importDialog.studyCardCB.getSelectedItem());
 		
-		QualityCardResult qualityControlResult = new QualityCardResult();
-
 		// Quality Check if the Study selected has Quality Cards to be checked at import
         try {
-            qualityControlResult = QualityUtils.checkQualityAtImport(importJob);
-
+			QualityCardResult qualityControlResult = QualityUtils.checkQualityAtImport(importJob);
 			// If quality check resulted in errors, show a message and do not start the import
 			if (!qualityControlResult.isEmpty() && (qualityControlResult.hasError())) {
 				JOptionPane.showMessageDialog(mainWindow.frame,  QualityUtils.getQualityControlreportScrollPane(qualityControlResult), 
 				ShUpConfig.resourceBundle.getString("shanoir.uploader.import.quality.check.window.title"), JOptionPane.ERROR_MESSAGE);
-
 				// set status FAILED
 				ShUpOnloadConfig.getCurrentNominativeDataController().updateNominativeDataPercentage(uploadFolder, UploadState.ERROR.toString());
 				logger.error("The upload for the patient {} failed due to quality control errors.", importJob.getSubject().getName());
-
 			} else {
 				// If quality control condition is VALID we do not set a quality card result entry but we update the subjectStudy qualityTag
 				if (!qualityControlResult.isEmpty() || !qualityControlResult.getUpdatedSubjectStudies().isEmpty()) {
 					// If quality control has one warning or failed valid condition fulfilled we inform the user and allow import to continue
 					if (qualityControlResult.hasWarning() || qualityControlResult.hasFailedValid()) {
 						JOptionPane.showMessageDialog(mainWindow.frame,  QualityUtils.getQualityControlreportScrollPane(qualityControlResult), 
-						ShUpConfig.resourceBundle.getString("shanoir.uploader.import.quality.check.window.title"), JOptionPane.WARNING_MESSAGE);
+							ShUpConfig.resourceBundle.getString("shanoir.uploader.import.quality.check.window.title"), JOptionPane.WARNING_MESSAGE);
 					}
 					// If Failed Valid No updated subject studies exist in the qualityControlResult
 					// For Now if Failed Valid then the quality tag of the subject on server side is not updated with an empty value
@@ -198,30 +193,28 @@ public class ImportFinishActionListener implements ActionListener {
 						//Set qualityTag to the importJob in order to update subjectStudy qualityTag on server side
 						importJob.setQualityTag(qualityControlResult.getUpdatedSubjectStudies().get(0).getQualityTag());
 					}
-				}
-				
-				Runnable runnable = new ImportFinishRunnable(uploadJob, uploadFolder, importJob, subjectREST.getName());
-				Thread thread = new Thread(runnable);
-				thread.start();
-	
-				JOptionPane.showMessageDialog(mainWindow.frame,
-				ShUpConfig.resourceBundle.getString("shanoir.uploader.import.start.auto.import.message"),
-				"Import", JOptionPane.INFORMATION_MESSAGE);
-		}
+				}				
+			}
         } catch (Exception ex) {
 			logger.error(ex.getMessage(), ex);
-			JOptionPane.showMessageDialog(mainWindow.frame,  ShUpConfig.resourceBundle.getString("shanoir.uploader.import.quality.check.exception.message") + ex.getMessage(), 
-			ShUpConfig.resourceBundle.getString("shanoir.uploader.select.error.title"), JOptionPane.ERROR_MESSAGE);
-			// set status FAILED
-			ShUpOnloadConfig.getCurrentNominativeDataController().updateNominativeDataPercentage(uploadFolder, UploadState.ERROR.toString());
+			JOptionPane.showMessageDialog(mainWindow.frame, 
+				ShUpConfig.resourceBundle.getString("shanoir.uploader.import.quality.check.exception.message") + ex.getMessage(), 
+				ShUpConfig.resourceBundle.getString("shanoir.uploader.select.error.title"), JOptionPane.ERROR_MESSAGE);
         }
-		
+
+		Runnable runnable = new ImportFinishRunnable(uploadJob, uploadFolder, importJob, subjectREST.getName());
+		Thread thread = new Thread(runnable);
+		thread.start();
+
+		JOptionPane.showMessageDialog(mainWindow.frame,
+			ShUpConfig.resourceBundle.getString("shanoir.uploader.import.start.auto.import.message"),
+		"Import", JOptionPane.INFORMATION_MESSAGE);
+
 		mainWindow.importDialog.setVisible(false);
 		mainWindow.importDialog.mrExaminationExamExecutiveLabel.setVisible(true);
 		mainWindow.importDialog.mrExaminationExamExecutiveCB.setVisible(true);
 		mainWindow.setCursor(null); // turn off the wait cursor
 		((JButton) event.getSource()).setEnabled(true);	
-		
 	}
 
 }

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/action/SelectionActionListener.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/action/SelectionActionListener.java
@@ -2,7 +2,6 @@ package org.shanoir.uploader.action;
 
 import java.time.LocalDate;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -18,7 +17,6 @@ import org.shanoir.ng.importer.model.ImportJob;
 import org.shanoir.ng.importer.model.Patient;
 import org.shanoir.ng.importer.model.Serie;
 import org.shanoir.ng.importer.model.Study;
-import org.shanoir.uploader.ShUpConfig;
 import org.shanoir.uploader.dicom.DicomTreeNode;
 import org.shanoir.uploader.dicom.query.PatientTreeNode;
 import org.shanoir.uploader.dicom.query.SerieTreeNode;

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/dicom/DicomServerClient.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/dicom/DicomServerClient.java
@@ -202,8 +202,15 @@ public class DicomServerClient implements IDicomServerClient {
 						}
 					}
 				}
-				instances.sort(new InstanceNumberSorter());
-				serie.setInstances(instances);
+				if (!instances.isEmpty()) {
+					instances.sort(new InstanceNumberSorter());
+					serie.setInstances(instances);
+					logger.info(instances.size() + " instances found for serie " + serie.getSeriesDescription());
+				} else {
+					logger.warn("Serie found with empty instances and therefore ignored (SeriesDescription: {}, SerieInstanceUID: {}).", serie.getSeriesDescription(), serie.getSeriesInstanceUID());
+					serie.setIgnored(true);
+					serie.setSelected(false);
+				}
 				downloadOrCopyReport.append("Download: serie "
 					+ (serie.getSeriesNumber() != null ? "(No. " + serie.getSeriesNumber() + ") " : "")
 					+ serie.getSeriesDescription()

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/utils/ImportUtils.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/utils/ImportUtils.java
@@ -289,6 +289,7 @@ public class ImportUtils {
 			List<Instance> instances = serie.getInstances();
 			if (instances == null) {
 				serie.setSelected(false);
+				logger.warn("Serie [" + serie.getSeriesDescription() + "] found with instances == null. Serie de-selected.");
 				continue;
 			}
 			/**

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/utils/ImportUtils.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/utils/ImportUtils.java
@@ -240,6 +240,8 @@ public class ImportUtils {
 
 	/**
 	 * subjectId and examinationId are created in the window of ImportDialog and are not known before.
+	 * In this method selectedSeries as attribute of ImportJob are copied into patient - study - serie
+	 * tree, as still expected like this on the server.
 	 * 
 	 * @param uploadJob
 	 * @param subjectName

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/utils/ImportUtils.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/utils/ImportUtils.java
@@ -287,9 +287,10 @@ public class ImportUtils {
 		final List<Serie> series = new ArrayList<>(importJob.getSelectedSeries());
 		for (Serie serie : series) {
 			List<Instance> instances = serie.getInstances();
-			if (instances == null) {
+			if (instances == null || instances.isEmpty()) {
+				serie.setIgnored(true);
 				serie.setSelected(false);
-				logger.warn("Serie [" + serie.getSeriesDescription() + "] found with instances == null. Serie de-selected.");
+				logger.warn("Serie [" + serie.getSeriesDescription() + "] found with instances == null or empty. Serie de-selected.");
 				continue;
 			}
 			/**

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/utils/ImportUtils.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/utils/ImportUtils.java
@@ -7,7 +7,6 @@ import java.text.ParseException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -17,6 +16,7 @@ import javax.swing.JProgressBar;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.SystemUtils;
 import org.shanoir.ng.importer.dicom.ImagesCreatorAndDicomFileAnalyzerService;
+import org.shanoir.ng.importer.dicom.SeriesNumberOrDescriptionSorter;
 import org.shanoir.ng.importer.model.ImportJob;
 import org.shanoir.ng.importer.model.Instance;
 import org.shanoir.ng.importer.model.Patient;
@@ -43,7 +43,6 @@ import org.shanoir.uploader.model.rest.ManufacturerModel;
 import org.shanoir.uploader.model.rest.Sex;
 import org.shanoir.uploader.model.rest.Study;
 import org.shanoir.uploader.model.rest.StudyCard;
-import org.shanoir.uploader.model.rest.StudyCenter;
 import org.shanoir.uploader.model.rest.SubjectStudy;
 import org.shanoir.uploader.model.rest.SubjectType;
 import org.shanoir.uploader.nominativeData.NominativeDataUploadJob;
@@ -308,9 +307,12 @@ public class ImportUtils {
 			}
 			serie.setSelected(true);
 		}
+		// We sort again here, even if the QueryPACSService or the DicomDirToModelService sort already
+		// The user select after both components in the tree GUI of ShanoirUploader, where a linked list
+		// is used, therefore as the user can click and series on his behalf, we sort again here.
+		series.sort(new SeriesNumberOrDescriptionSorter());
 		studyImportJob.setSeries(series);
 		studiesImportJob.add(studyImportJob);
-		//importJob.setStudy(studyImportJob);
 		patient.setStudies(studiesImportJob);
 		importJob.setPatients(patients);
 		return importJob;
@@ -630,18 +632,6 @@ public class ImportUtils {
 		for (AcquisitionEquipment acquisitionEquipment : acquisitionEquipments) {
 			if (acquisitionEquipment.getManufacturerModel().getManufacturer().getName().equalsIgnoreCase(manufacturer)) {
 				return acquisitionEquipment.getManufacturerModel().getManufacturer();
-			}
-		}
-		return null;
-	}
-
-	private static Center findCenterOfStudy(Study studyREST, UploadJob uploadJob) {
-		String institutionName = uploadJob.getMriInformation().getInstitutionName().toLowerCase();
-		List<StudyCenter> studyCenters = studyREST.getStudyCenterList();
-		for (StudyCenter studyCenter : studyCenters) {
-			String centerName = studyCenter.getCenter().getName().toLowerCase();
-			if (centerName.contains(institutionName) || institutionName.contains(centerName)) {
-				return studyCenter.getCenter();
 			}
 		}
 		return null;

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/utils/QualityUtils.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/utils/QualityUtils.java
@@ -45,9 +45,9 @@ public class QualityUtils {
 
 	public static QualityCardResult checkQualityAtImport(ImportJob importJob) throws Exception {
 
+		QualityCardResult qualityCardResult = new QualityCardResult();
 		ExaminationData examinationData = new ExaminationData();
 		SubjectStudy subjectStudy = new SubjectStudy();
-		QualityCardResult qualityCardResult = new QualityCardResult();
 		final File importJobDir = new File(importJob.getWorkFolder());
 		List<QualityCard> qualityCards = new ArrayList<>();
 		
@@ -58,12 +58,10 @@ public class QualityUtils {
 			logger.error("Error while retrieving quality cards from server for study " + importJob.getStudyId() + " : " + e.getMessage());
 			throw e;
 		}
-		
 
 		// If no quality cards are found for the study we skip the quality control
 		if (qualityCards == null || qualityCards.isEmpty()) {
 			logger.info("Quality Control At Import - No quality cards found for study " + importJob.getStudyId());
-
 			return qualityCardResult;
 		}
 		
@@ -103,7 +101,6 @@ public class QualityUtils {
 			throw e;
 		}
 		
-	
 		return qualityCardResult;
 	}
 

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/utils/QualityUtils.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/utils/QualityUtils.java
@@ -43,7 +43,7 @@ public class QualityUtils {
 
 	private static DatasetsCreatorService datasetsCreatorService = new DatasetsCreatorService();
 
-	public static QualityCardResult checkQualityAtImport(ImportJob importJob) throws Exception {
+	public static QualityCardResult checkQualityAtImport(ImportJob importJob, boolean isImportFromPACS) throws Exception {
 
 		QualityCardResult qualityCardResult = new QualityCardResult();
 		ExaminationData examinationData = new ExaminationData();
@@ -66,7 +66,7 @@ public class QualityUtils {
 		}
 		
 		// Convert instances to images with parameter isFromShUpQualityControl set to true to keep absolute filepath for the images
-		imagesCreatorAndDicomFileAnalyzer.createImagesAndAnalyzeDicomFiles(importJob.getPatients(), importJobDir.getAbsolutePath(), false, null, true);
+		imagesCreatorAndDicomFileAnalyzer.createImagesAndAnalyzeDicomFiles(importJob.getPatients(), importJobDir.getAbsolutePath(), isImportFromPACS, null, true);
 
 		// Construct Dicom datasets from images
 		for (org.shanoir.ng.importer.model.Patient patient : importJob.getPatients()) {
@@ -159,4 +159,5 @@ public class QualityUtils {
 
 		return scrollPane;
 	}
+
 }


### PR DESCRIPTION
Hi, this PR prepares a new release of ShUp and fixes the following:
- better log in case of ignored dicom instances occur (for debug with CHUGA and ofsep)
- harmonize instances management, in case empty
- continue import in case exception raised during QC (e.g. field corrupted etc.)
- fix: never worked with data from pacs as flag isFromPACS not used to calculate filePath (issue #2616)