### PR TITLE
Fix for change on Serie() constructor: series number from dicom

### DIFF
--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/dicom/ImagesCreatorAndDicomFileAnalyzerService.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/dicom/ImagesCreatorAndDicomFileAnalyzerService.java
@@ -76,6 +76,8 @@ public class ImagesCreatorAndDicomFileAnalyzerService {
 
 	private static final String YES = "YES";
 
+	private static final String SERIES_NUMBER_0 = "0";
+
 	@Autowired
 	private ShanoirEventService eventService;
 
@@ -401,7 +403,7 @@ public class ImagesCreatorAndDicomFileAnalyzerService {
 				serie.setSopClassUID(sopClassUIDDicomFile);
 			}
 		}
-		if (StringUtils.isEmpty(serie.getSeriesNumber())) {
+		if (StringUtils.isEmpty(serie.getSeriesNumber()) || SERIES_NUMBER_0.equals(serie.getSeriesNumber())) {
 			// has not been sent by PACS (case for Telemis), get it from .dcm file:
 			String seriesNumberDicomFile = attributes.getString(Tag.SeriesNumber);
 			if (StringUtils.isNotEmpty(seriesNumberDicomFile)) {


### PR DESCRIPTION
In the Serie() constructor, the way how the series number is retrieved has changed.
If not present, it is set to "0", so we need to adapt this as well in the ImagesCreator
AndDicomFileAnalyzerService.java, to retrieve it from the dicom files itself, if not set
by the DICOM server query/retrieve already.