### PR TITLE
issue#3391: Fix missing closing parenthesis in dataset processing security check.

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/controler/DatasetProcessingApi.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/processing/controler/DatasetProcessingApi.java
@@ -123,7 +123,7 @@ public interface DatasetProcessingApi {
             @ApiResponse(responseCode = "500", description = "unexpected error")})
     @PostMapping(value = "", produces = {"application/json"}, consumes = {
             "application/json"})
-    @PreAuthorize("hasAnyRole('ADMIN', 'EXPERT', 'USER') and !@datasetSecurityService.isDraftStudy(#datasetProcessing.getStudyId()")
+    @PreAuthorize("hasAnyRole('ADMIN', 'EXPERT', 'USER') and !@datasetSecurityService.isDraftStudy(#datasetProcessing.getStudyId())")
     ResponseEntity<DatasetProcessingDTO> saveNewDatasetProcessing(@Parameter(description = "dataset processing to create", required = true) @Valid @RequestBody DatasetProcessing datasetProcessing,
                                                                   BindingResult result) throws RestServiceException;
 


### PR DESCRIPTION
There was a missing closing parenthesis in the SpEL expression.

Urgent fix of draft studies -- **NEEDS TO BE MERGED BEFORE THE NEXT RELEASE**

How to test:

Current state: If you try to import a processed dataset (manually from the UI for example), you will have failures while trying to assign an input dataset.

Checkout to the PR head: Processed dataset importation will work as expected.

Close #3391 