### PR TITLE
shanoir-issue#2722: fix study.profile in mass exam import

### DIFF
--- a/shanoir-ng-front/src/app/studies/shared/study.dto.ts
+++ b/shanoir-ng-front/src/app/studies/shared/study.dto.ts
@@ -374,6 +374,7 @@ export class StudyLight {
   description: string;
   license: string;
   studyTags: Tag[];
+  profile: Profile;
 }
 
 

--- a/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/dto/StudyLightDTO.java
+++ b/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/dto/StudyLightDTO.java
@@ -17,6 +17,7 @@ package org.shanoir.ng.study.dto;
 import java.time.LocalDate;
 import java.util.List;
 
+import org.shanoir.ng.profile.model.Profile;
 import org.shanoir.ng.shared.dateTime.LocalDateAnnotations;
 import org.shanoir.ng.study.model.StudyStatus;
 import org.shanoir.ng.study.model.StudyType;
@@ -61,6 +62,8 @@ public class StudyLightDTO {
 	private List<String> protocolFilePaths;
 	
 	private List<String> dataUserAgreementPaths;
+
+	private Profile profile;
 
 	/**
 	 * Default constructor.
@@ -252,4 +255,11 @@ public class StudyLightDTO {
 		this.dataUserAgreementPaths = dataUserAgreementPaths;
 	}
 
+	public Profile getProfile() {
+		return profile;
+	}
+
+	public void setProfile(Profile profile) {
+		this.profile = profile;
+	}
 }


### PR DESCRIPTION
How to test:
Import data > check the "multiple examination import" box
Select a study and a studycard
Select a zip to import, it should be like this:

> TestMET01/M0/ACR_Phantom_t1_se_tra/[data]
> TestMET01/M1/ACR_Phantom_t1_se_tra/[data]

![image](https://github.com/user-attachments/assets/ea9e356b-17dd-46f9-8eae-cf9242f3e387)


The result gives:
![image](https://github.com/user-attachments/assets/0ad4d9cc-36b1-433e-b977-4b2d2598e08b)
