### PR TITLE
Fix regex pattern for VIP_URL_HOST variable

### DIFF
--- a/docker-compose/common/entrypoint_common
+++ b/docker-compose/common/entrypoint_common
@@ -84,7 +84,7 @@ require()
             SHANOIR_CERTIFICATE_PEM_CRT) ;;
             SHANOIR_CERTIFICATE_PEM_KEY) ;;
             VIP_URL_SCHEME)         match "$name" '^(http|https)$'                      ;;
-            VIP_URL_HOST)           match "$name" '^([a-z0-9.-:]+)$'                     ;;
+            VIP_URL_HOST)           match "$name" '^([a-z0-9.\-:]+)$'                     ;;
             VIP_CLIENT_SECRET)      ;;
             *)
                 error "unknown var: $name"


### PR DESCRIPTION
Currently vip.creatis.insa-lyon.fr isn't matching the pattern, but is suggested as default value.