### PR TITLE
update github repo url

### DIFF
--- a/shanoir-ng-import/pom.xml
+++ b/shanoir-ng-import/pom.xml
@@ -162,7 +162,7 @@
 				<enabled>false</enabled>
 			</snapshots>
 			<id>mvn-repo-master</id>
-			<url>https://raw.github.com/nroduit/mvn-repo/master/</url>
+			<url>https://raw.githubusercontent.com/nroduit/mvn-repo/master/</url>
 		</repository>
 	</repositories>
 

--- a/shanoir-uploader/pom.xml
+++ b/shanoir-uploader/pom.xml
@@ -336,7 +336,7 @@
 		</repository>
 		<repository>
 			<id>mvn-repo-master</id>
-			<url>https://raw.github.com/nroduit/mvn-repo/master/</url>
+			<url>https://raw.githubusercontent.com/nroduit/mvn-repo/master/</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>


### PR DESCRIPTION
Maven build seems to fail from GitHub during the ShanoirUploader Build & Release Action : 

Error: Failed to read artifact descriptor for org.weasis:weasis-dicom-tools:jar:5.31.1 Error: Caused by: The following artifacts could not be resolved: org.weasis:weasis-dicom-tools:pom:5.31.1 (absent): Could not transfer artifact org.weasis:weasis-dicom-tools:pom:5.31.1 from/to mvn-repo-master (https://raw.github.com/nroduit/mvn-repo/master/): status code: 503, reason phrase: hostname doesn't match against certificate (503)

It seems that the repository https://raw.github.com/nroduit/mvn-repo/master/ is obsolete and must be change to https://raw.githubusercontent.com/nroduit/mvn-repo/master/

This sudden error could be explained by the recent commit on Weasis repo : https://github.com/nroduit/mvn-repo