### PR TITLE
shanoir-issue#2850: fix sending an object with an id to ms-datasets

### DIFF
--- a/shanoir-ng-studies/src/main/java/org/shanoir/ng/subject/service/SubjectServiceImpl.java
+++ b/shanoir-ng-studies/src/main/java/org/shanoir/ng/subject/service/SubjectServiceImpl.java
@@ -226,6 +226,7 @@ public class SubjectServiceImpl implements SubjectService {
 	}
 
 	@Override
+	@Transactional
 	public Subject update(final Subject subject) throws ShanoirException {
 		final Subject subjectDb = subjectRepository.findById(subject.getId()).orElse(null);
 		if (subjectDb == null) {
@@ -235,9 +236,9 @@ public class SubjectServiceImpl implements SubjectService {
 			throw new ShanoirException("You cannot update subject common name.", HttpStatus.FORBIDDEN.value());
 		}
 		updateSubjectValues(subjectDb, subject);
-		subjectRepository.save(subjectDb);
-		updateSubjectName(subjectMapper.subjectToSubjectDTO(subjectDb));
-		return subjectDb;
+		Subject newSubject = subjectRepository.save(subjectDb);
+		updateSubjectName(subjectMapper.subjectToSubjectDTO(newSubject));
+		return newSubject;
 	}
 
 	/*


### PR DESCRIPTION
How to test:

Open a subject > edit > add a study > update

Before: an error was thrown in ms-datasets and it took a long time to save. The subjectStudy wasn't saved in datasets.subject_study table in the database

Now: no error thrown, faster requests and subject_study is saved in the database