### PR TITLE
SMTP fixes

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -58,6 +58,7 @@ jobs:
         SHANOIR_URL_SCHEME: http
         SHANOIR_PREFIX: github
         SHANOIR_ADMIN_EMAIL: nobody@inria.fr
+        SHANOIR_ADMIN_NAME: shanoir-admin
         SHANOIR_KEYCLOAK_USER: admin
         SHANOIR_KEYCLOAK_PASSWORD: '&a1A&a1A'
         VIP_URL_SCHEME: https

--- a/docker-compose/keycloak/cfg/shanoir-ng-realm.json
+++ b/docker-compose/keycloak/cfg/shanoir-ng-realm.json
@@ -1949,6 +1949,7 @@
     "password": "SHANOIR_SMTP_PASSWORD",
     "user": "SHANOIR_SMTP_USERNAME",
     "from": "SHANOIR_ADMIN_EMAIL",
+    "fromDisplayName": "SHANOIR_ADMIN_NAME",
     "envelopeFrom": "SHANOIR_SMTP_FROM",
     "port": "SHANOIR_SMTP_PORT"
   },

--- a/docker-compose/keycloak/cfg/shanoir-ng-realm.json
+++ b/docker-compose/keycloak/cfg/shanoir-ng-realm.json
@@ -1949,7 +1949,7 @@
     "password": "SHANOIR_SMTP_PASSWORD",
     "user": "SHANOIR_SMTP_USERNAME",
     "from": "SHANOIR_ADMIN_EMAIL",
-    "fromDisplayName": "SHANOIR_SMTP_FROM",
+    "envelopeFrom": "SHANOIR_SMTP_FROM",
     "port": "SHANOIR_SMTP_PORT"
   },
   "loginTheme": "shanoir-theme",

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/email/EmailServiceImpl.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/email/EmailServiceImpl.java
@@ -128,6 +128,21 @@ public class EmailServiceImpl implements EmailService {
         messageHelper.setFrom(new InternetAddress(administratorEmail, administratorName));
     }
 
+    private void setFromUser(MimeMessageHelper messageHelper, User user)
+            throws UnsupportedEncodingException, MessagingException {
+        String host = "shanoir";
+        try {
+            host = new URL(shanoirServerAddress).getHost();
+        } catch (Exception e) {
+        }
+        // Note: we put the user email in 'Reply-To' instead of 'From' to avoid
+        // sending emails with a source address in a foreign domain
+        messageHelper.setFrom(new InternetAddress(
+                administratorEmail,
+                String.format("%s %s (via %s)", user.getFirstName(), user.getLastName(), host)));
+        messageHelper.setReplyTo(user.getEmail());
+    }
+
     @Override
     public void notifyAccountWillExpire(User user) {
         MimeMessagePreparator messagePreparator = mimeMessage -> {
@@ -708,7 +723,7 @@ public class EmailServiceImpl implements EmailService {
         } else {
             MimeMessagePreparator messagePreparator = mimeMessage -> {
                 final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-                messageHelper.setFrom(user.get().getEmail());
+                this.setFromUser(messageHelper, user.get());
                 messageHelper.setTo(mail.getRecipienEmailAddress());
                 messageHelper.setSubject("[Shanoir] pleaser help configure DUA for study " + mail.getStudyName());
                 final Map<String, Object> variables = new HashMap<>();

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/email/EmailServiceImpl.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/email/EmailServiceImpl.java
@@ -14,6 +14,8 @@
 
 package org.shanoir.ng.email;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URL;
 import java.net.URLEncoder;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -24,6 +26,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
 import org.shanoir.ng.accessrequest.model.AccessRequest;
 import org.shanoir.ng.email.model.DatasetDetail;
 import org.shanoir.ng.shared.configuration.RabbitMQConfiguration;
@@ -108,6 +112,9 @@ public class EmailServiceImpl implements EmailService {
     @Value("${server.administrator.email}")
     private String administratorEmail;
 
+    @Value("${server.administrator.name}")
+    private String administratorName;
+
     @Value("${front.server.address}")
     private String shanoirServerAddress;
 
@@ -116,11 +123,16 @@ public class EmailServiceImpl implements EmailService {
 
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("MMM d yyyy");
 
+    private void setFromAdministrator(MimeMessageHelper messageHelper)
+            throws UnsupportedEncodingException, MessagingException {
+        messageHelper.setFrom(new InternetAddress(administratorEmail, administratorName));
+    }
+
     @Override
     public void notifyAccountWillExpire(User user) {
         MimeMessagePreparator messagePreparator = mimeMessage -> {
             final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-            messageHelper.setFrom(administratorEmail);
+            this.setFromAdministrator(messageHelper);
             messageHelper.setTo(user.getEmail());
             messageHelper.setSubject("Shanoir Account Expiration");
             final Map<String, Object> variables = new HashMap<>();
@@ -141,7 +153,7 @@ public class EmailServiceImpl implements EmailService {
         final List<String> adminEmails = userRepository.findAdminEmails();
         MimeMessagePreparator messagePreparator = mimeMessage -> {
             final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-            messageHelper.setFrom(administratorEmail);
+            this.setFromAdministrator(messageHelper);
             messageHelper.setTo(adminEmails.toArray(new String[0]));
             messageHelper.setSubject(email.getIsNew() ? "New draft study created" : "Draft study got edited");
             final Map<String, Object> variables = buildDraftStudyEmailVariables(user, email, shanoirServerAddress);
@@ -160,7 +172,7 @@ public class EmailServiceImpl implements EmailService {
             for (User studyMember : studyMembers) {
                 MimeMessagePreparator messagePreparator = mimeMessage -> {
                     final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-                    messageHelper.setFrom(administratorEmail);
+                    this.setFromAdministrator(messageHelper);
                     messageHelper.setTo(studyMember.getEmail());
                     messageHelper.setSubject("Study approved");
                     final Map<String, Object> variables = new HashMap<>();
@@ -186,7 +198,7 @@ public class EmailServiceImpl implements EmailService {
 
         MimeMessagePreparator messagePreparator = mimeMessage -> {
             final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-            messageHelper.setFrom(administratorEmail);
+            this.setFromAdministrator(messageHelper);
             messageHelper.setTo(adminEmails.toArray(new String[0]));
             messageHelper.setSubject("User account extension request from " + shanoirServerAddress);
             final Map<String, Object> variables = new HashMap<>();
@@ -226,7 +238,7 @@ public class EmailServiceImpl implements EmailService {
     public void notifyCreateUser(final User user, final String password) {
         MimeMessagePreparator messagePreparator = mimeMessage -> {
             final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-            messageHelper.setFrom(administratorEmail);
+            this.setFromAdministrator(messageHelper);
             messageHelper.setTo(user.getEmail());
             messageHelper.setSubject("Shanoir Account Creation");
             final Map<String, Object> variables = new HashMap<>();
@@ -246,7 +258,7 @@ public class EmailServiceImpl implements EmailService {
     public void notifyCreateAccountRequest(final User user, final String password) {
         MimeMessagePreparator messagePreparator = mimeMessage -> {
             final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-            messageHelper.setFrom(administratorEmail);
+            this.setFromAdministrator(messageHelper);
             messageHelper.setTo(user.getEmail());
             messageHelper.setSubject("Shanoir Account Creation");
             final Map<String, Object> variables = new HashMap<>();
@@ -266,7 +278,7 @@ public class EmailServiceImpl implements EmailService {
     public void notifyUserResetPassword(final User user, final String password) {
         MimeMessagePreparator messagePreparator = mimeMessage -> {
             final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-            messageHelper.setFrom(administratorEmail);
+            this.setFromAdministrator(messageHelper);
             messageHelper.setTo(user.getEmail());
             messageHelper.setSubject("[Shanoir] Réinitialisation du mot de passe");
             final Map<String, Object> variables = new HashMap<>();
@@ -296,7 +308,7 @@ public class EmailServiceImpl implements EmailService {
 
         MimeMessagePreparator messagePreparator = mimeMessage -> {
             final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-            messageHelper.setFrom(administratorEmail);
+            this.setFromAdministrator(messageHelper);
             messageHelper.setTo(adminEmails.toArray(new String[0]));
             messageHelper.setSubject("User account request granted (" + shanoirServerAddress + ")");
             final Map<String, Object> variables = new HashMap<>();
@@ -316,7 +328,7 @@ public class EmailServiceImpl implements EmailService {
 
         MimeMessagePreparator messagePreparator = mimeMessage -> {
             final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-            messageHelper.setFrom(administratorEmail);
+            this.setFromAdministrator(messageHelper);
             messageHelper.setTo(adminEmails.toArray(new String[0]));
             messageHelper.setSubject("User account request DENIED (" + shanoirServerAddress + ")");
             final Map<String, Object> variables = new HashMap<>();
@@ -334,7 +346,7 @@ public class EmailServiceImpl implements EmailService {
 
         MimeMessagePreparator messagePreparator = mimeMessage -> {
             final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-            messageHelper.setFrom(administratorEmail);
+            this.setFromAdministrator(messageHelper);
             messageHelper.setTo(adminEmails.toArray(new String[0]));
             messageHelper.setSubject("User account request granted (" + shanoirServerAddress + ")");
             final Map<String, Object> variables = new HashMap<>();
@@ -354,7 +366,7 @@ public class EmailServiceImpl implements EmailService {
 
         MimeMessagePreparator messagePreparator = mimeMessage -> {
             final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-            messageHelper.setFrom(administratorEmail);
+            this.setFromAdministrator(messageHelper);
             messageHelper.setTo(adminEmails.toArray(new String[0]));
             messageHelper.setSubject("User account request DENIED (" + shanoirServerAddress + ")");
             final Map<String, Object> variables = new HashMap<>();
@@ -368,7 +380,7 @@ public class EmailServiceImpl implements EmailService {
     private void notifyUserAccountRequestAccepted(final User user) {
         MimeMessagePreparator messagePreparator = mimeMessage -> {
             final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-            messageHelper.setFrom(administratorEmail);
+            this.setFromAdministrator(messageHelper);
             messageHelper.setTo(user.getEmail());
             messageHelper.setSubject("Granted: Your Shanoir account has been activated");
             final Map<String, Object> variables = new HashMap<>();
@@ -384,7 +396,7 @@ public class EmailServiceImpl implements EmailService {
     private void notifyUserAccountRequestDenied(final User user) {
         MimeMessagePreparator messagePreparator = mimeMessage -> {
             final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-            messageHelper.setFrom(administratorEmail);
+            this.setFromAdministrator(messageHelper);
             messageHelper.setTo(user.getEmail());
             messageHelper.setSubject("DENIED: Your Shanoir account request has been denied");
             final Map<String, Object> variables = new HashMap<>();
@@ -401,7 +413,7 @@ public class EmailServiceImpl implements EmailService {
     private void notifyUserExtensionRequestAccepted(final User user) {
         MimeMessagePreparator messagePreparator = mimeMessage -> {
             final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-            messageHelper.setFrom(administratorEmail);
+            this.setFromAdministrator(messageHelper);
             messageHelper.setTo(user.getEmail());
             messageHelper.setSubject("Granted: Your Shanoir account extension has been extended");
             final Map<String, Object> variables = new HashMap<>();
@@ -418,7 +430,7 @@ public class EmailServiceImpl implements EmailService {
     private void notifyUserExtensionRequestDenied(final User user) {
         MimeMessagePreparator messagePreparator = mimeMessage -> {
             final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-            messageHelper.setFrom(administratorEmail);
+            this.setFromAdministrator(messageHelper);
             messageHelper.setTo(user.getEmail());
             messageHelper.setSubject("DENIED: Your Shanoir account extension request has been denied");
             final Map<String, Object> variables = new HashMap<>();
@@ -455,7 +467,7 @@ public class EmailServiceImpl implements EmailService {
         for (User admin : admins) {
             MimeMessagePreparator messagePreparator = mimeMessage -> {
                 final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-                messageHelper.setFrom(administratorEmail);
+                this.setFromAdministrator(messageHelper);
                 messageHelper.setTo(admin.getEmail());
                 messageHelper.setSubject("[Shanoir] Data imported to " + generatedMail.getStudyName());
                 final Map<String, Object> variables = new HashMap<>();
@@ -496,7 +508,7 @@ public class EmailServiceImpl implements EmailService {
         for (User admin : admins) {
             MimeMessagePreparator messagePreparator = mimeMessage -> {
                 final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-                messageHelper.setFrom(administratorEmail);
+                this.setFromAdministrator(messageHelper);
                 messageHelper.setTo(admin.getEmail());
                 messageHelper.setSubject("[Shanoir] Import failure for " + generatedMail.getStudyName());
                 final Map<String, Object> variables = new HashMap<>();
@@ -533,7 +545,7 @@ public class EmailServiceImpl implements EmailService {
             for (User studyAdmin : studyAdmins) {
                 MimeMessagePreparator messagePreparator = mimeMessage -> {
                     final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-                    messageHelper.setFrom(administratorEmail);
+                    this.setFromAdministrator(messageHelper);
                     messageHelper.setCc(user != null ? user.getEmail() : administratorEmail);
                     messageHelper.setTo(studyAdmin.getEmail());
                     messageHelper.setSubject("[Shanoir] Member(s) added to " + email.getStudyName());
@@ -558,7 +570,7 @@ public class EmailServiceImpl implements EmailService {
         for (User studyUser : newStudyUsers) {
             MimeMessagePreparator messagePreparator = mimeMessage -> {
                 final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-                messageHelper.setFrom(administratorEmail);
+                this.setFromAdministrator(messageHelper);
                 messageHelper.setTo(studyUser.getEmail());
                 messageHelper.setSubject("[Shanoir] Welcome to " + email.getStudyName());
                 final Map<String, Object> variables = new HashMap<>();
@@ -587,7 +599,7 @@ public class EmailServiceImpl implements EmailService {
             for (User studyAdmin : studyAdmins) {
                 MimeMessagePreparator messagePreparator = mimeMessage -> {
                     final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-                    messageHelper.setFrom(administratorEmail);
+                    this.setFromAdministrator(messageHelper);
                     messageHelper.setTo(studyAdmin.getEmail());
                     messageHelper.setSubject("[Shanoir] Member(s) access request to " + createdRequest.getStudyName());
                     final Map<String, Object> variables = new HashMap<>();
@@ -627,7 +639,7 @@ public class EmailServiceImpl implements EmailService {
 
         MimeMessagePreparator messagePreparator = mimeMessage -> {
             final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-            messageHelper.setFrom(administratorEmail);
+            this.setFromAdministrator(messageHelper);
             messageHelper.setTo(email.getInvitedMail());
             messageHelper.setSubject("[Shanoir] Access to study " + email.getStudyName());
             final Map<String, Object> variables = new HashMap<>();
@@ -672,7 +684,7 @@ public class EmailServiceImpl implements EmailService {
 
         MimeMessagePreparator messagePreparator = mimeMessage -> {
             final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-            messageHelper.setFrom(administratorEmail);
+            this.setFromAdministrator(messageHelper);
             messageHelper.setTo(user.getEmail());
             messageHelper.setSubject("[Shanoir] Access to study " + refusedRequest.getStudyName());
             final Map<String, Object> variables = new HashMap<>();
@@ -713,7 +725,7 @@ public class EmailServiceImpl implements EmailService {
 
             messagePreparator = mimeMessage -> {
                 final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-                messageHelper.setFrom(administratorEmail);
+                this.setFromAdministrator(messageHelper);
                 messageHelper.setTo(user.get().getEmail());
                 messageHelper.setSubject("[Shanoir] DUA draft created for study " + mail.getStudyName());
                 final Map<String, Object> variables = new HashMap<>();

--- a/shanoir-ng-users/src/main/resources/application.yml
+++ b/shanoir-ng-users/src/main/resources/application.yml
@@ -19,6 +19,7 @@ server:
     whitelabel:
       enabled: false
   display-name: Shanoir
+  administrator.name: ${SHANOIR_ADMIN_NAME}
   administrator.email: ${SHANOIR_ADMIN_EMAIL}
 ##### Database #####
 spring:


### PR DESCRIPTION
This fixes a few things when sending emails :
- fix the configuration of the SMTP sender in keycloak
- restore the SHANOIR_ADMIN_NAME in the From header (`From: SHANOIR_ADMIN_NAME <SHANOIR_ADMIN_EMAIL>`)
- prevent sending emails with source address in a foreign domain (this can cause problems)<br>
  this uses:
    ```
    From: USER_FULL_NAME (via SHANOIR_URL_HOST) <SHANOIR_ADMIN_EMAIL>
    Reply-To: USER_EMAIL
    ```
    instead of:
    ```
    From: USER_EMAIL
    ```
