### PR TITLE
fix(study): correct end date validation and sync study centers to form

### DIFF
--- a/shanoir-ng-front/src/app/studies/study/study.component.ts
+++ b/shanoir-ng-front/src/app/studies/study/study.component.ts
@@ -13,7 +13,7 @@
  */
 import { KeyValue } from "@angular/common";
 import { Component, ElementRef, ViewChild } from '@angular/core';
-import { UntypedFormGroup, ValidationErrors, Validators } from '@angular/forms';
+import { AbstractControl, UntypedFormGroup, ValidationErrors, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 
 import { TaskState } from 'src/app/async-tasks/task.model';
@@ -290,6 +290,10 @@ export class StudyComponent extends EntityComponent<Study> {
 
         formGroup.setValidators(this.inclusionRatePairValidator.bind(this));
 
+        formGroup.get('startDate')?.valueChanges.subscribe(() => {
+            formGroup.get('endDate')?.updateValueAndValidity();
+        });
+
         return formGroup;
     }
 
@@ -328,11 +332,24 @@ export class StudyComponent extends EntityComponent<Study> {
         });
     }
 
-    private dateOrdervalidator = (): ValidationErrors | null => {
-        if (this.study.startDate && this.study.endDate && this.study.startDate >= this.study.endDate) {
-            return { order: true}
-        }
+    /** Uses form control values (not study entity) to avoid stale dates when the end date picker changes. */
+    private dateOrdervalidator = (control: AbstractControl): ValidationErrors | null => {
+        const form = control.parent;
+        if (!form) return null;
+        const start = form.get('startDate')?.value;
+        const end = control.value;
+        if (!start || !end || start === 'invalid' || end === 'invalid') return null;
+        const startDay = this.toDateOnlyTimestamp(start);
+        const endDay = this.toDateOnlyTimestamp(end);
+        if (startDay === null || endDay === null) return null;
+        if (endDay <= startDay) return { order: true };
         return null;
+    }
+
+    private toDateOnlyTimestamp(value: Date | string): number | null {
+        const date = value instanceof Date ? value : new Date(value);
+        if (isNaN(date.getTime())) return null;
+        return Date.UTC(date.getFullYear(), date.getMonth(), date.getDate());
     }
 
     public async hasStudyAdminRight(): Promise<boolean> {
@@ -424,8 +441,10 @@ export class StudyComponent extends EntityComponent<Study> {
             this.study.studyCenterList = [...this.study.studyCenterList];
             this.centerOptions.forEach(option => option.disabled = this.study.studyCenterList.findIndex(studyCenter => studyCenter.center.id == option.value.id) != -1);
         }
-        this.form.get('studyCenterList').markAsDirty();
-        this.form.get('studyCenterList').updateValueAndValidity();
+        const studyCenterListControl = this.form.get('studyCenterList');
+        studyCenterListControl.setValue([...this.study.studyCenterList]);
+        studyCenterListControl.markAsDirty();
+        studyCenterListControl.updateValueAndValidity();
     }
 
     onPrefixChange() {
@@ -444,8 +463,10 @@ export class StudyComponent extends EntityComponent<Study> {
         if (!this.study.studyCenterList) return;
         this.study.studyCenterList = this.study.studyCenterList.filter(item => item.center.id !== centerId);
         this.centerOptions.forEach(option => option.disabled = this.study.studyCenterList.findIndex(studyCenter => studyCenter.center.id == option.value.id) != -1);
-        this.form.get('studyCenterList').markAsDirty();
-        this.form.get('studyCenterList').updateValueAndValidity();
+        const studyCenterListControl = this.form.get('studyCenterList');
+        studyCenterListControl.setValue([...this.study.studyCenterList]);
+        studyCenterListControl.markAsDirty();
+        studyCenterListControl.updateValueAndValidity();
     }
 
     isMe(user: User): boolean {


### PR DESCRIPTION
## Summary

Fixes study edit blocked by a false end-date order error and improves center list handling on save.

## Issue

On study edit, the form can remain invalid with **"End date must be subsequent to start date"** even when start and end dates look correct (e.g. 23/03/2026 and 23/04/2026). Changing the end date several times sometimes clears the error and enables **Update**.

### Steps to reproduce

1. Edit a study with valid start/end dates.
2. Open **General** tab (end date is editable; start date is read-only in edit mode).
3. Optionally go to **Centers** and add a center.
4. **Update** stays disabled; end date error may appear after interacting with the end date field.

### Expected

If end date is after start date on the form, no order error and **Update** can enable when the form is dirty and valid.

### Actual

`dateOrdervalidator` in `StudyComponent` compares `this.study.startDate` / `this.study.endDate` instead of form control values, so validation can run on stale entity state when the datepicker updates `endDate`.

## Changes

- `study.component.ts`: date order validator uses form values; date-only comparison; revalidate end date when start date changes; `setValue` on `studyCenterList` when adding/removing centers.

## How to test

1. Edit study with start 23/03/2026, end 23/04/2026 → **Update** can enable without false order error.
2. Set end before start → error shown, **Update** disabled.
3. Add center → save → reload → new center persisted.