### PR TITLE
#2618 : Solr indexation not blocking anymore when failed

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/configuration/RabbitMQDatasetsService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/configuration/RabbitMQDatasetsService.java
@@ -184,7 +184,11 @@ public class RabbitMQDatasetsService {
 
 			studyService.updateStudy(updated, current);
 			
-			solrService.updateStudyAsync(current.getId());
+			try {
+				solrService.updateStudyAsync(current.getId());
+			}catch (Exception e){
+				LOG.error("Solr update failed for study {}", current.getId(), e);
+			}
 
 		} catch (Exception ex) {
 			LOG.error("An error occured while processing study update", ex);
@@ -231,7 +235,11 @@ public class RabbitMQDatasetsService {
 			// Update solr references
 			List<Long> subjectIdList = new ArrayList<Long>();
 			subjectIdList.add(su.getId());
-			solrService.updateSubjectsAsync(subjectIdList);
+			try {
+				solrService.updateSubjectsAsync(subjectIdList);
+			}catch (Exception e){
+				LOG.error("Solr update failed for subjects {}", subjectIdList, e);
+			}
 
 			return true;
 		} catch (Exception e) {

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/DicomSEGAndSRImporterService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/DicomSEGAndSRImporterService.java
@@ -302,12 +302,7 @@ public class DicomSEGAndSRImporterService {
 		createMetadata(datasetAttributes, dataset.getOriginMetadata().getDatasetModalityType(), newMsOrSegDataset);
 		createDatasetExpression(datasetAttributes, newMsOrSegDataset);
 		Dataset createdDataset = datasetService.create(newMsOrSegDataset);
-		try {
-			solrService.indexDataset(createdDataset.getId());
-		} catch(Exception e) {
-			LOG.error(e.getMessage(), e);
-			LOG.error("DICOM SEG or SR not indexed into Solr.");
-		}
+		solrService.indexDataset(createdDataset.getId());
 	}
 
 	/**

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/solr/controler/SolrApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/solr/controler/SolrApiController.java
@@ -52,23 +52,17 @@ public class SolrApiController implements SolrApi {
 	@Autowired
 	private SolrService solrService;
 
-	@Autowired
-	private ShanoirEventService eventService;
-
-	@Override
 	public ResponseEntity<Void> indexAll() throws SolrServerException, IOException {
 		solrService.indexAll();
 		return new ResponseEntity<>(HttpStatus.OK);
 	}
 	
-	@Override
 	public ResponseEntity<SolrResultPage<ShanoirSolrDocument>> facetSearch(
 			@Parameter(description = "facets", required = true) @Valid @RequestBody ShanoirSolrQuery facet, Pageable pageable) throws RestServiceException {
 		SolrResultPage<ShanoirSolrDocument> documents = solrService.facetSearch(facet, pageable);
 		return new ResponseEntity<>(documents, HttpStatus.OK);
 	}
 	
-	@Override
 	public ResponseEntity<Page<ShanoirSolrDocument>> findByIdIn(@Parameter(description = "dataset ids", required = true) @Valid @RequestBody List<Long> datasetIds, Pageable pageable) throws RestServiceException {
 		Page<ShanoirSolrDocument> documents = solrService.getByIdIn(datasetIds, pageable);
 		if (documents.getContent().isEmpty()) {

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/solr/service/SolrService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/solr/service/SolrService.java
@@ -37,32 +37,87 @@ import java.util.List;
  *
  */
 public interface SolrService {
-	
+
+	/**
+	 * Index a document to the existing index
+	 * @param document the document to index
+	 */
 	@PreAuthorize("hasRole('ADMIN')")
 	void addToIndex(ShanoirSolrDocument document) throws SolrServerException, IOException;
-	
+
+	/**
+	 * Index documents to the existing index
+	 * @param documents the documents to index
+	 */
 	void addAllToIndex(List<ShanoirSolrDocument> documents) throws SolrServerException, IOException;
 
+	/**
+	 * Index all datasets (beginning with the creation of a new index)
+	 */
 	void indexAll() throws SolrServerException, IOException;
 
-	void indexDataset(Long datasetId) throws SolrServerException, IOException;
-	
-	void indexDatasets(List<Long> datasetIds) throws SolrServerException, IOException;
+	/**
+	 * Index dataset to the existing index from its id
+	 * @param datasetId the dataset id relative to dataset to index
+	 */
+	void indexDataset(Long datasetId);
 
+	/**
+	 * Index datasets to the existing index from their ids
+	 * @param datasetIds the dataset ids relative to the datasets to index
+	 */
+	void indexDatasets(List<Long> datasetIds);
+
+	/**
+	 * Remove from index the dataset relative to the id
+	 * @param datasetId the dataset id relative to the dataset to remove from index
+	 */
 	void deleteFromIndex(Long datasetId) throws SolrServerException, IOException;
-	
+
+	/**
+	 * Remove from index the datasets relative to the ids
+	 * @param datasetIds the dataset ids relative to the datasets to remove from index
+	 */
 	void deleteFromIndex(List<Long> datasetIds) throws SolrServerException, IOException;
 
+	/**
+	 * Generate a list of results according to filters (the left side bar filters)
+	 * @param query the initial query according to user role and rights
+	 * @param pageable the left side bar filters
+	 * @return a solr result page object that gathers the results
+	 */
 	SolrResultPage<ShanoirSolrDocument> facetSearch(ShanoirSolrQuery query, Pageable pageable) throws RestServiceException;
 
+	/**
+	 * Generate a list of results according to a query (the top bar query)
+	 * @param datasetIds I'm not sure what are those ids
+	 * @param pageable the top bar query
+	 * @return a page gathering the filtered results
+	 */
 	Page<ShanoirSolrDocument> getByIdIn(List<Long> datasetIds, Pageable pageable) throws RestServiceException;
 
+	/**
+	 * Update a list of datasets in Solr.
+	 * @param datasetIds the list of dataset IDs to update
+	 */
 	void updateDatasets(List<Long> datasetIds) throws SolrServerException, IOException;
 
+	/**
+	 * Update a list of datasets in Solr asynchronously.
+	 * @param datasetIds the list of dataset IDs to update
+	 */
 	void updateDatasetsAsync(List<Long> datasetIds) throws SolrServerException, IOException;
 
+	/**
+	 * Update datasets relative to a list of subjects in Solr asynchronously.
+	 * @param subjectIds the list of subjects IDs to update
+	 */
 	void updateSubjectsAsync(List<Long> subjectIds) throws SolrServerException, IOException;
 
+	/**
+	 * Update datasets relative to a study in Solr asynchronously.
+	 * @param studyId the list of subjects IDs to update
+	 */
 	void updateStudyAsync(Long studyId) throws SolrServerException, IOException;
 
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/solr/service/SolrServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/solr/service/SolrServiceImpl.java
@@ -26,7 +26,6 @@ import java.util.stream.Collectors;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.shanoir.ng.dataset.repository.DatasetRepository;
-import org.shanoir.ng.examination.repository.ExaminationRepository;
 import org.shanoir.ng.shared.dateTime.DateTimeUtils;
 import org.shanoir.ng.shared.event.ShanoirEvent;
 import org.shanoir.ng.shared.event.ShanoirEventService;
@@ -35,7 +34,6 @@ import org.shanoir.ng.shared.exception.RestServiceException;
 import org.shanoir.ng.shared.model.Center;
 import org.shanoir.ng.shared.paging.PageImpl;
 import org.shanoir.ng.shared.repository.CenterRepository;
-import org.shanoir.ng.shared.repository.SubjectStudyRepository;
 import org.shanoir.ng.shared.subjectstudy.SubjectType;
 import org.shanoir.ng.solr.model.ShanoirMetadata;
 import org.shanoir.ng.solr.model.ShanoirSolrDocument;
@@ -49,7 +47,6 @@ import org.shanoir.ng.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -79,13 +76,7 @@ public class SolrServiceImpl implements SolrService {
 	private StudyUserRightsRepository rightsRepository;
 
 	@Autowired
-	private SubjectStudyRepository subjectStudyRepo;
-
-	@Autowired
 	private CenterRepository centerRepository;
-
-	@Autowired
-	private ExaminationRepository examRepository;
 
 	@Autowired
 	private DatasetRepository dsRepository;
@@ -115,8 +106,6 @@ public class SolrServiceImpl implements SolrService {
 		solrJWrapper.deleteAll();
 	}
 
-
-	@Override
 	@Async
 	@Transactional
 	public void indexAll() {
@@ -129,70 +118,10 @@ public class SolrServiceImpl implements SolrService {
 			cleanOldIndex(event);
 			fetchDatasToIndex(event, documents, tags);
 			indexDatas(event, documents, tags);
-		} catch (SolrServerException | IOException ignored) {
+		} catch (SolrServerException | IOException e) {
+			LOG.error("Solr indexation failed", e);
         }
     }
-
-	protected void indexDatas(ShanoirEvent event, List<ShanoirMetadata> documents, Map<Long, List<String>> tags) {
-		try {
-			int totalData = documents.size();
-			int indexedData = 0;
-			for (List<ShanoirMetadata> partition : ListUtils.partition(documents, 100000)) {
-				indexedData += partition.size();
-				event.setProgress((float) Math.floor(30F + ((indexedData / (float) totalData) * 70F)) / 100F);
-				indexDataPartition(event, partition, tags, indexedData);
-			}
-		} catch (Exception e) {
-			LOG.error("Error indexing datasets into Solr.", e);
-			eventService.publishErrorEvent(event, "Error indexing datasets into Solr : " + e.getMessage());
-		}
-	}
-
-	protected void indexDataPartition(ShanoirEvent event, List<ShanoirMetadata> documents, Map<Long, List<String>> tags, int indexedSize) throws SolrServerException, IOException {
-		indexDocumentsInSolr(documents, tags);
-		if(Objects.equals(1f, event.getProgress())){
-			eventService.publishSuccessEvent(event, "Indexed [" + indexedSize + "] datasets.");
-		} else {
-			eventService.publishEvent(event, "Indexing [" + indexedSize + "] datasets...", event.getProgress());
-		}
-	}
-
-	protected void fetchDatasToIndex(ShanoirEvent event, List<ShanoirMetadata> documents, Map<Long, List<String>> tags) {
-		try {
-			documents.addAll(shanoirMetadataRepository.findAllAsSolrDoc());
-			eventService.publishEvent(event, "Fetching data to index...", 0.2f);
-			tags.putAll(shanoirMetadataRepository.findAllTags(null));
-			eventService.publishEvent(event, "Fetching data to index...", 0.3f);
-		} catch(Exception e){
-			LOG.error("Error while fetching data to index.", e);
-			eventService.publishErrorEvent(event, "Error while fetching data to index : " + e.getMessage());
-			throw e;
-		}
-	}
-
-	protected void cleanOldIndex(ShanoirEvent event) throws SolrServerException, IOException {
-		try {
-			deleteAll();
-		} catch (SolrServerException | IOException e) {
-			LOG.error("Error while cleaning Solr index.", e);
-			eventService.publishErrorEvent(event, "Error while cleaning Solr index : " + e.getMessage());
-			throw e;
-		}
-		eventService.publishEvent(event, "Fetching data to index...", 0.1f);
-	}
-
-	@Transactional
-    protected ShanoirEvent beginIndexationProcess() {
-		ShanoirEvent event = new ShanoirEvent(
-				ShanoirEventType.SOLR_INDEX_ALL_EVENT,
-				null,
-				KeycloakUtil.getTokenUserId(),
-				"Cleaning Solr index...",
-				ShanoirEvent.IN_PROGRESS,
-				0f);
-		eventService.publishEvent(event);
-		return event;
-	}
 
     @Async
     @Transactional
@@ -218,52 +147,31 @@ public class SolrServiceImpl implements SolrService {
     }
 
 	@Transactional
-	@Override
-	public void indexDatasets(List<Long> datasetIds) throws SolrServerException, IOException {
-		// Get all associated datasets and index them to solr
-		List<ShanoirMetadata> metadatas = shanoirMetadataRepository.findSolrDocs(datasetIds);
-		Map<Long, List<String>> tags = shanoirMetadataRepository.findAllTags(datasetIds);
-		this.indexDocumentsInSolr(metadatas, tags);
+	public void indexDatasets(List<Long> datasetIds){
+		try {
+			List<ShanoirMetadata> metadatas = shanoirMetadataRepository.findSolrDocs(datasetIds);
+			Map<Long, List<String>> tags = shanoirMetadataRepository.findAllTags(datasetIds);
+			this.indexDocumentsInSolr(metadatas, tags);
+		} catch (Exception e) {
+			LOG.error("Solr indexation failed", e);
+		}
 	}
 
-	@Override
 	@Transactional(isolation = Isolation.READ_UNCOMMITTED,  propagation = Propagation.REQUIRES_NEW)
-	public void indexDataset(Long datasetId) throws SolrServerException, IOException {
-		ShanoirMetadata shanoirMetadata = shanoirMetadataRepository.findOneSolrDoc(datasetId);
-		if (shanoirMetadata == null) throw new IllegalStateException("shanoir metadata with id " +  datasetId + " query failed to return any result");
-		ShanoirSolrDocument doc = getShanoirSolrDocument(shanoirMetadata);
-		Map<Long, List<String>> tags = shanoirMetadataRepository.findAllTags(Collections.singletonList(datasetId));
-		doc.setTags(tags.get(datasetId));
-		solrJWrapper.addToIndex(doc);
-	}
-
-	private void indexDocumentsInSolr(List<ShanoirMetadata> metadatas, Map<Long, List<String>> tags) throws SolrServerException, IOException {
-		Iterator<ShanoirMetadata> docIt = metadatas.iterator();
-		List<ShanoirSolrDocument> solrDocuments = new ArrayList<>();
-
-		while (docIt.hasNext()) {
-			ShanoirMetadata shanoirMetadata = docIt.next();
-			ShanoirSolrDocument doc = this.getShanoirSolrDocument(shanoirMetadata);
-			doc.setTags(tags.get(shanoirMetadata.getDatasetId()));
-			solrDocuments.add(doc);
+	public void indexDataset(Long datasetId){
+		try {
+			ShanoirMetadata shanoirMetadata = shanoirMetadataRepository.findOneSolrDoc(datasetId);
+			if (shanoirMetadata == null) throw new IllegalStateException("shanoir metadata with id " +  datasetId + " query failed to return any result");
+			ShanoirSolrDocument doc = getShanoirSolrDocument(shanoirMetadata);
+			Map<Long, List<String>> tags = shanoirMetadataRepository.findAllTags(Collections.singletonList(datasetId));
+			doc.setTags(tags.get(datasetId));
+			solrJWrapper.addToIndex(doc);
+		} catch (Exception e) {
+			LOG.error("Solr indexation failed", e);
 		}
-		if(!solrDocuments.isEmpty()){
-			solrJWrapper.addAllToIndex(solrDocuments);
-		}
-	}
-
-	private ShanoirSolrDocument getShanoirSolrDocument(ShanoirMetadata shanoirMetadata) {
-		return new ShanoirSolrDocument(String.valueOf(shanoirMetadata.getDatasetId()), shanoirMetadata.getDatasetId(), shanoirMetadata.getDatasetName(),
-				shanoirMetadata.getDatasetType(), shanoirMetadata.getDatasetNature(), DateTimeUtils.localDateToDate(shanoirMetadata.getDatasetCreationDate()),
-				shanoirMetadata.getExaminationId(), shanoirMetadata.getExaminationComment(), DateTimeUtils.localDateToDate(shanoirMetadata.getExaminationDate()), shanoirMetadata.getAcquisitionEquipmentName(),
-				shanoirMetadata.getSubjectName(), SubjectType.getType(shanoirMetadata.getSubjectType()) != null ? SubjectType.getType(shanoirMetadata.getSubjectType()).name() : null, shanoirMetadata.getSubjectId(),
-				shanoirMetadata.getStudyName(), shanoirMetadata.getStudyId(), shanoirMetadata.getCenterName(),
-				shanoirMetadata.getCenterId(), shanoirMetadata.getSliceThickness(), shanoirMetadata.getPixelBandwidth(), shanoirMetadata.getMagneticFieldStrength(),
-				shanoirMetadata.isProcessed(), DateTimeUtils.localDateToDate(shanoirMetadata.getImportDate()), shanoirMetadata.getUsername(), shanoirMetadata.getSortingIndex());
 	}
 
 	@Transactional
-	@Override
 	public SolrResultPage<ShanoirSolrDocument> facetSearch(ShanoirSolrQuery query, Pageable pageable) throws RestServiceException {
 		SolrResultPage<ShanoirSolrDocument> result;
 		pageable = prepareTextFields(pageable);
@@ -276,6 +184,64 @@ public class SolrServiceImpl implements SolrService {
 		return result;
 	}
 
+	public Page<ShanoirSolrDocument> getByIdIn(List<Long> datasetIds, Pageable pageable) throws RestServiceException {
+		if (datasetIds.isEmpty()) {
+			return new PageImpl<>();
+		}
+		Page<ShanoirSolrDocument> result;
+		pageable = prepareTextFields(pageable);
+		if (KeycloakUtil.getTokenRoles().contains("ROLE_ADMIN")) {
+			result = solrJWrapper.findByDatasetIdIn(datasetIds, pageable);
+		} else {
+			Map<Long, List<String>> studiesCenter = getStudiesCenter();
+			result = solrJWrapper.findByStudyIdInAndDatasetIdIn(studiesCenter, datasetIds, pageable);
+		}
+		return result;
+	}
+
+	public void updateDatasets(List<Long> datasetIds) throws SolrServerException, IOException {
+		if (CollectionUtils.isEmpty(datasetIds)) {
+			return;
+		}
+		this.deleteFromIndex(datasetIds);
+		this.indexDatasets(datasetIds);
+	}
+
+	@Async
+	public void updateDatasetsAsync(List<Long> datasetIds) throws SolrServerException, IOException {
+		this.updateDatasets(datasetIds);
+	}
+
+	@Async
+	@Transactional
+	public void updateSubjectsAsync(List<Long> subjectIds) throws SolrServerException, IOException {
+		List<Long> ids = this.dsRepository.findIdsBySubjectIdIn(subjectIds);
+		this.updateDatasets(ids);
+	}
+
+	@Async
+	public void updateStudyAsync(Long studyId) throws SolrServerException, IOException {
+		List<Long> ids = this.dsRepository.findIdsByStudyId(studyId);
+		this.updateDatasets(ids);
+	}
+
+	@Transactional
+	protected ShanoirEvent beginIndexationProcess() {
+		ShanoirEvent event = new ShanoirEvent(
+				ShanoirEventType.SOLR_INDEX_ALL_EVENT,
+				null,
+				KeycloakUtil.getTokenUserId(),
+				"Cleaning Solr index...",
+				ShanoirEvent.IN_PROGRESS,
+				0f);
+		eventService.publishEvent(event);
+		return event;
+	}
+
+	/**
+	 * Get all study centers relative to the current user
+	 * @return a map with all study relative to the current user and their associated centers
+	 */
 	private Map<Long, List<String>> getStudiesCenter() {
 		List<StudyUser> studyUsers = Utils.toList(rightsRepository.findByUserId(KeycloakUtil.getTokenUserId()));
 		Map<Long, List<String>> studiesCenter = new HashMap<>();
@@ -287,12 +253,23 @@ public class SolrServiceImpl implements SolrService {
 		}
 		return studiesCenter;
 	}
-	
+
+	/**
+	 * Get the name of a center if present in a list
+	 * @param centers all allowed centers
+	 * @param id the id of a specific center
+	 * @return the name of the center
+	 */
 	private String findCenterName(List<Center> centers, Long id) {
 		List<Center> filteredCenters = centers.stream().filter(centerToFilter -> centerToFilter.getId().equals(id)).collect(Collectors.toList());
 		return filteredCenters.size() > 0 ? filteredCenters.get(0).getName() : null;
 	}
 
+	/**
+	 * Prepare the pageable object according to the filters
+	 * @param pageable pageable object to prepare
+	 * @return the prepared pageable
+	 */
 	private Pageable prepareTextFields(Pageable pageable) {
 		for (Sort.Order order : pageable.getSort()) {
 			if (order.getProperty().equals("studyName") || order.getProperty().equals("subjectName")
@@ -311,54 +288,109 @@ public class SolrServiceImpl implements SolrService {
 		return pageable;
 	}
 
-	@Override
-	public Page<ShanoirSolrDocument> getByIdIn(List<Long> datasetIds, Pageable pageable) throws RestServiceException {
-		if (datasetIds.isEmpty()) {
-			return new PageImpl<>();
+	/**
+	 * Index data to the existing index and manage shanoir event
+	 * @param event the Shanoir event relative to the indexation
+	 * @param documents the documents to index
+	 * @param tags the tags relative to the documents to index
+	 */
+	private void indexDatas(ShanoirEvent event, List<ShanoirMetadata> documents, Map<Long, List<String>> tags) {
+		try {
+			int totalData = documents.size();
+			int indexedData = 0;
+			for (List<ShanoirMetadata> partition : ListUtils.partition(documents, 100000)) {
+				indexedData += partition.size();
+				event.setProgress((float) Math.floor(30F + ((indexedData / (float) totalData) * 70F)) / 100F);
+				indexDataPartition(event, partition, tags, indexedData);
+			}
+		} catch (Exception e) {
+			LOG.error("Error indexing datasets into Solr.", e);
+			eventService.publishErrorEvent(event, "Error indexing datasets into Solr : " + e.getMessage());
 		}
-		Page<ShanoirSolrDocument> result;
-		pageable = prepareTextFields(pageable);
-		if (KeycloakUtil.getTokenRoles().contains("ROLE_ADMIN")) {
-			result = solrJWrapper.findByDatasetIdIn(datasetIds, pageable);
-		} else {
-			Map<Long, List<String>> studiesCenter = getStudiesCenter();
-			result = solrJWrapper.findByStudyIdInAndDatasetIdIn(studiesCenter, datasetIds, pageable);
-		}
-		return result;
 	}
 
 	/**
-	 * Updates a list of datasets in Solr.
-	 * @param datasetIds the list of dataset IDs to update
+	 * Index data to the existing index by partition and manage shanoir event
+	 * @param event the Shanoir event relative to the indexation
+	 * @param documents the documents to index
+	 * @param tags the tags relative to the documents to index
+	 * @param indexedSize the documents already indexed
 	 */
-	@Override
-	public void updateDatasets(List<Long> datasetIds) throws SolrServerException, IOException {
-		if (CollectionUtils.isEmpty(datasetIds)) {
-			return;
+	private void indexDataPartition(ShanoirEvent event, List<ShanoirMetadata> documents, Map<Long, List<String>> tags, int indexedSize) throws SolrServerException, IOException {
+		indexDocumentsInSolr(documents, tags);
+		if(Objects.equals(1f, event.getProgress())){
+			eventService.publishSuccessEvent(event, "Indexed [" + indexedSize + "] datasets.");
+		} else {
+			eventService.publishEvent(event, "Indexing [" + indexedSize + "] datasets...", event.getProgress());
 		}
-		this.deleteFromIndex(datasetIds);
-		this.indexDatasets(datasetIds);		
 	}
 
-	@Override
-	@Async
-	public void updateDatasetsAsync(List<Long> datasetIds) throws SolrServerException, IOException {
-		this.updateDatasets(datasetIds);
+	/**
+	 * Get all datasets and tags and put them in lists
+	 * @param event the Shanoir event relative to the indexation
+	 * @param documents the list in which are stored all datasets fetched for indexation
+	 * @param tags the list in which are stored all tags fetched for iddexation
+	 */
+	private void fetchDatasToIndex(ShanoirEvent event, List<ShanoirMetadata> documents, Map<Long, List<String>> tags) {
+		try {
+			documents.addAll(shanoirMetadataRepository.findAllAsSolrDoc());
+			eventService.publishEvent(event, "Fetching data to index...", 0.2f);
+			tags.putAll(shanoirMetadataRepository.findAllTags(null));
+			eventService.publishEvent(event, "Fetching data to index...", 0.3f);
+		} catch(Exception e){
+			LOG.error("Error while fetching data to index.", e);
+			eventService.publishErrorEvent(event, "Error while fetching data to index : " + e.getMessage());
+			throw e;
+		}
 	}
 
-	@Override
-	@Async
-	@Transactional
-	public void updateSubjectsAsync(List<Long> subjectIds) throws SolrServerException, IOException {
-		List<Long> ids = this.dsRepository.findIdsBySubjectIdIn(subjectIds);
-		this.updateDatasets(ids);
+	/**
+	 * Remove the existing index
+	 * @param event the Shanoir event relative to the indexation removal
+	 */
+	private void cleanOldIndex(ShanoirEvent event) throws SolrServerException, IOException {
+		try {
+			deleteAll();
+		} catch (SolrServerException | IOException e) {
+			LOG.error("Error while cleaning Solr index.", e);
+			eventService.publishErrorEvent(event, "Error while cleaning Solr index : " + e.getMessage());
+			throw e;
+		}
+		eventService.publishEvent(event, "Fetching data to index...", 0.1f);
 	}
 
-	@Override
-	@Async
-	public void updateStudyAsync(Long studyId) throws SolrServerException, IOException {
-		List<Long> ids = this.dsRepository.findIdsByStudyId(studyId);
-		this.updateDatasets(ids);
+	/**
+	 * Index documents with their tags
+	 * @param metadatas the documents to index
+	 * @param tags the tags relative to the documents to index
+	 */
+	private void indexDocumentsInSolr(List<ShanoirMetadata> metadatas, Map<Long, List<String>> tags) throws SolrServerException, IOException {
+		Iterator<ShanoirMetadata> docIt = metadatas.iterator();
+		List<ShanoirSolrDocument> solrDocuments = new ArrayList<>();
+
+		while (docIt.hasNext()) {
+			ShanoirMetadata shanoirMetadata = docIt.next();
+			ShanoirSolrDocument doc = this.getShanoirSolrDocument(shanoirMetadata);
+			doc.setTags(tags.get(shanoirMetadata.getDatasetId()));
+			solrDocuments.add(doc);
+		}
+		if(!solrDocuments.isEmpty()){
+			solrJWrapper.addAllToIndex(solrDocuments);
+		}
 	}
 
+	/**
+	 * Create a ShanoirSolrDocument object from a ShanoirMetadata object
+	 * @param shanoirMetadata the documents to transform
+	 * @return the constructed ShanoirSolrDocument
+	 */
+	private ShanoirSolrDocument getShanoirSolrDocument(ShanoirMetadata shanoirMetadata) {
+		return new ShanoirSolrDocument(String.valueOf(shanoirMetadata.getDatasetId()), shanoirMetadata.getDatasetId(), shanoirMetadata.getDatasetName(),
+				shanoirMetadata.getDatasetType(), shanoirMetadata.getDatasetNature(), DateTimeUtils.localDateToDate(shanoirMetadata.getDatasetCreationDate()),
+				shanoirMetadata.getExaminationId(), shanoirMetadata.getExaminationComment(), DateTimeUtils.localDateToDate(shanoirMetadata.getExaminationDate()), shanoirMetadata.getAcquisitionEquipmentName(),
+				shanoirMetadata.getSubjectName(), SubjectType.getType(shanoirMetadata.getSubjectType()) != null ? SubjectType.getType(shanoirMetadata.getSubjectType()).name() : null, shanoirMetadata.getSubjectId(),
+				shanoirMetadata.getStudyName(), shanoirMetadata.getStudyId(), shanoirMetadata.getCenterName(),
+				shanoirMetadata.getCenterId(), shanoirMetadata.getSliceThickness(), shanoirMetadata.getPixelBandwidth(), shanoirMetadata.getMagneticFieldStrength(),
+				shanoirMetadata.isProcessed(), DateTimeUtils.localDateToDate(shanoirMetadata.getImportDate()), shanoirMetadata.getUsername(), shanoirMetadata.getSortingIndex());
+	}
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/controler/StudyCardApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/controler/StudyCardApiController.java
@@ -48,6 +48,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @Controller
@@ -252,8 +253,12 @@ public class StudyCardApiController implements StudyCardApi {
         }
         
         // Update solr metadata
-        solrService.updateDatasetsAsync(datasetIds);
-        
+        try {
+            solrService.updateDatasetsAsync(datasetIds);
+        }catch (Exception e){
+            LOG.error("Solr update failed for datasets {}", datasetIds, e);
+        }
+
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/vip/output/handler/OFSEPSeqIdHandler.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/vip/output/handler/OFSEPSeqIdHandler.java
@@ -282,7 +282,11 @@ public class OFSEPSeqIdHandler extends OutputHandler {
             acquisitionService.update(acq);
         }
 
-        solrService.updateDatasets(Arrays.asList(ds.getId()));
+        try {
+            solrService.updateDatasets(Arrays.asList(ds.getId()));
+        }catch (Exception e){
+            LOG.error("Solr update failed for dataset {}", ds.getId(), e);
+        }
     }
 
     /**


### PR DESCRIPTION
Instead of update the callers when necessary, I prefered to turn all indexation method (except indexAll(), which is a special case) not blocking by surrounding their lines with a systematic try/catch. Here are some pros and cons :

Pros :
- Won't be blocking at any moment in the future, whatever it's relative to new methods or updated methods.
- Reduce complexity of indexation calls by avoiding exception management
- Not annoying for debug with logs, as we still have the calling stack (not the case for solrUpdate).

Cons : 
- Non specific log message (but not an issue for debug as we still have the calling stack)
- No way to modify indexation failure behaviour (according to me, it's not an issue because indexation is a "secondary" task, but not the core objective of the calling method (except for indexAll(), which is still a special case))

For solr updating methods, try/catch is relative to caller instead of called method, because they are in majority @Async, which could have been an issue for debugging as we can't have the calling stack anterior to the thread relative to the @Async method. 

Tell me if you prefer modifying the callers instead of the calling methods.

**Side work** : 
Cleaning and sorting SolrServiceImpl + some doc