### PR TITLE
Scale up the starting shup memory to 512m up to 2g max

### DIFF
--- a/shanoir-uploader/start-shup-linux-mac-java.sh
+++ b/shanoir-uploader/start-shup-linux-mac-java.sh
@@ -1,12 +1,12 @@
 if [ -n "$JAVA_HOME" ];
 then
 echo "Starting ShanoirUploader... (JAVA_HOME IS SET TO '$JAVA_HOME')";
-$JAVA_HOME/bin/java -Dhttps.protocols=TLSv1.2 -Xms128m -Xmx512m -Xnoclassgc -jar shanoir-uploader-9.0.0-jar-with-dependencies.jar
+$JAVA_HOME/bin/java -Dhttps.protocols=TLSv1.2 -Xms512m -Xmx2g -Xnoclassgc -jar shanoir-uploader-9.0.0-jar-with-dependencies.jar
 else
 java -version >/dev/null 2>&1
 if [ $? -ne 0 ]; then echo "ERROR";
 else
 echo "Starting ShanoirUploader... (without JAVA_HOME)";
-java -Dhttps.protocols=TLSv1.2 -Xms128m -Xmx512m -Xnoclassgc -jar shanoir-uploader-9.0.0-jar-with-dependencies.jar
+java -Dhttps.protocols=TLSv1.2 -Xms512m -Xmx2g -Xnoclassgc -jar shanoir-uploader-9.0.0-jar-with-dependencies.jar
 fi
 fi

--- a/shanoir-uploader/start-shup-windows-java.bat
+++ b/shanoir-uploader/start-shup-windows-java.bat
@@ -10,6 +10,6 @@ IF EXIST "%JAVA_HOME%\bin\javaw.exe" (
 		pause
 	) ELSE (
 		ECHO Starting ShanoirUploader without JAVA_HOME...
-		javaw -Dhttps.protocols=TLSv1.2 -Xms128m -Xmx512m -Xnoclassgc -jar shanoir-uploader-9.0.0-jar-with-dependencies.jar org.shanoir.uploader.ShanoirUploader
+		javaw -Dhttps.protocols=TLSv1.2 -Xms512m -Xmx2g -Xnoclassgc -jar shanoir-uploader-9.0.0-jar-with-dependencies.jar org.shanoir.uploader.ShanoirUploader
 	)
 )

--- a/shanoir-uploader/start-shup-windows-java.bat
+++ b/shanoir-uploader/start-shup-windows-java.bat
@@ -2,7 +2,7 @@
 
 IF EXIST "%JAVA_HOME%\bin\javaw.exe" (
 	ECHO Starting ShanoirUploader using JAVA_HOME...
-	"%JAVA_HOME%\bin\javaw.exe" -Dhttps.protocols=TLSv1.2 -Xms128m -Xmx512m -Xnoclassgc -jar shanoir-uploader-9.0.0-jar-with-dependencies.jar org.shanoir.uploader.ShanoirUploader  
+	"%JAVA_HOME%\bin\javaw.exe" -Dhttps.protocols=TLSv1.2 -Xms512m -Xmx2g -Xnoclassgc -jar shanoir-uploader-9.0.0-jar-with-dependencies.jar org.shanoir.uploader.ShanoirUploader  
 ) ELSE (
 	java.exe -version >nul 2>&1
 	IF %ERRORLEVEL% NEQ 0 (


### PR DESCRIPTION
When importing big dicom exams such as XA exams, we encounter a java heap space issue that do not appear in the su.log file.
The user can't identify why the mass imports are not loading and the application experience instability such as shutting down.

This PR corrects that behaviour.