### PR TITLE
#2764: Add Content Security Policy (CSP) report.

### DIFF
--- a/docker-compose/nginx/http.conf
+++ b/docker-compose/nginx/http.conf
@@ -4,7 +4,7 @@ server {
 	server_name         SHANOIR_URL_HOST;
 
 	# Content Security Policy (CSP) configuration
-	add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'" always;
+	add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';" always;
 
 	include shanoir.conf;
 }
@@ -14,7 +14,7 @@ server {
 	server_name	SHANOIR_VIEWER_OHIF_URL_HOST;
 
 	# Content Security Policy (CSP) configuration
-	add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'" always;
+	add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';" always;
 
 	include ohif-viewer.conf;
 }

--- a/docker-compose/nginx/https.conf
+++ b/docker-compose/nginx/https.conf
@@ -16,7 +16,7 @@ server {
 	ssl_protocols		TLSv1.2 TLSv1.3;
 
 	# Content Security Policy (CSP) configuration
-	add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'" always;
+	add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';" always;
 
 	include shanoir.conf;
 }
@@ -31,7 +31,7 @@ server {
 	ssl_protocols		TLSv1.2 TLSv1.3;
 
 	# Content Security Policy (CSP) configuration
-	add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'" always;
+	add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';" always;
 
 	include ohif-viewer.conf;
 }


### PR DESCRIPTION
This PR adds a CSP for Shanoir and OHIF Viewer.

The PR has been tested on neurinfo qualif, and the implemented policy is adjusted to the application's structure in order to deliver correctly all the necessary resources.

To check the policy in the headers:
`curl -i -k https://shanoir-qualif.irisa.fr`

```bash
HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Mon, 26 Jan 2026 13:39:26 GMT
Content-Type: text/html
Content-Length: 162
Connection: keep-alive
Location: https://shanoir-qualif.irisa.fr/shanoir-ng/welcome
Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';
Strict-Transport-Security: max-age=31536000
Referrer-Policy: strict-origin-when-cross-origin
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN

<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx</center>
</body>
</html>
```

Closes: #2764 