### PR TITLE
Increase hikari.maximum-pool-size

### DIFF
--- a/shanoir-ng-datasets/src/main/resources/application.yml
+++ b/shanoir-ng-datasets/src/main/resources/application.yml
@@ -25,8 +25,8 @@ spring:
     username: datasets
     password: password
     driver-class-name: com.mysql.cj.jdbc.Driver
-    hikari.maximum-pool-size: 60
-    hikari.minimum-idle:  60
+    hikari.maximum-pool-size: 70
+    hikari.minimum-idle:  70
   jpa:
     defer-datasource-initialization: true
     generate-ddl: false # default, but prefer to set it explicitly (bootstrap.sh)

--- a/shanoir-ng-import/src/main/resources/application.yml
+++ b/shanoir-ng-import/src/main/resources/application.yml
@@ -25,8 +25,8 @@ spring:
     username: import
     password: password
     driver-class-name: com.mysql.cj.jdbc.Driver
-    hikari.maximum-pool-size: 40
-    hikari.minimum-idle: 40
+    hikari.maximum-pool-size: 50
+    hikari.minimum-idle: 50
   jpa:
     defer-datasource-initialization: true
     generate-ddl: false # default, but prefer to set it explicitly (bootstrap.sh)


### PR DESCRIPTION
This PR increases **hikari.maximum-pool-size** on ms import (40 to 50) and ms datasets (60 to 70).
This allows to have more db-connections in the pool for parallel user requests in both microservices.
Our MySQL database, version 5.7, that is behind all 6 microservices has a default
max_connections configuration from **151**.
With this PR, the max_connections are configured and distributed as follows:
- MS Users: default, 10
- MS Studies: default, 10
- MS Import: now 50
- MS Datasets: now 70
- MS Preclinical: default, 10
- MS NIfTI Conversion: 0, as requires NO connection to database
- **SUMMARY: 150** (to relate with the max_numbers supported by MySQL)
