### PR TITLE
Update SubjectServiceImpl.java

### DIFF
--- a/shanoir-ng-studies/src/main/java/org/shanoir/ng/subject/service/SubjectServiceImpl.java
+++ b/shanoir-ng-studies/src/main/java/org/shanoir/ng/subject/service/SubjectServiceImpl.java
@@ -377,7 +377,8 @@ public class SubjectServiceImpl implements SubjectService {
 			List<SubjectStudy> subjectStudyList = subject.getSubjectStudyList();
 			if (subjectStudyList != null) {
 				subjectStudyList.stream().forEach(ss -> {
-					ss.setSubjectStudyTags(subjectStudyRepository.findSubjectStudyTagsByStudyIdAndSubjectId(ss.getStudy().getId(), ss.getSubject().getId()));
+					ss.getSubjectStudyTags().clear();
+					ss.getSubjectStudyTags().addAll(subjectStudyRepository.findSubjectStudyTagsByStudyIdAndSubjectId(ss.getStudy().getId(), ss.getSubject().getId()));
 					Study studyWithTags = studyRepository.findStudyWithTagsById(ss.getStudy().getId());
 					if (studyWithTags != null) {
 						ss.getStudy().setTags(studyWithTags.getTags());


### PR DESCRIPTION
Using a setter over a whole collection reference in entities leads to hibernate losing its proxy and the track of things.

One solution is using clear() and add/addAll

We should inspect the whole code for this error.