### PR TITLE
shanoir-issue#2752: add extra data in examination details

### DIFF
--- a/shanoir-ng-front/src/app/examinations/examination/examination.component.html
+++ b/shanoir-ng-front/src/app/examinations/examination/examination.component.html
@@ -156,15 +156,23 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
                             </ng-template>
                         </span>
                     </li>
-                    <li *ngIf="mode == 'create' || mode=='edit'">
-                        <label i18n="Examination detail|Attached files label@@examinationDetailAttachedFiles">Attach new files</label>
+                    <li>
+                        <label i18n="Examination detail|Attached files label@@examinationDetailAttachedFiles">Extra data</label>
                         <span class="right-col" [ngSwitch]="mode">
-                            <input #input hidden type="file" (change)="attachNewFile($event)"/>
-                            <button (click)="setFile()" class="left-icon"><i class="fas fa-upload"></i>Choose file</button>
-                            <ul>
-                                <li *ngFor="let file of examination.extraDataFilePathList"> {{getFileName(file)}} <button (click)="deleteFile(file)"><i class="fa-regular fa-trash-can"></i></button>
-                                </li>
-                            </ul>
+							<ng-template [ngSwitchCase]="'view'">
+                                <ul>
+                                    <li *ngFor="let file of examination.extraDataFilePathList"> {{getFileName(file)}} <button type="button" class="dl-button" (click)="downloadFile(file)"><i class="fas fa-download"></i></button>
+                                    </li>
+                                </ul>
+							</ng-template>
+							<ng-template ngSwitchDefault>
+                                <input #input hidden type="file" (change)="attachNewFile($event)"/>
+                                <button (click)="setFile()" class="left-icon"><i class="fas fa-upload"></i>Choose file</button>
+                                <ul>
+                                    <li *ngFor="let file of examination.extraDataFilePathList"> {{getFileName(file)}} <button (click)="deleteFile(file)"><i class="fa-regular fa-trash-can"></i></button>
+                                    </li>
+                                </ul>
+                            </ng-template>
 						</span>
                     </li>
                     <li *ngIf="mode != 'create' && examination.copies?.length > 0">

--- a/shanoir-ng-front/src/app/examinations/examination/examination.component.ts
+++ b/shanoir-ng-front/src/app/examinations/examination/examination.component.ts
@@ -272,4 +272,8 @@ export class ExaminationComponent extends EntityComponent<Examination> implement
             subscribtion.unsubscribe();
         }
     }
+
+    downloadFile(file) {
+        this.examinationService.downloadFile(file, this.examination.id, this.downloadState);
+    }
 }


### PR DESCRIPTION
Before:
<img width="856" height="333" alt="image" src="https://github.com/user-attachments/assets/41936107-cf4a-4ba0-ab49-17883e45530f" />


After as mode = view:
<img width="986" height="398" alt="image" src="https://github.com/user-attachments/assets/c7ceefa2-e966-4991-bb74-c583db25d949" />
Mode = Edit:
<img width="942" height="463" alt="image" src="https://github.com/user-attachments/assets/88311277-ca82-460a-999c-1875b629120a" />


How to test:
From an examination's details, click edit and add an extra data (any .zip will do)
Click update
The extra data now appears in the details, click the download button next to it, it works.

Tested only locally