### PR TITLE
Fix subjects in ms-datasets

### DIFF
--- a/docker-compose/database/db-changes/datasets/0059_single-study_subject_fix.sql
+++ b/docker-compose/database/db-changes/datasets/0059_single-study_subject_fix.sql
@@ -1,0 +1,12 @@
+UPDATE datasets.subject d
+JOIN studies.subject s ON d.id = s.id
+SET
+    d.study_id     = s.study_id,
+    d.subject_type = s.subject_type,
+    d.quality_tag  = s.quality_tag
+WHERE
+    -- On ne met à jour que si les valeurs sont différentes ou null
+    (d.study_id     IS NULL OR d.study_id     <> s.study_id)
+ OR (d.subject_type IS NULL OR d.subject_type <> s.subject_type)
+ OR (d.quality_tag  IS NULL OR d.quality_tag  <> s.quality_tag)
+;


### PR DESCRIPTION
Before running this script we have this:
<img width="1817" height="334" alt="image" src="https://github.com/user-attachments/assets/02611d00-b682-4392-9d8a-359b29668e3c" />

Some subject have a study_id = null in datasets.
The subjects with this are the one that used to be in multiple studies. Since the single-study subject was started, we split subjects that used to be in multiple studies into multiple subject with a different study_id.
Something was missing in the script and we ended up with NULL values.

Also, some mixing up of the study_id of the newly created subject (here, subject with id=1 should have study_id=45 instead of 2).

After running the script:
<img width="1888" height="349" alt="image" src="https://github.com/user-attachments/assets/d1616380-7c04-492f-b86d-b056350c48c1" />
