### PR TITLE
Use case-insensitive matching for Git error "Not a valid object name"

### DIFF
--- a/docker-compose/database/check_migration_names.py
+++ b/docker-compose/database/check_migration_names.py
@@ -23,7 +23,7 @@ for path in pathlib.Path("db-changes").glob("*"):
         if proc.returncode == 0:
             released_migrations = set(line.split("\t", 1)[1] for line in proc.stdout.splitlines())
 
-        elif "Not a valid object name" in proc.stderr:
+        elif "not a valid object name" in proc.stderr.lower():
             released_migrations = []
             latest_migration = ""
         else:


### PR DESCRIPTION
Fixes #3357

Git is lowercasing the `fatal: Not a valid object name` error message
to follow its CodingGuidelines. This change makes the string matching
case-insensitive so it works with both the current and future Git versions.

Changes:
- Use `.lower()` before checking for the error substring

See: https://lore.kernel.org/git/pull.2052.git.1771836302101.gitgitgadget@gmail.com