### PR TITLE
Wrap monitoring input datasets in a new list to avoid shared references (#3065)

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/vip/output/handler/DefaultHandler.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/vip/output/handler/DefaultHandler.java
@@ -88,7 +88,7 @@ public class DefaultHandler extends OutputHandler {
                 }
             }
 
-            List<Dataset> inputDatasets = monitoring.getInputDatasets();
+            List<Dataset> inputDatasets = new ArrayList<>(monitoring.getInputDatasets());
 
             if(inputDatasets.isEmpty()) {
                 throw new ResultHandlerException("No input datasets found.", null);


### PR DESCRIPTION
Previously, `inputDatasets` referenced the same collection managed by JPA, 
which caused a Hibernate exception when processing the result archive:

`org.springframework.orm.jpa.JpaSystemException: Found shared references to a collection`

Now, we create a new `ArrayList` from `monitoring.getInputDatasets()`, 
ensuring a mutable, independent list for further processing.

Related issue: #3065