### PR TITLE
Revert "Bump org.apache.poi:poi-ooxml from 4.1.2 to 5.4.0 in /shanoir-ng-anonymization"

### DIFF
--- a/shanoir-ng-anonymization/pom.xml
+++ b/shanoir-ng-anonymization/pom.xml
@@ -24,7 +24,7 @@
 		<maven.compiler.target>17</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<dcm4che.version>5.30.0</dcm4che.version>
-		<poi.version>5.4.0</poi.version>
+		<poi.version>4.1.2</poi.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Reverts fli-iam/shanoir-ng#2784
2025-06-20_09:08:43.285 [Thread-0] INFO  o.s.a.a.AnonymizationServiceImpl - Start anonymization, for 166 DICOM files.
Exception in thread "Thread-0" java.lang.NoSuchMethodError: 'org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream$Builder org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream.builder()'
        at org.apache.poi.util.IOUtils.peekFirstNBytes(IOUtils.java:144)
        at org.apache.poi.poifs.filesystem.FileMagic.valueOf(FileMagic.java:209)
        at org.apache.poi.openxml4j.opc.internal.ZipHelper.verifyZipHeader(ZipHelper.java:147)
        at org.apache.poi.openxml4j.opc.internal.ZipHelper.openZipStream(ZipHelper.java:191)
        at org.apache.poi.openxml4j.opc.ZipPackage.<init>(ZipPackage.java:156)
        at org.apache.poi.openxml4j.opc.OPCPackage.open(OPCPackage.java:363)
        at org.apache.poi.ooxml.util.PackageHelper.open(PackageHelper.java:67)
        at org.apache.poi.xssf.usermodel.XSSFWorkbook.<init>(XSSFWorkbook.java:315)
        at org.apache.poi.xssf.usermodel.XSSFWorkbook.<init>(XSSFWorkbook.java:289)
        at org.shanoir.anonymization.anonymization.AnonymizationRulesSingleton.<init>(AnonymizationRulesSingleton.java:59)
        at org.shanoir.anonymization.anonymization.AnonymizationRulesSingleton.<clinit>(AnonymizationRulesSingleton.java:40)
        at org.shanoir.anonymization.anonymization.AnonymizationServiceImpl.anonymizeForShanoir(AnonymizationServiceImpl.java:97)
        at org.shanoir.uploader.dicom.anonymize.Anonymizer.pseudonymize(Anonymizer.java:24)
        at org.shanoir.uploader.action.ImportFinishRunnable.run(ImportFinishRunnable.java:47)
        at java.base/java.lang.Thread.run(Thread.java:1583)