### PR TITLE
Update import/order rule severity to error

### DIFF
--- a/shanoir-ng-front/eslint.config.js
+++ b/shanoir-ng-front/eslint.config.js
@@ -74,7 +74,7 @@ module.exports = tseslint.config(
       "import/no-unresolved": "error",
       "import/no-duplicates": "error",
       "import/order": [
-        "warn",
+        "error",
         {
           "groups": ["builtin", "external", "internal", "parent", "sibling", "index"],
           "newlines-between": "always"


### PR DESCRIPTION
Changed import/order rule severity from 'warn' to 'error'.