### PR TITLE
Fix download dialog for Generic and VIP NIfTI datasets

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/dto/DatasetLight.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/dto/DatasetLight.java
@@ -56,7 +56,7 @@ public class DatasetLight {
         this.hasProcessings = hasProcessings;
         this.id = id;
         this.name = name;
-        this.type = type.getDeclaredConstructor().newInstance().getType().name();
+        this.type = type.getDeclaredConstructor().newInstance().getType().toString();
         this.study = new IdName(studyId, studyName);
         this.subject = new IdName(subjectId, subjectName);
         this.centerId = centerId;

--- a/shanoir-ng-front/src/app/shared/mass-download/download-setup-alt/download-setup-alt.component.ts
+++ b/shanoir-ng-front/src/app/shared/mass-download/download-setup-alt/download-setup-alt.component.ts
@@ -135,11 +135,18 @@ export class DownloadSetupAltComponent implements OnInit, OnDestroy {
     // This method checks if the list of given datasets has dicom or not.
     private hasDicomInDatasets(datasets: Dataset[] | DatasetLight[]) {
         for (const dataset of datasets) {
-            if (dataset.type != DatasetType.Eeg && dataset.type != DatasetType.BIDS && dataset.type != DatasetType.Generic) {
+            if (!this.isNonDicomDatasetType(dataset.type)) {
                 return true;
             }
         }
         return false;
+    }
+
+    private isNonDicomDatasetType(type: DatasetType | string): boolean {
+        const normalized = typeof type === 'string' ? type.toLowerCase() : String(type).toLowerCase();
+        return normalized === DatasetType.Eeg.toLowerCase()
+            || normalized === DatasetType.BIDS.toLowerCase()
+            || normalized === DatasetType.Generic.toLowerCase();
     }
 
     hasError(fieldName: string, errors: string[]) {

--- a/shanoir-ng-front/src/app/shared/mass-download/download-setup/download-setup.component.ts
+++ b/shanoir-ng-front/src/app/shared/mass-download/download-setup/download-setup.component.ts
@@ -162,13 +162,21 @@ export class DownloadSetupComponent implements OnInit, OnDestroy {
     }
 
     // This method checks if the list of given datasets has dicom or not.
-    private hasDicomInDatasets(datasets: {type: DatasetType, hasProcessings: boolean}[]) {
+    private hasDicomInDatasets(datasets: {type: DatasetType | string, hasProcessings: boolean}[]) {
         for (const dataset of datasets) {
-            if (dataset.type != DatasetType.Eeg && dataset.type != DatasetType.BIDS && dataset.type != DatasetType.Generic) {
+            if (!this.isNonDicomDatasetType(dataset.type)) {
                 return true;
             }
         }
         return false;
+    }
+
+    /** Matches DatasetType labels and legacy enum names from DatasetLight (e.g. GENERIC vs Generic). */
+    private isNonDicomDatasetType(type: DatasetType | string): boolean {
+        const normalized = typeof type === 'string' ? type.toLowerCase() : String(type).toLowerCase();
+        return normalized === DatasetType.Eeg.toLowerCase()
+            || normalized === DatasetType.BIDS.toLowerCase()
+            || normalized === DatasetType.Generic.toLowerCase();
     }
 
     ngOnDestroy() {


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2 class="mt-6 mb-2 font-semibold text-2xl" data-streamdown="heading-2" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 10px; --tw-font-weight: 600; font-weight: 600; color: rgba(228, 228, 228, 0.92); line-height: 1.25; font-size: 1.3em; margin-top: 20px; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgba(228, 228, 228, 0.92); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Generic datasets (including VIP pipeline outputs such as defaced NIfTI files) incorrectly triggered the mass-download<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">“Dataset files format: Dicom”</span><span> </span>UI when downloaded alone. This was caused by a mismatch between the dataset type string returned by<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">DatasetLight</code><span> </span>and the values expected by the frontend.</p><h2 class="mt-6 mb-2 font-semibold text-2xl" data-streamdown="heading-2" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 10px; --tw-font-weight: 600; font-weight: 600; color: rgba(228, 228, 228, 0.92); line-height: 1.25; font-size: 1.3em; margin-top: 20px; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Problem</h2><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgba(228, 228, 228, 0.92); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">When downloading a<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">single</span><span> </span>processed VIP result stored as modality type<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Generic</span><span> </span>(e.g.<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">*.reface_plus.nii.gz</code>):</p><ol class="list-inside list-decimal whitespace-normal [li_&amp;]:pl-6" data-streamdown="ordered-list" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; list-style-type: decimal; white-space: normal; padding-left: 2em; display: flex !important; flex-direction: column !important; gap: 6px !important; margin: 6px 0px !important; color: rgba(228, 228, 228, 0.92); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">The download modal still showed<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Dataset files format</span><span> </span>with<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Dicom</span><span> </span>selected by default.</li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">Switching to<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Nifti</span><span> </span>required a<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">DICOM→NIfTI converter</span>, which is irrelevant for files already stored as NIfTI.</li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">Users could believe Shanoir was treating the dataset as DICOM, although the file on disk is NIfTI (<code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">NIFTI_SINGLE_FILE</code>).</li></ol><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgba(228, 228, 228, 0.92); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Typical context:</span><span> </span>VIP deface pipeline under study<span> </span><em>patric</em>, processed dataset with modality<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">GENERIC</span><span> </span>/<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Generic</span>, processed type<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Execution result</span>.</p><h2 class="mt-6 mb-2 font-semibold text-2xl" data-streamdown="heading-2" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 10px; --tw-font-weight: 600; font-weight: 600; color: rgba(228, 228, 228, 0.92); line-height: 1.25; font-size: 1.3em; margin-top: 20px; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Root cause</h2><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgba(228, 228, 228, 0.92); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">DatasetLight</code><span> </span>built the<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">type</code><span> </span>field with<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">DatasetType.name()</code><span> </span>(Java enum constant), e.g.<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">"GENERIC"</code>,<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">"MR"</code>, instead of the API label from<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">DatasetType.toString()</code>, e.g.<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">"Generic"</code>,<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">"Mr"</code>.</p><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgba(228, 228, 228, 0.92); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The download setup components decide whether to show DICOM/NIfTI options via<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">hasDicomInDatasets()</code>, which treats only<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">Eeg</code>,<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">BIDS</code>, and<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">Generic</code><span> </span>as non-DICOM:</p><div class="composer-message-codeblock" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-top: 8px; margin-bottom: 8px; color: rgba(228, 228, 228, 0.92); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-code-block" style="position: relative; margin-top: 0px; margin-bottom: 0px; border-radius: 8px; border-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; overflow: hidden; background-color: rgb(24, 24, 24); min-height: 26px;"><div class="ui-code-block-content" style="position: relative; min-height: 26px;"><div class="ui-scroll-area" data-scroll-padding="4" data-visibility="hover" data-direction="horizontal" style="--scrollbar-size: 6px; --scrollbar-inset: 1px; --scrollbar-thumb-top-offset: 6px; --scroll-area-scroll-padding: 4px; position: relative; overflow: hidden; display: grid; grid-template: 1fr / 1fr;"><div class="ui-scroll-area__viewport" style="grid-area: 1 / 1; min-height: 0px; max-height: 100%; border-radius: inherit; overflow: auto hidden; scroll-padding: 0px 4px; overscroll-behavior: contain auto; scrollbar-width: none !important;"><div class="ui-scroll-area__content" style="box-sizing: border-box; width: max-content; min-width: 100%; max-width: none; min-height: 100%; display: flex; flex-direction: row; height: fit-content;"><div class="ui-default-code ui-code-block-default-code" style="min-width: 100%; width: max-content; background: rgb(24, 24, 24); min-height: 36px; padding: 6px 0px; font-size: 12px; font-weight: normal; line-height: 20px; contain: layout style paint; tab-size: 4; font-family: Consolas, &quot;Courier New&quot;, monospace; --shiki-foreground: rgba(228, 228, 228, 0.92); --shiki-background: transparent; --shiki-token-constant: #f8c762; --shiki-token-string: #E394DC; --shiki-token-comment: #E4E4E45E; --shiki-token-keyword: #82D2CE; --shiki-token-parameter: #D6D6DD; --shiki-token-function: #EFB080; --shiki-token-string-expression: #E394DC; --shiki-token-punctuation: rgba(228, 228, 228, 0.92); --shiki-token-link: #87c3ff; --shiki-token-tag: #82D2CE; --shiki-token-attribute: #AAA0FA; --shiki-token-property: #AAA0FA; --shiki-token-type: #EFB080; --shiki-token-variable: #87C3FF; --shiki-token-class: #EFB080; --shiki-token-language-variable: #CC7C8A; --shiki-token-constant-variable: #AAA0FA; --ui-default-code-tab-size: 4;"><div class="ui-default-code__content" style="min-width: fit-content; contain: layout style;"><div class="ui-default-code__line" style="display: flex; min-height: 20px;"><div class="ui-default-code__line-content" style="flex: 1 1 0%; white-space: pre; overflow: hidden; text-overflow: ellipsis; padding-left: 6px; color: rgba(228, 228, 228, 0.92); padding-right: 8px; position: relative;"><span style="color: rgb(135, 195, 255);">dataset</span><span style="color: rgba(228, 228, 228, 0.92);">.</span><span style="color: rgb(170, 160, 250);">type</span><span style="color: rgba(228, 228, 228, 0.92);"> </span><span style="color: rgba(228, 228, 228, 0.92);">!=</span><span style="color: rgba(228, 228, 228, 0.92);"> </span><span style="color: rgb(135, 195, 255);">DatasetType</span><span style="color: rgba(228, 228, 228, 0.92);">.</span><span style="color: rgb(170, 160, 250);">Generic</span><span style="color: rgba(228, 228, 228, 0.92);">  </span><span style="color: rgba(228, 228, 228, 0.37); font-style: italic;">// expects 'Generic'</span></div></div></div></div></div></div></div></div></div></div><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgba(228, 228, 228, 0.92); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Because<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">"GENERIC" !== "Generic"</code>, Generic datasets were wrongly classified as DICOM-like and the format selector was always shown.</p><h2 class="mt-6 mb-2 font-semibold text-2xl" data-streamdown="heading-2" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 10px; --tw-font-weight: 600; font-weight: 600; color: rgba(228, 228, 228, 0.92); line-height: 1.25; font-size: 1.3em; margin-top: 20px; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Solution</h2><ol class="list-inside list-decimal whitespace-normal [li_&amp;]:pl-6" data-streamdown="ordered-list" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; list-style-type: decimal; white-space: normal; padding-left: 2em; display: flex !important; flex-direction: column !important; gap: 6px !important; margin: 6px 0px !important; color: rgba(228, 228, 228, 0.92); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;"><p style="margin: 0px; word-break: break-word;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Backend (<code class="md-clickable-code md-inline-path-filename-like" role="button" tabindex="0" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: rgb(129, 161, 193); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all; cursor: pointer;"><span class="md-inline-path-filename">DatasetLight.java</span></code>):</span><span> </span>Use<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">getType().toString()</code><span> </span>instead of<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">getType().name()</code><span> </span>so light dataset responses use the same type labels as the rest of the API (<code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">Generic</code>,<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">Mr</code>, etc.).</p></li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;"><p style="margin: 0px; word-break: break-word;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Frontend (<code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">download-setup</code><span> </span>and<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">download-setup-alt</code>):</span><span> </span>Compare dataset types in a case-insensitive way and accept both enum labels and legacy constant names (<code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">GENERIC</code><span> </span>/<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">Generic</code>) via<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">isNonDicomDatasetType()</code>, so existing deployments are tolerant until the backend change is deployed.</p></li></ol><h2 class="mt-6 mb-2 font-semibold text-2xl" data-streamdown="heading-2" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 10px; --tw-font-weight: 600; font-weight: 600; color: rgba(228, 228, 228, 0.92); line-height: 1.25; font-size: 1.3em; margin-top: 20px; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Files changed</h2><div class="ui-scroll-area" data-scroll-padding="4" data-visibility="hover" data-direction="horizontal" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; --scrollbar-size: 6px; --scrollbar-inset: 0px; --scrollbar-thumb-top-offset: 6px; --scroll-area-scroll-padding: 4px; position: relative; overflow: hidden; display: grid; grid-template: 1fr / 1fr; margin: 1em 0px; border-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; border-radius: 6px; color: rgba(228, 228, 228, 0.92); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-scroll-area__viewport" style="grid-area: 1 / 1; min-height: 0px; max-height: 100%; border-radius: inherit; overflow: auto hidden; scroll-padding: 0px 4px; overscroll-behavior: contain auto; scrollbar-width: none !important;"><div class="ui-scroll-area__content" style="box-sizing: border-box; width: auto; min-width: 100%; max-width: 100%; min-height: 100%; display: flex; flex-direction: row; height: fit-content;">
File | Change
-- | --
shanoir-ng-datasets/.../DatasetLight.java | name() → toString() for dataset type
shanoir-ng-front/.../download-setup.component.ts | Robust non-DICOM type detection
shanoir-ng-front/.../download-setup-alt.component.ts | Same as above

</div></div></div><h2 class="mt-6 mb-2 font-semibold text-2xl" data-streamdown="heading-2" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 10px; --tw-font-weight: 600; font-weight: 600; color: rgba(228, 228, 228, 0.92); line-height: 1.25; font-size: 1.3em; margin-top: 20px; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Test plan</h2><ul class="list-inside list-disc whitespace-normal [li_&amp;]:pl-6 contains-task-list" data-streamdown="unordered-list" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; list-style: none; white-space: normal; padding-left: 0px; display: flex !important; flex-direction: column !important; gap: 6px !important; margin: 6px 0px !important; color: rgba(228, 228, 228, 0.92); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="py-1 [&amp;&gt;p]:inline task-list-item" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;"><span class="ui-checkbox" data-size="compact" data-variant="neutral" aria-disabled="true" style="display: inline-flex; align-items: center; justify-content: center; position: relative; cursor: default; top: 1px; margin-right: 0.4em;"><input disabled="" class="ui-checkbox__input" aria-label="Incomplete task" type="checkbox" style="padding: 0px; margin: 0px; position: absolute; inset: 0px; opacity: 0; cursor: inherit; outline: transparent none 0px !important; outline-offset: 0px !important; color: inherit; font-family: inherit; font-size: 13px;"><span class="ui-checkbox__box" data-disabled="true" aria-hidden="true" style="display: inline-flex; align-items: center; justify-content: center; transition-property: color, background-color, border-color, opacity, transform; transition-duration: 150ms; transition-timing-function: ease; box-sizing: border-box; width: 12px; height: 12px; color: rgb(25, 28, 34); border-color: color(srgb 0.894118 0.894118 0.894118 / 0.184314); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); opacity: 0.5;"></span></span><span> </span>Import or use an existing<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Generic</span><span> </span>VIP output (NIfTI, e.g.<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">*.nii.gz</code>).</li><li class="py-1 [&amp;&gt;p]:inline task-list-item" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;"><span class="ui-checkbox" data-size="compact" data-variant="neutral" aria-disabled="true" style="display: inline-flex; align-items: center; justify-content: center; position: relative; cursor: default; top: 1px; margin-right: 0.4em;"><input disabled="" class="ui-checkbox__input" aria-label="Incomplete task" type="checkbox" style="padding: 0px; margin: 0px; position: absolute; inset: 0px; opacity: 0; cursor: inherit; outline: transparent none 0px !important; outline-offset: 0px !important; color: inherit; font-family: inherit; font-size: 13px;"><span class="ui-checkbox__box" data-disabled="true" aria-hidden="true" style="display: inline-flex; align-items: center; justify-content: center; transition-property: color, background-color, border-color, opacity, transform; transition-duration: 150ms; transition-timing-function: ease; box-sizing: border-box; width: 12px; height: 12px; color: rgb(25, 28, 34); border-color: color(srgb 0.894118 0.894118 0.894118 / 0.184314); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); opacity: 0.5;"></span></span><span> </span>Open the dataset detail page →<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Download</span><span> </span>(single dataset,<span> </span><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">downloadByIds</code>).</li><li class="py-1 [&amp;&gt;p]:inline task-list-item" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;"><span class="ui-checkbox" data-size="compact" data-variant="neutral" aria-disabled="true" style="display: inline-flex; align-items: center; justify-content: center; position: relative; cursor: default; top: 1px; margin-right: 0.4em;"><input disabled="" class="ui-checkbox__input" aria-label="Incomplete task" type="checkbox" style="padding: 0px; margin: 0px; position: absolute; inset: 0px; opacity: 0; cursor: inherit; outline: transparent none 0px !important; outline-offset: 0px !important; color: inherit; font-family: inherit; font-size: 13px;"><span class="ui-checkbox__box" data-disabled="true" aria-hidden="true" style="display: inline-flex; align-items: center; justify-content: center; transition-property: color, background-color, border-color, opacity, transform; transition-duration: 150ms; transition-timing-function: ease; box-sizing: border-box; width: 12px; height: 12px; color: rgb(25, 28, 34); border-color: color(srgb 0.894118 0.894118 0.894118 / 0.184314); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); opacity: 0.5;"></span></span><span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Expected:</span><span> </span>No<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Dataset files format</span><span> </span>/<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Nifti converter</span><span> </span>fields in the modal.</li><li class="py-1 [&amp;&gt;p]:inline task-list-item" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;"><span class="ui-checkbox" data-size="compact" data-variant="neutral" aria-disabled="true" style="display: inline-flex; align-items: center; justify-content: center; position: relative; cursor: default; top: 1px; margin-right: 0.4em;"><input disabled="" class="ui-checkbox__input" aria-label="Incomplete task" type="checkbox" style="padding: 0px; margin: 0px; position: absolute; inset: 0px; opacity: 0; cursor: inherit; outline: transparent none 0px !important; outline-offset: 0px !important; color: inherit; font-family: inherit; font-size: 13px;"><span class="ui-checkbox__box" data-disabled="true" aria-hidden="true" style="display: inline-flex; align-items: center; justify-content: center; transition-property: color, background-color, border-color, opacity, transform; transition-duration: 150ms; transition-timing-function: ease; box-sizing: border-box; width: 12px; height: 12px; color: rgb(25, 28, 34); border-color: color(srgb 0.894118 0.894118 0.894118 / 0.184314); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); opacity: 0.5;"></span></span><span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Expected:</span><span> </span>Download succeeds and the zip contains the<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">.nii.gz</code><span> </span>(or other non-DICOM file) as stored.</li><li class="py-1 [&amp;&gt;p]:inline task-list-item" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;"><span class="ui-checkbox" data-size="compact" data-variant="neutral" aria-disabled="true" style="display: inline-flex; align-items: center; justify-content: center; position: relative; cursor: default; top: 1px; margin-right: 0.4em;"><input disabled="" class="ui-checkbox__input" aria-label="Incomplete task" type="checkbox" style="padding: 0px; margin: 0px; position: absolute; inset: 0px; opacity: 0; cursor: inherit; outline: transparent none 0px !important; outline-offset: 0px !important; color: inherit; font-family: inherit; font-size: 13px;"><span class="ui-checkbox__box" data-disabled="true" aria-hidden="true" style="display: inline-flex; align-items: center; justify-content: center; transition-property: color, background-color, border-color, opacity, transform; transition-duration: 150ms; transition-timing-function: ease; box-sizing: border-box; width: 12px; height: 12px; color: rgb(25, 28, 34); border-color: color(srgb 0.894118 0.894118 0.894118 / 0.184314); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); opacity: 0.5;"></span></span><span> </span>Repeat with an<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">MR</span><span> </span>dataset in the same study →<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Expected:</span><span> </span>DICOM/NIfTI format options still appear.</li><li class="py-1 [&amp;&gt;p]:inline task-list-item" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;"><span class="ui-checkbox" data-size="compact" data-variant="neutral" aria-disabled="true" style="display: inline-flex; align-items: center; justify-content: center; position: relative; cursor: default; top: 1px; margin-right: 0.4em;"><input disabled="" class="ui-checkbox__input" aria-label="Incomplete task" type="checkbox" style="padding: 0px; margin: 0px; position: absolute; inset: 0px; opacity: 0; cursor: inherit; outline: transparent none 0px !important; outline-offset: 0px !important; color: inherit; font-family: inherit; font-size: 13px;"><span class="ui-checkbox__box" data-disabled="true" aria-hidden="true" style="display: inline-flex; align-items: center; justify-content: center; transition-property: color, background-color, border-color, opacity, transform; transition-duration: 150ms; transition-timing-function: ease; box-sizing: border-box; width: 12px; height: 12px; color: rgb(25, 28, 34); border-color: color(srgb 0.894118 0.894118 0.894118 / 0.184314); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); opacity: 0.5;"></span></span><span> </span>Mixed selection (MR + Generic) →<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Expected:</span><span> </span>format options still appear (MR requires them).</li><li class="py-1 [&amp;&gt;p]:inline task-list-item" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;"><span class="ui-checkbox" data-size="compact" data-variant="neutral" aria-disabled="true" style="display: inline-flex; align-items: center; justify-content: center; position: relative; cursor: default; top: 1px; margin-right: 0.4em;"><input disabled="" class="ui-checkbox__input" aria-label="Incomplete task" type="checkbox" style="padding: 0px; margin: 0px; position: absolute; inset: 0px; opacity: 0; cursor: inherit; outline: transparent none 0px !important; outline-offset: 0px !important; color: inherit; font-family: inherit; font-size: 13px;"><span class="ui-checkbox__box" data-disabled="true" aria-hidden="true" style="display: inline-flex; align-items: center; justify-content: center; transition-property: color, background-color, border-color, opacity, transform; transition-duration: 150ms; transition-timing-function: ease; box-sizing: border-box; width: 12px; height: 12px; color: rgb(25, 28, 34); border-color: color(srgb 0.894118 0.894118 0.894118 / 0.184314); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); opacity: 0.5;"></span></span><span> </span>Regression: download MR as Dicom and as Nifti (with converter) still works.</li><li class="py-1 [&amp;&gt;p]:inline task-list-item" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;"><span class="ui-checkbox" data-size="compact" data-variant="neutral" aria-disabled="true" style="display: inline-flex; align-items: center; justify-content: center; position: relative; cursor: default; top: 1px; margin-right: 0.4em;"><input disabled="" class="ui-checkbox__input" aria-label="Incomplete task" type="checkbox" style="padding: 0px; margin: 0px; position: absolute; inset: 0px; opacity: 0; cursor: inherit; outline: transparent none 0px !important; outline-offset: 0px !important; color: inherit; font-family: inherit; font-size: 13px;"><span class="ui-checkbox__box" data-disabled="true" aria-hidden="true" style="display: inline-flex; align-items: center; justify-content: center; transition-property: color, background-color, border-color, opacity, transform; transition-duration: 150ms; transition-timing-function: ease; box-sizing: border-box; width: 12px; height: 12px; color: rgb(25, 28, 34); border-color: color(srgb 0.894118 0.894118 0.894118 / 0.184314); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; border-radius: 4px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); opacity: 0.5;"></span></span><span> </span>Optional: verify<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">POST /datasets/allById</code><span> </span>returns<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">"type": "Generic"</code><span> </span>(not<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">"GENERIC"</code>) for a Generic dataset.</li></ul><h2 class="mt-6 mb-2 font-semibold text-2xl" data-streamdown="heading-2" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 10px; --tw-font-weight: 600; font-weight: 600; color: rgba(228, 228, 228, 0.92); line-height: 1.25; font-size: 1.3em; margin-top: 20px; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Notes for reviewers</h2><ul class="list-inside list-disc whitespace-normal [li_&amp;]:pl-6" data-streamdown="unordered-list" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; list-style-type: disc; white-space: normal; padding-left: 2em; display: flex !important; flex-direction: column !important; gap: 6px !important; margin: 6px 0px !important; color: rgba(228, 228, 228, 0.92); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">Backend download logic (<code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">DatasetDownloaderServiceImpl</code>) was already correct for<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">NIFTI_SINGLE_FILE</code>; only the<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">UI gate</span><span> </span>was wrong.</li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">VIP outputs also create separate datasets per output file (e.g.<span> </span><code class="md-inline-path-filename-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;"><span class="md-inline-path-filename">.json</span></code><span> </span>vs<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">.nii.gz</code>); users must select the<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;"><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">.nii.gz</code></span><span> </span>node before download.</li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">Unrelated: VIP executions still hardcode processing type<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">SEGMENTATION</code><span> </span>in<span> </span><code class="md-clickable-code md-inline-path-filename-like" role="button" tabindex="0" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: rgb(129, 161, 193); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all; cursor: pointer;"><span class="md-inline-path-filename">execution.component.ts</span></code><span> </span>(separate issue).</li></ul><br class="Apple-interchange-newline"><!--EndFragment-->
</body>
</html>