### PR TITLE
issue#3381: Allow blob URLs in frame-src for PDF iframe rendering

### DIFF
--- a/docker-compose/nginx/http.conf
+++ b/docker-compose/nginx/http.conf
@@ -4,7 +4,7 @@ server {
 	server_name         SHANOIR_URL_HOST;
 
 	# Content Security Policy (CSP) configuration
-	add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;" always;
+	add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src 'self' blob:;" always;
 
 	include shanoir.conf;
 }
@@ -14,7 +14,7 @@ server {
 	server_name	SHANOIR_VIEWER_OHIF_URL_HOST;
 
 	# Content Security Policy (CSP) configuration
-	add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;" always;
+	add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src 'self' blob:;" always;
 
 	include ohif-viewer.conf;
 }

--- a/docker-compose/nginx/https.conf
+++ b/docker-compose/nginx/https.conf
@@ -16,7 +16,7 @@ server {
 	ssl_protocols		TLSv1.2 TLSv1.3;
 
 	# Content Security Policy (CSP) configuration
-	add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;" always;
+	add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src 'self' blob:;" always;
 
 	include shanoir.conf;
 }
@@ -31,7 +31,7 @@ server {
 	ssl_protocols		TLSv1.2 TLSv1.3;
 
 	# Content Security Policy (CSP) configuration
-	add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;" always;
+	add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src 'self' blob:;" always;
 
 	include ohif-viewer.conf;
 }


### PR DESCRIPTION
Hello @michaelkain 

This is a very small and quick fix for the CSP header.

It was blocking iframe blobs and as a result, the DUA preview was not loading (check PR's related issue)

Closes #3381