### PR TITLE
set custom selection model for dicomTree to allow only unique patient selection

### DIFF
--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/action/FindDicomActionListener.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/action/FindDicomActionListener.java
@@ -22,6 +22,7 @@ import org.shanoir.ng.importer.model.Study;
 import org.shanoir.ng.utils.Utils;
 import org.shanoir.uploader.ShUpConfig;
 import org.shanoir.uploader.dicom.IDicomServerClient;
+import org.shanoir.uploader.dicom.UniquePatientTreeSelectionModel;
 import org.shanoir.uploader.dicom.query.Media;
 import org.shanoir.uploader.dicom.query.PatientTreeNode;
 import org.shanoir.uploader.dicom.query.SerieTreeNode;
@@ -199,6 +200,8 @@ public class FindDicomActionListener extends JPanel implements ActionListener {
 		}
 		// set values for display in the GUI tree
 		mainWindow.dicomTree = new DicomTree(media);
+		// set custom selection model to avoid multiple patients selection
+		mainWindow.dicomTree.setSelectionModel(new UniquePatientTreeSelectionModel(mainWindow.dicomTree));		
 		// expand entire JTree after creation
 		for (int i = 0; i < mainWindow.dicomTree.getRowCount(); i++) {
 			mainWindow.dicomTree.expandRow(i);

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/dicom/UniquePatientTreeSelectionModel.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/dicom/UniquePatientTreeSelectionModel.java
@@ -1,0 +1,67 @@
+package org.shanoir.uploader.dicom;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.swing.JTree;
+import javax.swing.tree.DefaultTreeSelectionModel;
+import javax.swing.tree.TreePath;
+
+import org.shanoir.uploader.dicom.query.PatientTreeNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Custom TreeSelectionModel to allow selection of multiple nodes only if they belong to the same patient.
+ * 
+ * @author lvallet
+ *
+ */
+public class UniquePatientTreeSelectionModel extends DefaultTreeSelectionModel{
+
+    private static final Logger logger = LoggerFactory.getLogger(UniquePatientTreeSelectionModel.class);
+
+    private final JTree tree;
+
+    public UniquePatientTreeSelectionModel(JTree tree) {
+        this.tree = tree;
+        setSelectionMode(DISCONTIGUOUS_TREE_SELECTION);
+    }
+
+    @Override
+    public void addSelectionPaths(TreePath[] paths) {
+        if (paths == null || paths.length == 0) return;
+
+        // Get all selected patients
+        Set<Object> selectedPatients = new HashSet<>();
+        if (getSelectionPaths() != null) {
+            for (TreePath p : getSelectionPaths()) {
+                selectedPatients.add(getPatientNode(p));
+            }
+        }
+
+        for (TreePath p : paths) {
+            Object patient = getPatientNode(p);
+
+            // If a patient is already selected and this one is different → ignore
+            if (!selectedPatients.isEmpty() && !selectedPatients.contains(patient)) {
+                logger.warn("Multiple selection allowed only for the same patient.");
+                return;
+            }
+            selectedPatients.add(patient);
+        }
+
+        super.addSelectionPaths(paths);
+    }
+
+    // Climb up the tree to find the parent PatientTreeNode
+    private Object getPatientNode(TreePath path) {
+        Object[] nodes = path.getPath();
+        for (Object node : nodes) {
+            if (node instanceof PatientTreeNode) {
+                return node;
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
In SHUP, user cannot select multiple DICOM studies or series from different patients.

Multiple selections in the dicom query tree can only be made if they come from the same patient.

To test : 
Query a PACS from ShanoirUploader and try to select multiple nodes from several patients.