### PR TITLE
feature#3482: Notify platform admins on study approval

### DIFF
--- a/shanoir-ng-ms-common/src/main/java/org/shanoir/ng/shared/email/EmailStudy.java
+++ b/shanoir-ng-ms-common/src/main/java/org/shanoir/ng/shared/email/EmailStudy.java
@@ -37,7 +37,7 @@ public class EmailStudy extends EmailBase {
     private String principalInvestigator;
     private String scientificAdvisor;
     private List<Long> studyUsers;
-    private Boolean isNew;
+    private String action;
 
     public String getDescription() {
         return description;
@@ -191,11 +191,11 @@ public class EmailStudy extends EmailBase {
         this.studyUsers = studyUsers;
     }
 
-    public Boolean getIsNew() {
-        return isNew;
+    public String getAction() {
+        return action;
     }
 
-    public void setIsNew(Boolean isNew) {
-        this.isNew = isNew;
+    public void setAction(String action) {
+        this.action = action;
     }
 }

--- a/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/service/StudyServiceImpl.java
+++ b/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/service/StudyServiceImpl.java
@@ -264,7 +264,7 @@ public class StudyServiceImpl implements StudyService {
             sendStudyUserReport(studyDb, studyDb.getStudyUserList());
             if (studyDb.getIsDraft()) {
                 // Notify users service to send emails to study admins about new study
-                sendAdminEmailReport(studyDb, true);
+                sendAdminEmailReport(studyDb, "created");
             }
         }
 
@@ -279,6 +279,7 @@ public class StudyServiceImpl implements StudyService {
         study.setIsDraft(false);
         studyRepository.save(study);
         updateStudyName(studyMapper.studyToStudyDTODetailed(study));
+        sendAdminEmailReport(study, "approved");
         sendMembersApprovalEmailReport(study);
         return study;
     }
@@ -466,7 +467,7 @@ public class StudyServiceImpl implements StudyService {
         }
 
         if (studyDb.getIsDraft()) {
-            sendAdminEmailReport(studyDb, false);
+            sendAdminEmailReport(studyDb, "edited");
         }
 
         return studyDb;
@@ -831,9 +832,9 @@ public class StudyServiceImpl implements StudyService {
         }
     }
 
-    private void sendAdminEmailReport(Study study, boolean isNew) {
+    private void sendAdminEmailReport(Study study, String action) {
         EmailStudy email = buildAdminEmailReport(study);
-        email.setIsNew(isNew);
+        email.setAction(action);
 
         try {
             rabbitTemplate.convertAndSend(

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/configuration/amqp/RabbitMQUserService.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/configuration/amqp/RabbitMQUserService.java
@@ -154,6 +154,7 @@ public class RabbitMQUserService {
         try {
             EmailStudy mail = mapper.readValue(generatedMailAsString, EmailStudy.class);
             this.emailService.notifyStudyMembersStudyApproval(mail);
+            this.emailService.notifyAdminStudyEvent(mail);
         } catch (Exception e) {
             LOG.error("Something went wrong deserializing the study created event.", e);
             throw new AmqpRejectAndDontRequeueException("Something went wrong deserializing the event.", e);

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/configuration/amqp/RabbitMQUserService.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/configuration/amqp/RabbitMQUserService.java
@@ -154,7 +154,6 @@ public class RabbitMQUserService {
         try {
             EmailStudy mail = mapper.readValue(generatedMailAsString, EmailStudy.class);
             this.emailService.notifyStudyMembersStudyApproval(mail);
-            this.emailService.notifyAdminStudyEvent(mail);
         } catch (Exception e) {
             LOG.error("Something went wrong deserializing the study created event.", e);
             throw new AmqpRejectAndDontRequeueException("Something went wrong deserializing the event.", e);

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/email/EmailServiceImpl.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/email/EmailServiceImpl.java
@@ -199,11 +199,32 @@ public class EmailServiceImpl implements EmailService {
                     LOG.info(content);
                     messageHelper.setText(content, true);
                 };
-                // Send the message
-                LOG.info("Sending approve-study mail to {} for study {}", studyMember.getUsername(), email.getStudyId());
+                LOG.info("Sending study approval mail to {} for study {}", studyMember.getEmail(), email.getStudyId());
                 mailSender.send(messagePreparator);
             }
         }
+
+        // Notify the admins too.
+        final List<String> adminEmails = userRepository.findAdminEmails();
+        User approvingAdmin = userRepository.findById(email.getUserId()).orElse(null);
+        MimeMessagePreparator messagePreparator = mimeMessage -> {
+            final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
+            this.setFromAdministrator(messageHelper);
+            messageHelper.setTo(adminEmails.toArray(new String[0]));
+            messageHelper.setSubject("Study approved");
+            final Map<String, Object> variables = new HashMap<>();
+            variables.put(FIRSTNAME, approvingAdmin.getFirstName());
+            variables.put(LASTNAME, approvingAdmin.getLastName());
+            variables.put(USERNAME, approvingAdmin.getUsername());
+            variables.put(EMAIL, approvingAdmin.getEmail());
+            variables.put(STUDY_NAME, email.getStudyName());
+            variables.put(SERVER_ADDRESS, shanoirServerAddress + "study/details/" + email.getStudyId());
+            final String content = build("notifyAdminStudyApproval", variables);
+            LOG.info(content);
+            messageHelper.setText(content, true);
+        };
+        LOG.info("Sending study approval mail to admins {} for study {}", adminEmails, email.getStudyId());
+        mailSender.send(messagePreparator);
     }
 
     @Override

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/email/EmailServiceImpl.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/email/EmailServiceImpl.java
@@ -170,8 +170,16 @@ public class EmailServiceImpl implements EmailService {
             final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
             this.setFromAdministrator(messageHelper);
             messageHelper.setTo(adminEmails.toArray(new String[0]));
-            messageHelper.setSubject(email.getIsNew() ? "New draft study created" : "Draft study got edited");
-            final Map<String, Object> variables = buildDraftStudyEmailVariables(user, email, shanoirServerAddress);
+
+            if (email.getAction() == "created") {
+                messageHelper.setSubject("New draft study created");
+            } else if (email.getAction() == "edited") {
+                messageHelper.setSubject("A draft study got edited");
+            } else if (email.getAction() == "approved") {
+                messageHelper.setSubject("A study got approved");
+            }
+
+            final Map<String, Object> variables = buildStudyEmailVariables(user, email, shanoirServerAddress);
             final String content = build("notifyAdminDraftStudy", variables);
             LOG.info(content);
             messageHelper.setText(content, true);
@@ -203,28 +211,6 @@ public class EmailServiceImpl implements EmailService {
                 mailSender.send(messagePreparator);
             }
         }
-
-        // Notify the admins too.
-        final List<String> adminEmails = userRepository.findAdminEmails();
-        User approvingAdmin = userRepository.findById(email.getUserId()).orElse(null);
-        MimeMessagePreparator messagePreparator = mimeMessage -> {
-            final MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-            this.setFromAdministrator(messageHelper);
-            messageHelper.setTo(adminEmails.toArray(new String[0]));
-            messageHelper.setSubject("Study approved");
-            final Map<String, Object> variables = new HashMap<>();
-            variables.put(FIRSTNAME, approvingAdmin.getFirstName());
-            variables.put(LASTNAME, approvingAdmin.getLastName());
-            variables.put(USERNAME, approvingAdmin.getUsername());
-            variables.put(EMAIL, approvingAdmin.getEmail());
-            variables.put(STUDY_NAME, email.getStudyName());
-            variables.put(SERVER_ADDRESS, shanoirServerAddress + "study/details/" + email.getStudyId());
-            final String content = build("notifyAdminStudyApproval", variables);
-            LOG.info(content);
-            messageHelper.setText(content, true);
-        };
-        LOG.info("Sending study approval mail to admins {} for study {}", adminEmails, email.getStudyId());
-        mailSender.send(messagePreparator);
     }
 
     @Override
@@ -776,10 +762,10 @@ public class EmailServiceImpl implements EmailService {
         }
     }
 
-    private Map<String, Object> buildDraftStudyEmailVariables(User user, EmailStudy email, String shanoirServerAddress) {
+    private Map<String, Object> buildStudyEmailVariables(User user, EmailStudy email, String shanoirServerAddress) {
         Map<String, Object> variables = new HashMap<>();
 
-        // User info
+        // User who performed action info
         variables.put(FIRSTNAME, user.getFirstName());
         variables.put(LASTNAME, user.getLastName());
         variables.put(EMAIL, user.getEmail());
@@ -796,7 +782,7 @@ public class EmailServiceImpl implements EmailService {
         variables.put("studyCardPolicy", email.getStudyCardPolicy());
         variables.put("clinical", email.isClinical());
         variables.put("challenge", email.isChallenge());
-        variables.put("isNew", email.getIsNew());
+        variables.put("action", email.getAction());
 
         // Extra details
         variables.put("expectedNbOfSubjects", email.getExpectedNbOfSubjects());

--- a/shanoir-ng-users/src/main/resources/templates/notifyAdminStudyApproval.html
+++ b/shanoir-ng-users/src/main/resources/templates/notifyAdminStudyApproval.html
@@ -1,0 +1,30 @@
+<!--
+Shanoir NG - Import, manage and share neuroimaging data
+Copyright (C) 2009-2019 Inria - https://www.inria.fr/
+Contact us on https://project.inria.fr/shanoir/
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
+-->
+
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head></head>
+<body>
+    <p><span>Dear administrator,</span></p>
+    <p>A draft study has been approved on Shanoir</p>
+    <p><b>Study name:</b> <span th:text="${studyName}"></span></p>
+    <p>
+        <b>Approved by:</b>
+        <span th:text="${firstname}"></span> <span th:text="${lastname}"></span>
+        (<span th:text="${username}"></span> - <span th:text="${email}"></span>)
+    </p>
+    <p>You can access and manage the study here: <a th:href="${serverAddress}">Manage Study</a></p>
+    <p>Regards</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
On study approval an email is sent to the admins of the platform, notifying them with:
- Which study was approved
- Which admin approved the study
- The study details

## Qualif test
- [x] Approve a study and verify that the platfrom admins receive the approval email
- [x] Verify the admin email correctly shows the approving admin's details
- [x] Verify the admin email correctly shows the study's details

The mails in qualif are located in `/data/neurinfo/qualif/smtpsink/new/`

Closes #3482