### PR TITLE
feature#3446: Sync StudyInstanceUID from PACS for examinations

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/controler/ExaminationApi.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/controler/ExaminationApi.java
@@ -194,6 +194,19 @@ public interface ExaminationApi {
             @Parameter(description = "id of the center", required = true) @PathVariable("centerId") Long centerId,
             @Parameter(description = "file to upload", required = true) @Valid @RequestBody MultipartFile file) throws RestServiceException;
 
+    @Operation(summary = "", description = "Retrieves the DICOM StudyInstanceUID from the backup PACS for the given examination and updates it in the database")
+    @ApiResponses(value = { @ApiResponse(responseCode = "204", description = "study instance UID synced from PACS and updated"),
+            @ApiResponse(responseCode = "401", description = "unauthorized"),
+            @ApiResponse(responseCode = "403", description = "forbidden"),
+            @ApiResponse(responseCode = "404", description = "no examination found"),
+            @ApiResponse(responseCode = "422", description = "study instance UID not resolvable or not found in PACS"),
+            @ApiResponse(responseCode = "500", description = "unexpected error") })
+    @PutMapping(value = "/{examinationId}/studyInstanceUID", produces = { "application/json" })
+    @PreAuthorize("hasRole('ADMIN') or (hasAnyRole('EXPERT', 'USER') and @datasetSecurityService.hasRightOnExamination(#examinationId, 'CAN_IMPORT'))")
+    ResponseEntity<Void> syncStudyInstanceUIDFromPacs(
+            @Parameter(description = "id of the examination", required = true) @PathVariable("examinationId") Long examinationId)
+            throws RestServiceException;
+
     @Operation(summary = "", description = "Download extra data from an examination", tags = {})
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "examination updated"),

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/controler/ExaminationApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/controler/ExaminationApiController.java
@@ -226,6 +226,20 @@ public class ExaminationApiController implements ExaminationApi {
     }
 
     @Override
+    public ResponseEntity<Void> syncStudyInstanceUIDFromPacs(
+            @Parameter(description = "id of the examination", required = true) @PathVariable("examinationId") Long examinationId)
+            throws RestServiceException {
+        try {
+            examinationService.syncStudyInstanceUIDFromPacs(examinationId);
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        } catch (EntityNotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (ShanoirException e) {
+            throw new RestServiceException(new ErrorModel(HttpStatus.UNPROCESSABLE_ENTITY.value(), e.getMessage()));
+        }
+    }
+
+    @Override
     public ResponseEntity<Void> addExtraData(
             @Parameter(description = "id of the examination", required = true) @PathVariable("examinationId") Long examinationId,
             @Parameter(description = "file to upload", required = true) @Valid @RequestBody MultipartFile file) throws RestServiceException {

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/service/ExaminationService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/service/ExaminationService.java
@@ -165,4 +165,16 @@ public interface ExaminationService {
     @PreAuthorize("hasRole('ADMIN') or (hasAnyRole('EXPERT', 'USER') and (@datasetSecurityService.hasRightOnExamination(#examinationId, 'CAN_DOWNLOAD') or @datasetSecurityService.hasRightOnExamination(#examinationId, 'CAN_ADMINISTRATE')))")
     String getExtraDataFilePath(Long examinationId, String fileName);
 
+    /**
+     * Retrieves the DICOM StudyInstanceUID from the backup PACS for the given examination
+     * and updates it in the database. The UID is extracted from the WADO path stored in
+     * dataset_file and verified against the PACS before persisting.
+     *
+     * @param examinationId examination id.
+     * @throws EntityNotFoundException if no examination found with given id.
+     * @throws ShanoirException if the StudyInstanceUID cannot be resolved or is not found in the PACS.
+     */
+    @PreAuthorize("hasRole('ADMIN') or (hasAnyRole('EXPERT', 'USER') and @datasetSecurityService.hasRightOnExamination(#examinationId, 'CAN_IMPORT'))")
+    void syncStudyInstanceUIDFromPacs(Long examinationId) throws EntityNotFoundException, ShanoirException;
+
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/service/ExaminationServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/service/ExaminationServiceImpl.java
@@ -394,4 +394,21 @@ public class ExaminationServiceImpl implements ExaminationService {
         return dataDir + "/examination-" + examinationId + "/" + fileName;
     }
 
+    @Override
+    @Transactional
+    public void syncStudyInstanceUIDFromPacs(Long examinationId) throws EntityNotFoundException, ShanoirException {
+        Examination examination = examinationRepository.findByIdWithEagerAcquisitions(examinationId)
+                .orElseThrow(() -> new EntityNotFoundException(Examination.class, examinationId));
+        String studyInstanceUID = studyInstanceUIDHandler.findStudyInstanceUID(examination);
+        if (studyInstanceUID == null) {
+            throw new ShanoirException("Could not find StudyInstanceUID from WADO paths for examination: " + examinationId);
+        }
+        String pacsResponse = dicomWebService.findStudy(studyInstanceUID, "all");
+        if (pacsResponse == null || pacsResponse.isBlank() || "[]".equals(pacsResponse.trim())) {
+            throw new ShanoirException("Study not found in PACS for StudyInstanceUID: " + studyInstanceUID + ", examination: " + examinationId);
+        }
+        LOG.info("Syncing StudyInstanceUID {} from PACS for examination {}", studyInstanceUID, examinationId);
+        examinationRepository.updateStudyInstanceUID(examinationId, studyInstanceUID);
+    }
+
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/service/ExaminationServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/examination/service/ExaminationServiceImpl.java
@@ -403,10 +403,6 @@ public class ExaminationServiceImpl implements ExaminationService {
         if (studyInstanceUID == null) {
             throw new ShanoirException("Could not find StudyInstanceUID from WADO paths for examination: " + examinationId);
         }
-        String pacsResponse = dicomWebService.findStudy(studyInstanceUID, "all");
-        if (pacsResponse == null || pacsResponse.isBlank() || "[]".equals(pacsResponse.trim())) {
-            throw new ShanoirException("Study not found in PACS for StudyInstanceUID: " + studyInstanceUID + ", examination: " + examinationId);
-        }
         LOG.info("Syncing StudyInstanceUID {} from PACS for examination {}", studyInstanceUID, examinationId);
         examinationRepository.updateStudyInstanceUID(examinationId, studyInstanceUID);
     }


### PR DESCRIPTION
Update the examination's study_instance_uid in the databse based on the examination id.

Close #3446 