### PR TITLE
Fix OHIF AI segmentation: configure onnxruntime-web wasmPaths

### DIFF
--- a/docker-compose/nginx/viewer/app-config.js
+++ b/docker-compose/nginx/viewer/app-config.js
@@ -39,7 +39,10 @@ window.config = {
 			}, 
 		}, 
 	], 
-	defaultDataSourceName: 'dicomweb', 
+	defaultDataSourceName: 'dicomweb',
+	onnxConfig: {
+		wasmPaths: '/ort/',
+	},
 	oidc: [
   	  {
     	// ~ REQUIRED


### PR DESCRIPTION
## Summary

Fixes the OHIF v3.11 AI segmentation tools (SAM-B encoder/decoder, labelmap slice propagation, marker labelmap) which were failing with:
- `Could not find a CPU kernel and hence can't constant fold Div node '/image_encoder/blocks.X/attn/Div'`
- `Error: no available backend found`

## Root cause

OHIF v3.11 uses `onnxruntime-web` for browser-side AI inference. The official `ohif/app:v3.11.0` Docker image already ships the ORT wasm files at `/usr/share/nginx/html/ort/` (verified by running `docker run --rm ohif/app:v3.11.0 ls /usr/share/nginx/html/ort/`). The existing Shanoir nginx `Dockerfile` already copies these files to `/etc/nginx/viewer/html/ort/` via:

`COPY --link --from=nginx-viewer /usr/share/nginx/html/. /etc/nginx/viewer/html/`

However, without explicitly setting `onnxConfig.wasmPaths` in `app-config.js`, `onnxruntime-web` does not know where to find its wasm kernels (it tries a default path that doesn't match how Shanoir serves assets), which causes ORT to fail to initialize the inference session.

## Fix

Add `onnxConfig: { wasmPaths: '/ort/' }` to `window.config` in `docker-compose/nginx/viewer/app-config.js`. This tells `onnxruntime-web` to load its wasm kernels from the `/ort/` path, which is served by the existing `location /` block in `ohif-viewer.template.conf` (which already sets the required `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` headers needed for threaded wasm and `SharedArrayBuffer`).

**No nginx template changes are required** — the default `location /` block already serves `/ort/*.wasm` correctly with the right MIME type and COOP/COEP headers.

## Browser requirement

OHIF v3.10+ AI segmentation uses WebGPU. End users need:
- Chrome / Edge / Opera 113+ (WebGPU enabled by default)
- Firefox 141+ with `dom.webgpu.enabled = true` (on Linux/macOS)

This is an OHIF platform constraint, not a Shanoir one.

## Test plan

- [x] Verify official `ohif/app:v3.11.0` image ships `/usr/share/nginx/html/ort/ort-wasm-simd-threaded.jsep.wasm`
- [x] Verify `app-config.js` parses without syntax errors in-browser
- [x] Verify `/ort/ort-wasm-simd-threaded.jsep.wasm` returns 200 from the nginx viewer
- [x] Verify SAM-B encoder and decoder models load (`status ready`, `encoder Rendered image on 0`)
- [x] Verify AI segmentation tool (marker/slice propagation) initializes end-to-end in Chrome