### PR TITLE
run compute statistics at startup

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/controler/DatasetApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/controler/DatasetApiController.java
@@ -70,6 +70,7 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
@@ -84,6 +85,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.context.event.EventListener;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -636,6 +638,14 @@ public class DatasetApiController implements DatasetApi {
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+
+    /**
+     * Compute overall statistics on application startup.
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void computeOverallStatisticsOnStartup() {
+        computeOverallStatistics();
     }
 
     /**

--- a/shanoir-ng-ms-common/src/main/java/org/shanoir/ng/shared/event/ShanoirEventType.java
+++ b/shanoir-ng-ms-common/src/main/java/org/shanoir/ng/shared/event/ShanoirEventType.java
@@ -95,11 +95,12 @@ public final class ShanoirEventType {
 
     /** Download dataset. */
     public static final String DOWNLOAD_DATASET_EVENT = "downloadDataset.event";
-    /** Download statistics. */
-    public static final String DOWNLOAD_STATISTICS_EVENT = "downloadStatistics.event";
+
+    /** Mass Download of datasets. */
+    public static final String MASSIVE_OUTPUTS_DOWNLOAD = "massiveOutputsDownload.event";
 
     /** Download statistics. */
-    public static final String MASSIVE_OUTPUTS_DOWNLOAD = "massiveOutputsDownload.event";
+    public static final String DOWNLOAD_STATISTICS_EVENT = "downloadStatistics.event";
 
     /** User subscribed to a challenge. */
     public static final String CHALLENGE_SUBSCRIPTION_EVENT = "challengeSubscription.event";
@@ -110,6 +111,7 @@ public final class ShanoirEventType {
     /** User added to a study. */
     public static final String USER_ADD_TO_STUDY_EVENT = "userAddToStudy.event";
 
+    /** Apply quality card */
     public static final String CHECK_QUALITY_EVENT = "checkQuality.event";
 
     /** Index all datasets in solr */


### PR DESCRIPTION
Fixes compute overall statistics for welcome page allowing it to run at startup of ms datasets in addition to the CRON at 6 am.