### PR TITLE
<none> only at the last facet page

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/solr/solrj/SolrJWrapperImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/solr/solrj/SolrJWrapperImpl.java
@@ -470,10 +470,11 @@ public class SolrJWrapperImpl implements SolrJWrapper {
                         continue;
                     }
 
-                    if (isMissing) {
-                        renamedAndFilteredValues.add(new FacetField.Count(facetField, UNKNOWN, count.getCount()));
-                    } else {
+                    if (!isMissing) {
                         renamedAndFilteredValues.add(count);
+                    } else if (facetField.getValues().size() < pageableFacet.getPageSize()) {
+                        // only add <none> at the last page
+                        renamedAndFilteredValues.add(new FacetField.Count(facetField, UNKNOWN, count.getCount()));
                     }
                 }
 


### PR DESCRIPTION
In Solr : <none> is displayed at every facet page if you scroll down in subject or dataset

<img width="261" height="417" alt="image" src="https://github.com/user-attachments/assets/6f982c6f-6696-4189-b949-e7291099bb52" />


the pr set <none> only at the end of the last page

* if the last page is full (15 elements), another page with just <none> should exist