### PR TITLE
add new overall stats procedure at database build

### DIFF
--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -364,6 +364,7 @@ COPY --link --chmod=0755 \
     database/2_add_users.sql \
     database/3_add_statistics_procedure.sql \
     database/4_add_studyStatistics_procedure.sql \
+    database/5_add_computeOverallStatistics_procedure.sql \
     /docker-entrypoint-initdb.d/
 
 COPY --link database/db-changes /opt/db-changes

--- a/docker-compose/database/5_add_computeOverallStatistics_procedure.sql
+++ b/docker-compose/database/5_add_computeOverallStatistics_procedure.sql
@@ -1,0 +1,30 @@
+-- Shanoir NG - Import, manage and share neuroimaging data
+-- Copyright (C) 2009-2019 Inria - https://www.inria.fr/
+-- Contact us on https://project.inria.fr/shanoir/
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
+
+
+USE datasets;
+
+DROP PROCEDURE IF EXISTS computeOverallStatistics;
+
+delimiter //
+CREATE PROCEDURE computeOverallStatistics()
+BEGIN
+DELETE FROM overall_statistics WHERE stats_date = CURDATE();
+INSERT into overall_statistics (stats_date, studies_count, subjects_count, dataset_acquisitions_count)
+VALUES (CURDATE(),
+    (SELECT COUNT(*) FROM study),
+    (SELECT COUNT(*) FROM subject where study_id IS NOT NULL),
+    (SELECT COUNT(DISTINCT dataset_acquisition_id) FROM dataset)
+);
+END //
+
+delimiter ;


### PR DESCRIPTION
Adding the computeOverallStats procedure in Dockerfile to avoid errors of missing procedure when building up the db.