### PR TITLE
Laurent shup start windows script bugfix

### DIFF
--- a/shanoir-uploader/start-shup-linux-mac-java.sh
+++ b/shanoir-uploader/start-shup-linux-mac-java.sh
@@ -5,15 +5,17 @@ if [ -z "$JAR_FILE" ]; then
   exit 1
 fi
 
+APP_VERSION=$(echo "$JAR_FILE" | sed -E 's/shanoir-uploader-([0-9.]+)-jar-with-dependencies\.jar/v\1/')
+
 if [ -n "$JAVA_HOME" ];
 then
 echo "Starting ShanoirUploader... (JAVA_HOME IS SET TO '$JAVA_HOME')";
-$JAVA_HOME/bin/java -Dhttps.protocols=TLSv1.2 -Xms512m -Xmx2g -Xnoclassgc -jar "$JAR_FILE"
+$JAVA_HOME/bin/java -Dhttps.protocols=TLSv1.2 -Xms512m -Xmx2g -Xnoclassgc -Dapp.version="$APP_VERSION" -jar "$JAR_FILE"
 else
 java -version >/dev/null 2>&1
 if [ $? -ne 0 ]; then echo "ERROR";
 else
 echo "Starting ShanoirUploader... (without JAVA_HOME)";
-java -Dhttps.protocols=TLSv1.2 -Xms512m -Xmx2g -Xnoclassgc -jar "$JAR_FILE"
+java -Dhttps.protocols=TLSv1.2 -Xms512m -Xmx2g -Xnoclassgc -Dapp.version="$APP_VERSION" -jar "$JAR_FILE"
 fi
 fi

--- a/shanoir-uploader/start-shup-windows-java.bat
+++ b/shanoir-uploader/start-shup-windows-java.bat
@@ -1,4 +1,5 @@
 @ECHO OFF
+setlocal enabledelayedexpansion
 
 FOR %%f in (shanoir-uploader-*-jar-with-dependencies.jar) do (
     set "JAR_FILE=%%f"
@@ -8,6 +9,7 @@ FOR %%f in (shanoir-uploader-*-jar-with-dependencies.jar) do (
 ECHO ERROR: No JAR file found with the pattern shanoir-uploader-*-jar-with-dependencies.jar
 EXIT /b 1
 
+:found
 IF EXIST "%JAVA_HOME%\bin\javaw.exe" (
 	ECHO Starting ShanoirUploader using JAVA_HOME...
 	"%JAVA_HOME%\bin\javaw.exe" -Dhttps.protocols=TLSv1.2 -Xms512m -Xmx2g -Xnoclassgc -jar "%JAR_FILE%" org.shanoir.uploader.ShanoirUploader  

--- a/shanoir-uploader/start-shup-windows-java.bat
+++ b/shanoir-uploader/start-shup-windows-java.bat
@@ -10,9 +10,13 @@ ECHO ERROR: No JAR file found with the pattern shanoir-uploader-*-jar-with-depen
 EXIT /b 1
 
 :found
+FOR /F "tokens=3 delims=-" %%v IN ("!JAR_FILE!") DO (
+    set "APP_VERSION=v%%v"
+)
+
 IF EXIST "%JAVA_HOME%\bin\javaw.exe" (
 	ECHO Starting ShanoirUploader using JAVA_HOME...
-	"%JAVA_HOME%\bin\javaw.exe" -Dhttps.protocols=TLSv1.2 -Xms512m -Xmx2g -Xnoclassgc -jar "%JAR_FILE%" org.shanoir.uploader.ShanoirUploader  
+	"%JAVA_HOME%\bin\javaw.exe" -Dhttps.protocols=TLSv1.2 -Xms512m -Xmx2g -Xnoclassgc -Dapp.version=!APP_VERSION! -jar "!JAR_FILE!" org.shanoir.uploader.ShanoirUploader  
 ) ELSE (
 	java.exe -version >nul 2>&1
 	IF %ERRORLEVEL% NEQ 0 (
@@ -20,6 +24,6 @@ IF EXIST "%JAVA_HOME%\bin\javaw.exe" (
 		pause
 	) ELSE (
 		ECHO Starting ShanoirUploader without JAVA_HOME...
-		javaw -Dhttps.protocols=TLSv1.2 -Xms512m -Xmx2g -Xnoclassgc -jar "%JAR_FILE%" org.shanoir.uploader.ShanoirUploader
+		javaw -Dhttps.protocols=TLSv1.2 -Xms512m -Xmx2g -Xnoclassgc -Dapp.version=!APP_VERSION! -jar "!JAR_FILE!" org.shanoir.uploader.ShanoirUploader
 	)
 )


### PR DESCRIPTION
bug fix of .sh and .bat scripts to run as previously (without executables) and injecting app.version into java command for logback to have (avoid the bug of default .su_dev folder created only for su.log file).