### PR TITLE
avoid exception if modality is null to create manufacturer model

### DIFF
--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/action/FindDicomActionListener.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/action/FindDicomActionListener.java
@@ -121,7 +121,8 @@ public class FindDicomActionListener extends JPanel implements ActionListener {
 					+ mainWindow.patientIDTF.getText() + " "
 					+ mainWindow.birthDate.toString() + " "
 					+ mainWindow.studyDescriptionTF.getText() + " "
-					+ mainWindow.studyDate.toString()) ;
+					+ mainWindow.studyDate.toString() + " "
+					+ mainWindow.modality);
 			this.mainWindow.isFromPACS = true;
 
 			this.mainWindow.setCursor(Cursor

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/action/ImportFromTableRunner.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/action/ImportFromTableRunner.java
@@ -122,7 +122,8 @@ public class ImportFromTableRunner extends SwingWorker<Void, Integer> {
 				String patientName = importJob.getDicomQuery().getPatientName();
 				String patientID = importJob.getDicomQuery().getPatientID();
 				String studyDate = importJob.getDicomQuery().getStudyDate();
-				String importJobIdentifier = "[Line: " + i + ", patientName: " + patientName + ", patientID: " + patientID + ", studyDate: " + studyDate + "]";
+				String modality = importJob.getDicomQuery().getModality();
+				String importJobIdentifier = "[Line: " + i + ", patientName: " + patientName + ", patientID: " + patientID + ", studyDate: " + studyDate +  ", modality: " + modality + "]";
 				logger.info("\r\n------------------------------------------------------\r\n"
 					+ "Starting importJob " + importJobIdentifier + "\r\n"
 					+ "------------------------------------------------------");
@@ -294,7 +295,12 @@ public class ImportFromTableRunner extends SwingWorker<Void, Integer> {
 						logger.error(importJob.getErrorMessage());
 						return false;
 					}
+
+					// Modality is mandatory to create a new Manufacturer model, but not mandatory in the dicom query
 					String modality = importJob.getDicomQuery().getModality();
+					if (modality == null || modality.isBlank()) {
+						modality = importJob.getSelectedSeries().iterator().next().getModality();
+					}
 					Integer datasetModalityType = DatasetModalityType.getIdFromModalityName(modality);
 					String magneticFieldStrength = uploadJob.getMriInformation().getMagneticFieldStrength();
 					if (magneticFieldStrength == null || magneticFieldStrength.isBlank() || "unknown".equals(magneticFieldStrength)) {


### PR DESCRIPTION
linked to https://github.com/fli-iam/shanoir-ng/issues/2592

During mass import tests I encountered an error when modality is not filled in the excel file but mandatory to create a new manufacturer model.