### PR TITLE
shanoir-issue#2750: fix statistics procedure

### DIFF
--- a/docker-compose/database/db-changes/datasets/0056_add_statistics_procedure.sql
+++ b/docker-compose/database/db-changes/datasets/0056_add_statistics_procedure.sql
@@ -39,7 +39,10 @@ FROM dataset
     LEFT JOIN studies.subject AS subject ON (subject.id = examination.subject_id)
     LEFT JOIN studies.study AS study ON (study.id = examination.study_id)
 
-WHERE subject.name NOT rlike if(subjectNameOutRegExp IS NULL  OR subjectNameOutRegExp = '', '^\b\B$', subjectNameOutRegExp) AND study.name rlike if(studyNameInRegExp IS NULL  OR studyNameInRegExp = '', '.*', studyNameInRegExp)
+WHERE subject.name rlike if(subjectNameInRegExp IS NULL  OR subjectNameInRegExp = '', '.*', subjectNameInRegExp)
+  AND subject.name NOT rlike if(subjectNameOutRegExp IS NULL  OR subjectNameOutRegExp = '', '^\b\B$', subjectNameOutRegExp)
+  AND study.name rlike if(studyNameInRegExp IS NULL  OR studyNameInRegExp = '', '.*', studyNameInRegExp)
+  AND study.name NOT rlike if(studyNameOutRegExp IS NULL  OR studyNameOutRegExp = '', '^\b\B$', studyNameOutRegExp)
 ) as full_query;
 END //
 
@@ -118,7 +121,10 @@ FROM dataset
     LEFT JOIN studies.center AS center ON (center.id = examination.center_id)
     LEFT JOIN studies.pseudonymus_hash_values AS pseudonymus_hash_values ON (pseudonymus_hash_values.id = subject.pseudonymus_hash_values_id)
 
-WHERE subject.name NOT rlike if(subjectNameOutRegExp IS NULL  OR subjectNameOutRegExp = '', '^\b\B$', subjectNameOutRegExp) AND study.name rlike if(studyNameInRegExp IS NULL  OR studyNameInRegExp = '', '.*', studyNameInRegExp)
+WHERE subject.name rlike if(subjectNameInRegExp IS NULL  OR subjectNameInRegExp = '', '.*', subjectNameInRegExp)
+  AND subject.name NOT rlike if(subjectNameOutRegExp IS NULL  OR subjectNameOutRegExp = '', '^\b\B$', subjectNameOutRegExp)
+  AND study.name rlike if(studyNameInRegExp IS NULL  OR studyNameInRegExp = '', '.*', studyNameInRegExp)
+  AND study.name NOT rlike if(studyNameOutRegExp IS NULL  OR studyNameOutRegExp = '', '^\b\B$', studyNameOutRegExp)
 	LIMIT blocSize OFFSET startRow;
 END //
 

--- a/docker-compose/database/db-changes/datasets/0057_add_statistics_procedure.sql
+++ b/docker-compose/database/db-changes/datasets/0057_add_statistics_procedure.sql
@@ -39,7 +39,10 @@ FROM dataset
     LEFT JOIN studies.subject AS subject ON (subject.id = examination.subject_id)
     LEFT JOIN studies.study AS study ON (study.id = examination.study_id)
 
-WHERE subject.name NOT rlike if(subjectNameOutRegExp IS NULL  OR subjectNameOutRegExp = '', '^\b\B$', subjectNameOutRegExp) AND study.name rlike if(studyNameInRegExp IS NULL  OR studyNameInRegExp = '', '.*', studyNameInRegExp)
+WHERE subject.name rlike if(subjectNameInRegExp IS NULL  OR subjectNameInRegExp = '', '.*', subjectNameInRegExp)
+  AND subject.name NOT rlike if(subjectNameOutRegExp IS NULL  OR subjectNameOutRegExp = '', '^\b\B$', subjectNameOutRegExp)
+  AND study.name rlike if(studyNameInRegExp IS NULL  OR studyNameInRegExp = '', '.*', studyNameInRegExp)
+  AND study.name NOT rlike if(studyNameOutRegExp IS NULL  OR studyNameOutRegExp = '', '^\b\B$', studyNameOutRegExp)
 ) as full_query;
 END //
 
@@ -118,7 +121,10 @@ FROM dataset
     LEFT JOIN studies.center AS center ON (center.id = examination.center_id)
     LEFT JOIN studies.pseudonymus_hash_values AS pseudonymus_hash_values ON (pseudonymus_hash_values.id = subject.pseudonymus_hash_values_id)
 
-WHERE subject.name NOT rlike if(subjectNameOutRegExp IS NULL  OR subjectNameOutRegExp = '', '^\b\B$', subjectNameOutRegExp) AND study.name rlike if(studyNameInRegExp IS NULL  OR studyNameInRegExp = '', '.*', studyNameInRegExp)
+WHERE subject.name rlike if(subjectNameInRegExp IS NULL  OR subjectNameInRegExp = '', '.*', subjectNameInRegExp)
+  AND subject.name NOT rlike if(subjectNameOutRegExp IS NULL  OR subjectNameOutRegExp = '', '^\b\B$', subjectNameOutRegExp)
+  AND study.name rlike if(studyNameInRegExp IS NULL  OR studyNameInRegExp = '', '.*', studyNameInRegExp)
+  AND study.name NOT rlike if(studyNameOutRegExp IS NULL  OR studyNameOutRegExp = '', '^\b\B$', studyNameOutRegExp)
 	LIMIT blocSize OFFSET startRow;
 END //
 


### PR DESCRIPTION
How to test:
As an admin, open the "download statistics" menu
Fill the "Regular expression filtering the subjects to include" and "Regular expression filtering the subjects to exclude" fields and click the "download statistics" button

Make sure the result file match the form.

The issue comes from the WHERE clause in the procedure which is strange and doesn't use the "subjectNameInRegExp" variable:

From this:
```
WHERE subject.name NOT rlike if(subjectNameOutRegExp IS NULL  OR subjectNameOutRegExp = '', '^\b\B$', subjectNameOutRegExp) 
AND study.name rlike if(studyNameInRegExp IS NULL  OR studyNameInRegExp = '', '.*', studyNameInRegExp)
```

To this:
```
WHERE subject.name rlike if(subjectNameInRegExp IS NULL  OR subjectNameInRegExp = '', '.*', subjectNameInRegExp)
  AND subject.name NOT rlike if(subjectNameOutRegExp IS NULL  OR subjectNameOutRegExp = '', '^\b\B$', subjectNameOutRegExp)
  AND study.name rlike if(studyNameInRegExp IS NULL  OR studyNameInRegExp = '', '.*', studyNameInRegExp)
  AND study.name NOT rlike if(studyNameOutRegExp IS NULL  OR studyNameOutRegExp = '', '^\b\B$', studyNameOutRegExp)

```

EDIT: Tested on neurinfo-qualif. Works well, for instance filter by including study "UCAN" and subjectName="UCAN_13_027". The statistics have 198 lines, just the number of datasets displayed in solr
![image](https://github.com/user-attachments/assets/21cca575-6d29-42c4-96e3-36d940d487c9)

Same test but reversed by excluding subjectName="UCAN_13_027". There are 29215 results which matches with solr :
![image](https://github.com/user-attachments/assets/12ff9515-7890-4c05-8a58-7d59753dcf0e)

29199 + 214 = 29413
29413 - 198 =  29215