### PR TITLE
fix(front): enable save when form becomes dirty without status change

### DIFF
--- a/shanoir-ng-front/src/app/shared/components/entity/entity.component.abstract.ts
+++ b/shanoir-ng-front/src/app/shared/components/entity/entity.component.abstract.ts
@@ -25,7 +25,7 @@ import {
 } from '@angular/core';
 import { AbstractControl, FormArray, FormGroup, UntypedFormBuilder, UntypedFormGroup, ValidationErrors } from '@angular/forms';
 import { ActivatedRoute, NavigationExtras, Router } from '@angular/router';
-import { firstValueFrom, Subject, Subscription } from 'rxjs';
+import { firstValueFrom, merge, Subject, Subscription } from 'rxjs';
 
 import { Selection, TreeService } from 'src/app/studies/study/tree.service';
 import { SuperPromise } from 'src/app/utils/super-promise';
@@ -303,15 +303,23 @@ export abstract class EntityComponent<T extends Entity> implements OnInit, OnDes
         }
     }
 
+    private updateFooterState(): void {
+        if (!this.form || !this.footerState) return;
+        this.footerState.valid = this.form.status === 'VALID' && (this.form.dirty || this.mode === 'create');
+        this.footerState.dirty = this.form.dirty;
+    }
+
     private manageFormSubscriptions() {
         this.form = this.buildForm();
         this.form$.resolve();
         if (this.form) {
+            this.updateFooterState();
             this.subscriptions.push(
-                this.form.statusChanges.subscribe(status => {
-                    this.footerState.valid = status == 'VALID' && (this.form.dirty || this.mode == 'create');
-                    this.footerState.dirty = this.form.dirty;
-                }),
+                merge(
+                    this.form.statusChanges,
+                    this.form.valueChanges,
+                    this.form.events,
+                ).subscribe(() => this.updateFooterState()),
             );
             this.subscribeEntityPropsUpdatesFromForm(this.form, this._entity);
             if (this.mode != 'view') setTimeout(() => this.styleRequiredLabels());
@@ -565,7 +573,7 @@ export abstract class EntityComponent<T extends Entity> implements OnInit, OnDes
                 fieldControl.updateValueAndValidity({emitEvent: false});
                 if (!fieldControl.valid) fieldControl.markAsTouched();
             }
-            this.footerState.valid = this.form.status == 'VALID';
+            this.updateFooterState();
             return null;
         } else {
             throw reason;


### PR DESCRIPTION
## Summary

Fixes the footer **Update** / **Save** button staying disabled when the form becomes dirty without a validation status change (e.g. adding a center on study edit).

## Issue

Update button stays disabled when adding a center.

When editing a study that already has at least one center, adding another center on the **Centers** tab does not enable the **Update** button, although the form was changed.

### Steps to reproduce

1. Open a study that already has one or more centers.
2. Click **Edit**.
3. Go to **Centers**, add a center with the **+** control.
4. Observe the **Update** button in the footer.

### Expected

**Update** becomes enabled so the new center can be saved.

### Actual

**Update** stays gray/disabled until another field triggers a validation status change (e.g. editing **End date** on General).

### Cause

In `EntityComponent.manageFormSubscriptions()`, `footerState.valid` is updated only on `form.statusChanges`. Adding a center marks the form dirty via `studyCenterList` but often does not change validation status, so the footer is not refreshed.

### Environment

- Shanoir-NG front (Angular), study edit mode
- Reproduced on 2.11.x

## Changes

- `entity.component.abstract.ts`: recompute `footerState` on `statusChanges`, `valueChanges`, and `form.events`.

## How to test

1. Edit a study with ≥1 center → **Centers** → add a center → **Update** enables (no need to edit end date).
2. Regression: edit any entity form, change a field, confirm save still enables when valid.