### PR TITLE
#3402 : fix for VIP_URL_HOST env var check

### DIFF
--- a/docker-compose/common/entrypoint_common
+++ b/docker-compose/common/entrypoint_common
@@ -84,7 +84,7 @@ require()
             SHANOIR_CERTIFICATE_PEM_CRT) ;;
             SHANOIR_CERTIFICATE_PEM_KEY) ;;
             VIP_URL_SCHEME)         match "$name" '^(http|https)$'                      ;;
-            VIP_URL_HOST)           match "$name" '^([a-z0-9.\-:]+)$'                     ;;
+            VIP_URL_HOST)           match "$name" '^([a-z0-9.:-]+)$'                     ;;
             VIP_CLIENT_SECRET)      ;;
             *)
                 error "unknown var: $name"


### PR DESCRIPTION
For some reason, the - was still considered as a range character, even with the \ before (from what gpt says, the behaviour depends of the regex "engine", but I don't really understand how Axel from CIBM can use a distinct engine from us ... like, for me it's not depending of the host, idk).

Moving it at the end of the regex avoids this issue.