### PR TITLE
equals and hascode

### DIFF
--- a/shanoir-ng-back/checkstyle.xml
+++ b/shanoir-ng-back/checkstyle.xml
@@ -191,7 +191,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
     <!-- Checks for common coding problems               -->
     <!-- See https://checkstyle.org/checks/coding/index.html -->
     <module name="EmptyStatement"/>
-    <!-- <module name="EqualsHashCode"/> -->
+    <module name="EqualsHashCode"/>
     <!-- <module name="HiddenField"/> -->
     <module name="IllegalInstantiation"/>
     <module name="InnerAssignment"/>

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/model/DatasetMetadata.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/model/DatasetMetadata.java
@@ -194,23 +194,4 @@ public class DatasetMetadata extends AbstractEntity {
             this.processedDatasetType = processedDatasetType.getId();
         }
     }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (!(obj instanceof AbstractEntity)) {
-            return false;
-        }
-        AbstractEntity entity = (AbstractEntity) obj;
-        if (this.getId() == null && entity.getId() != null) {
-            return false;
-        } else {
-            return this.getId().equals(entity.getId());
-        }
-    }
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/download/AcquisitionAttributes.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/download/AcquisitionAttributes.java
@@ -104,6 +104,16 @@ public class AcquisitionAttributes<T> {
         }
     }
 
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        for (T id : datasetMap.keySet()) {
+            Attributes attributes = datasetMap.get(id).orElse(null);
+            hash = 31 * hash + (attributes != null ? attributes.hashCode() : 0);
+        }
+        return hash;
+    }
+
     public Class<?> getParametrizedType() {
         if (this.datasetMap != null && !this.datasetMap.keySet().isEmpty()) {
             return this.datasetMap.keySet().iterator().next().getClass();

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/model/Cardinality.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/model/Cardinality.java
@@ -73,6 +73,14 @@ public class Cardinality {
     }
 
     @Override
+    public int hashCode() {
+        int result = 17;
+        result = 31 * result + number;
+        result = 31 * result + (isMultiplier ? 1 : 0);
+        return result;
+    }
+
+    @Override
     public String toString() {
         return getNumber() + (isMultiplier() ? "N" : "");
     }

--- a/shanoir-ng-ms-common/src/main/java/org/shanoir/ng/shared/core/model/AbstractEntity.java
+++ b/shanoir-ng-ms-common/src/main/java/org/shanoir/ng/shared/core/model/AbstractEntity.java
@@ -16,6 +16,8 @@ package org.shanoir.ng.shared.core.model;
 
 import java.io.Serializable;
 
+import org.hibernate.Hibernate;
+
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -52,5 +54,37 @@ public abstract class AbstractEntity implements Serializable {
      */
     public void setId(Long id) {
         this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (Hibernate.getClass(this) != Hibernate.getClass(obj)) {
+            return false;
+        }
+        AbstractEntity entity = (AbstractEntity) obj;
+        if (this.getId() == null || entity.getId() == null) {
+            return false;
+        } else {
+            return this.getId().equals(entity.getId());
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        if (getId() != null) {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + getId().hashCode();
+            return result;
+        }
+        // ID is not set, return a unique constant hash code to avoid
+        // all objects having the same hash code of 31.
+        return System.identityHashCode(this);
     }
 }

--- a/shanoir-ng-ms-common/src/main/java/org/shanoir/ng/shared/dicom/EchoTime.java
+++ b/shanoir-ng-ms-common/src/main/java/org/shanoir/ng/shared/dicom/EchoTime.java
@@ -45,13 +45,4 @@ public class EchoTime {
     public void setEchoTime(Double echoTime) {
         this.echoTime = echoTime;
     }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + echoNumber;
-        result = prime * result + echoTime.hashCode();
-        return result;
-    }
 }

--- a/shanoir-ng-nifti-conversion/src/main/java/org/shanoir/ng/model/EchoTime.java
+++ b/shanoir-ng-nifti-conversion/src/main/java/org/shanoir/ng/model/EchoTime.java
@@ -52,4 +52,26 @@ public class EchoTime {
         result = prime * result + echoTime.hashCode();
         return result;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        EchoTime other = (EchoTime) obj;
+        if (echoNumber == null) {
+            if (other.echoNumber != null)
+                return false;
+        } else if (!echoNumber.equals(other.echoNumber))
+            return false;
+        if (echoTime == null) {
+            if (other.echoTime != null)
+                return false;
+        } else if (!echoTime.equals(other.echoTime))
+            return false;
+        return true;
+    }
 }


### PR DESCRIPTION
* add the checkstyle rule : equals can't go without hashCode and vice versa
* add equals() and hashCode() to abstractEntity
* remove redundant methods from entites
* complete the duo into 1 or 2 independant classes

reminder : 

- equals checks whether two Java objects are logically equal
-  hashCode provides a numeric value used by hash-based collections (like HashMap or HashSet). 
-  They must be consistent: if two objects are equal according to equals, they must return the same hashCode.