### PR TITLE
Fix BIDS import examination date from scans.tsv and sessions.tsv.

### DIFF
--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/bids/BidsExaminationDateResolution.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/bids/BidsExaminationDateResolution.java
@@ -1,0 +1,95 @@
+/**
+ * Shanoir NG - Import, manage and share neuroimaging data
+ * Copyright (C) 2009-2019 Inria - https://www.inria.fr/
+ * Contact us on https://project.inria.fr/shanoir/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+package org.shanoir.ng.importer.bids;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.attribute.FileTime;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Resolves examination date for BIDS import with explicit source for logging/events.
+ */
+public final class BidsExaminationDateResolution {
+
+    private final LocalDate date;
+    private final String sourceDescription;
+    private final boolean fallback;
+
+    public BidsExaminationDateResolution(LocalDate date, String sourceDescription, boolean fallback) {
+        this.date = date;
+        this.sourceDescription = sourceDescription;
+        this.fallback = fallback;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public String getSourceDescription() {
+        return sourceDescription;
+    }
+
+    public boolean isFallback() {
+        return fallback;
+    }
+
+    public String formatEventMessage() {
+        if (fallback) {
+            return "Warning: " + sourceDescription + " (date: " + date + ")";
+        }
+        return "Examination date from " + sourceDescription + " (" + date + ")";
+    }
+
+    /**
+     * Priority: sessions.tsv (matching session) → scans.tsv (earliest acq_time) → folder creation time.
+     */
+    public static BidsExaminationDateResolution resolve(File sessionFolder, String sessionLabel,
+            Map<String, LocalDate> sessionDatesFromSubjectTsv, FileTime folderCreationTime, ZoneId fallbackZone)
+            throws IOException {
+        LocalDate fromSessions = BidsTsvDateParser.lookupSessionDate(sessionDatesFromSubjectTsv, sessionLabel);
+        if (fromSessions != null) {
+            return new BidsExaminationDateResolution(fromSessions,
+                    "sub-*_sessions.tsv (acq_time for session " + sessionLabel + ")", false);
+        }
+        Optional<LocalDate> fromScans = BidsTsvDateParser.readEarliestAcqTimeFromScansFolder(sessionFolder);
+        if (fromScans.isPresent()) {
+            return new BidsExaminationDateResolution(fromScans.get(),
+                    "session *_scans.tsv (earliest acq_time)", false);
+        }
+        LocalDate fallbackDate = LocalDate.ofInstant(folderCreationTime.toInstant(), fallbackZone);
+        return new BidsExaminationDateResolution(fallbackDate,
+                "folder creation time — no parseable acq_time in sessions.tsv or scans.tsv", true);
+    }
+
+    /**
+     * For subject folder without {@code ses-*} subfolders: scans.tsv then folder date (UTC).
+     */
+    public static BidsExaminationDateResolution resolveWithoutSessionFolder(File subjectOrSessionFolder,
+            FileTime folderCreationTime) throws IOException {
+        Optional<LocalDate> fromScans = BidsTsvDateParser.readEarliestAcqTimeFromScansFolder(subjectOrSessionFolder);
+        if (fromScans.isPresent()) {
+            return new BidsExaminationDateResolution(fromScans.get(),
+                    "*_scans.tsv (earliest acq_time)", false);
+        }
+        LocalDate fallbackDate = LocalDate.ofInstant(folderCreationTime.toInstant(), ZoneOffset.UTC);
+        return new BidsExaminationDateResolution(fallbackDate,
+                "folder creation time — no parseable acq_time in scans.tsv", true);
+    }
+}

--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/bids/BidsImporterApiController.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/bids/BidsImporterApiController.java
@@ -21,14 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.TemporalAccessor;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.shanoir.ng.importer.ImporterApiController;
@@ -59,10 +52,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.csv.CsvMapper;
-import com.fasterxml.jackson.dataformat.csv.CsvParser;
 
 import io.swagger.v3.oas.annotations.Parameter;
 
@@ -81,8 +71,6 @@ public class BidsImporterApiController implements BidsImporterApi {
     private static final String SUBJECT_CREATION_ERROR = "An error occured during the subject creation, please check your rights.";
 
     private static final String EXAMINATION_CREATION_ERROR = "An error occured during the examination creation, please check your rights.";
-
-    private static final String CSV_SEPARATOR = "\t";
 
     @Autowired
     private ImporterApiController importer;
@@ -159,7 +147,7 @@ public class BidsImporterApiController implements BidsImporterApi {
 
 
             // STEP 3: Examination level, check if there are session, otherwise create examinations
-            Map<String, LocalDate> examDates = checkDatesFromSessionFile(subjectFile);
+            Map<String, LocalDate> examDates = BidsTsvDateParser.readDatesFromSessionsFile(subjectFile);
             // Filter out scans.tsv and sessions.tsv files
             File[] examFiles = subjectFile.listFiles(new FilenameFilter() {
                 @Override
@@ -178,18 +166,17 @@ public class BidsImporterApiController implements BidsImporterApi {
                 // STEP 3.1 There is a session level
                 if (sessionFile.getName().startsWith("ses-")) {
                     String sessionLabel = sessionFile.getName().substring(sessionFile.getName().indexOf("ses-") + "ses-".length());
-                    LocalDate examDate = examDates.get(sessionLabel);
-
-                    // Check for scans.tsv if session does not exist
-                    if (examDate == null) {
-                        examDate = checkDateFromScansFile(sessionFile);
+                    BidsExaminationDateResolution dateResolution = BidsExaminationDateResolution.resolve(
+                            sessionFile, sessionLabel, examDates, creationTime, ZoneId.systemDefault());
+                    if (dateResolution.isFallback()) {
+                        LOG.warn("BIDS import subject [{}] session [{}]: {}", subjectName, sessionLabel,
+                                dateResolution.getSourceDescription());
+                    } else {
+                        LOG.info("BIDS import subject [{}] session [{}]: examination date {} from {}",
+                                subjectName, sessionLabel, dateResolution.getDate(), dateResolution.getSourceDescription());
                     }
-
-                    // Set file creation as default
-                    if (examDate == null) {
-                        examDate = LocalDate.ofInstant(creationTime.toInstant(), ZoneId.systemDefault());
-                    }
-                    examination = ImportUtils.createExam(studyId, centerId, subjectId, sessionLabel, examDate, subjectName);
+                    examination = ImportUtils.createExam(studyId, centerId, subjectId, sessionLabel,
+                            dateResolution.getDate(), subjectName);
                     examCreated = true;
 
                     // Create multiple examinations for every session folder
@@ -198,7 +185,7 @@ public class BidsImporterApiController implements BidsImporterApi {
                     if (examId == null) {
                         throw new RestServiceException(new ErrorModel(HttpStatus.UNPROCESSABLE_ENTITY.value(), EXAMINATION_CREATION_ERROR, null));
                     }
-                    eventService.publishEvent(new ShanoirEvent(ShanoirEventType.CREATE_EXAMINATION_EVENT, examId.toString(), KeycloakUtil.getTokenUserId(), "centerId:" + centerId + ";subjectId:" + examination.getSubject().getId(), ShanoirEvent.SUCCESS, examination.getStudyId()));
+                    publishExaminationCreatedEvent(examId, examination, centerId, dateResolution);
 
                     importJob.setExaminationId(examId);
 
@@ -216,19 +203,19 @@ public class BidsImporterApiController implements BidsImporterApi {
                 } else {
                     // STEP 3.2 No session level
                     if (!examCreated) {
-                        // Try to find acqusition_time in _scans.tsv file
-                        LocalDate examDate = checkDateFromScansFile(sessionFile);
-                        if (examDate == null) {
-                            // Set exam date by default using file creation date
-                            examDate = LocalDate.ofInstant(creationTime.toInstant(), ZoneOffset.UTC);
+                        BidsExaminationDateResolution dateResolution = BidsExaminationDateResolution
+                                .resolveWithoutSessionFolder(sessionFile, creationTime);
+                        if (dateResolution.isFallback()) {
+                            LOG.warn("BIDS import subject [{}]: {}", subjectName, dateResolution.getSourceDescription());
                         }
-                        examination = ImportUtils.createExam(studyId, centerId, subjectId, "", examDate, subjectName);
+                        examination = ImportUtils.createExam(studyId, centerId, subjectId, "",
+                                dateResolution.getDate(), subjectName);
                         examId = (Long) rabbitTemplate.convertSendAndReceive(RabbitMQConfiguration.EXAMINATION_CREATION_QUEUE, objectMapper.writeValueAsString(examination));
 
                         if (examId == null) {
                             throw new RestServiceException(new ErrorModel(HttpStatus.UNPROCESSABLE_ENTITY.value(), EXAMINATION_CREATION_ERROR, null));
                         }
-                        eventService.publishEvent(new ShanoirEvent(ShanoirEventType.CREATE_EXAMINATION_EVENT, examId.toString(), KeycloakUtil.getTokenUserId(), "centerId:" + centerId + ";subjectId:" + examination.getSubject().getId(), ShanoirEvent.SUCCESS, examination.getStudyId()));
+                        publishExaminationCreatedEvent(examId, examination, centerId, dateResolution);
 
                         importJob.setExaminationId(examId);
                         examCreated = true;
@@ -242,110 +229,12 @@ public class BidsImporterApiController implements BidsImporterApi {
         return new ResponseEntity<>(null, HttpStatus.OK);
     }
 
-    /**
-     * This methods check if a _scans.tsv exists in the folder, and load the date of the first reference
-     * @param parentFile the parent folder where the scancs.tsv file can be found
-     * @return the first found date in the tsv file, null otherwise
-     * @throws IOException when the file reading fails.
-     */
-    private LocalDate checkDateFromScansFile(File parentFile) throws IOException {
-        File[] scansFiles = parentFile.listFiles(new FilenameFilter() {
-            @Override
-            public boolean accept(File dir, String name) {
-                return name.endsWith("_scans.tsv");
-            }
-        });
-
-        // We found _scans.tsv file
-        if (scansFiles.length != 1) {
-            return null;
-        }
-
-        File scanFile = scansFiles[0];
-
-        CsvMapper mapper = new CsvMapper();
-        mapper.enable(CsvParser.Feature.WRAP_AS_ARRAY);
-        MappingIterator<String[]> it = mapper.readerFor(String[].class).readValues(scanFile);
-
-        // Check that the list of column is known
-        List<String> columns = Arrays.asList(it.next()[0].split(CSV_SEPARATOR));
-
-        int dateIndex = columns.indexOf("acq_time");
-
-        // If there is no date, just give up
-        if (dateIndex == -1) {
-            return null;
-        }
-        // Legal format in BIDS (are we up to date ? I don't think so)
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss[.SSSSSS][X]");
-        String[] row = it.next()[0].split(CSV_SEPARATOR);
-        String dateAsString = row[dateIndex];
-        try {
-            TemporalAccessor date = formatter.parseBest(dateAsString, LocalDate::from, LocalDateTime::from);
-            return LocalDate.from(date);
-        } catch (Exception e) {
-            LOG.error("Could not parse date [{}] for csv.", dateAsString);
-            return null;
-        }
-    }
-
-    /**
-     * This methods check if a _sessions.tsv file exists in the folder, and load the dates for every referenced session
-     * @param parentFile the parent folder where the sessions.tsv file can be found
-     * @return a Map of sessionID -> Date, an empty Hashset otherwise.
-     * @throws IOException when the file reading fails.
-     */
-    private Map<String, LocalDate> checkDatesFromSessionFile(File parentFile) throws IOException {
-        // Try to find sub-<label>_sessions.tsv file
-        Map<String, LocalDate> examDates = new HashMap<String, LocalDate>();
-        File[] sessionFiles = parentFile.listFiles(new FilenameFilter() {
-            @Override
-            public boolean accept(File dir, String name) {
-                return name.endsWith("_sessions.tsv");
-            }
-        });
-
-        // We found session_tsv file
-        if (sessionFiles.length != 1) {
-            return examDates;
-        }
-        File sessionFile = sessionFiles[0];
-
-        // session_id;acq_time;pathology
-        // analyze date for every session
-        CsvMapper mapper = new CsvMapper();
-        mapper.enable(CsvParser.Feature.WRAP_AS_ARRAY);
-        MappingIterator<String[]> it = mapper.readerFor(String[].class).readValues(sessionFile);
-
-        // Check File is not empty
-        if (sessionFile.length() > 0) {
-            LOG.error("We found a non empty session.tsv file ");
-            // Check that the list of column is known
-            List<String> columns = Arrays.asList(it.next()[0].split(CSV_SEPARATOR));
-            int sessionIdIndex = columns.indexOf("session_id");
-            int dateIndex = columns.indexOf("acq_time");
-
-            // If there is no date, just give up
-            if (dateIndex == -1) {
-                return examDates;
-            }
-
-            // Legal format in BIDS (are we up to date ? I don't think so)
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("YYYY-MM-DDThh:mm:ss[.000000][Z]");
-
-            while (it.hasNext()) {
-                String[] row = it.next()[0].split(CSV_SEPARATOR);
-                String sessionLabel = row[sessionIdIndex];
-                String dateAsString = row[dateIndex];
-                TemporalAccessor date = formatter.parseBest(dateAsString, LocalDate::from);
-                examDates.put(sessionLabel, LocalDate.from(date));
-            }
-        } else {
-            LOG.error("We found an empty session.tsv file ");
-            return examDates;
-        }
-
-        return examDates;
+    private void publishExaminationCreatedEvent(Long examId, ExaminationDTO examination, Long centerId,
+            BidsExaminationDateResolution dateResolution) {
+        String message = dateResolution.formatEventMessage() + ";centerId:" + centerId + ";subjectId:"
+                + examination.getSubject().getId();
+        eventService.publishEvent(new ShanoirEvent(ShanoirEventType.CREATE_EXAMINATION_EVENT, examId.toString(),
+                KeycloakUtil.getTokenUserId(), message, ShanoirEvent.SUCCESS, examination.getStudyId()));
     }
 
     /**

--- a/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/bids/BidsTsvDateParser.java
+++ b/shanoir-ng-import/src/main/java/org/shanoir/ng/importer/bids/BidsTsvDateParser.java
@@ -1,0 +1,244 @@
+/**
+ * Shanoir NG - Import, manage and share neuroimaging data
+ * Copyright (C) 2009-2019 Inria - https://www.inria.fr/
+ * Contact us on https://project.inria.fr/shanoir/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+package org.shanoir.ng.importer.bids;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.MappingIterator;
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvParser;
+
+/**
+ * Parses BIDS {@code acq_time} values from {@code *_sessions.tsv} and {@code *_scans.tsv} files.
+ */
+public final class BidsTsvDateParser {
+
+    static final String CSV_SEPARATOR = "\t";
+
+    private static final Logger LOG = LoggerFactory.getLogger(BidsTsvDateParser.class);
+
+    private BidsTsvDateParser() {
+    }
+
+    /**
+     * Parses a BIDS {@code acq_time} value into a {@link LocalDate}.
+     */
+    public static Optional<LocalDate> parseAcqTime(String dateAsString) {
+        if (dateAsString == null) {
+            return Optional.empty();
+        }
+        String trimmed = dateAsString.trim();
+        if (trimmed.isEmpty() || "n/a".equalsIgnoreCase(trimmed)) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(LocalDate.parse(trimmed, DateTimeFormatter.ISO_LOCAL_DATE));
+        } catch (DateTimeParseException ignored) {
+            // continue
+        }
+        try {
+            return Optional.of(LocalDateTime.parse(trimmed, DateTimeFormatter.ISO_LOCAL_DATE_TIME).toLocalDate());
+        } catch (DateTimeParseException ignored) {
+            // continue
+        }
+        try {
+            return Optional.of(OffsetDateTime.parse(trimmed, DateTimeFormatter.ISO_OFFSET_DATE_TIME).toLocalDate());
+        } catch (DateTimeParseException ignored) {
+            // continue
+        }
+        try {
+            return Optional.of(ZonedDateTime.parse(trimmed, DateTimeFormatter.ISO_ZONED_DATE_TIME).toLocalDate());
+        } catch (DateTimeParseException ignored) {
+            // continue
+        }
+        try {
+            return Optional.of(Instant.parse(trimmed).atZone(ZoneId.of("UTC")).toLocalDate());
+        } catch (DateTimeParseException ignored) {
+            // continue
+        }
+        try {
+            DateTimeFormatter flexible = DateTimeFormatter.ofPattern("yyyy-MM-dd['T'][ ]HH:mm:ss[.SSSSSSSSS][.SSSSSS][.SSS][XXX][X][Z]");
+            return Optional.of(LocalDateTime.parse(trimmed, flexible).toLocalDate());
+        } catch (DateTimeParseException | IllegalArgumentException e) {
+            LOG.debug("Could not parse BIDS acq_time [{}]", trimmed);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Reads session dates from {@code sub-*_sessions.tsv} at subject level.
+     * Keys are normalized session labels (without {@code ses-} prefix when present in TSV).
+     */
+    public static Map<String, LocalDate> readDatesFromSessionsFile(File subjectFolder) throws IOException {
+        Map<String, LocalDate> examDates = new HashMap<>();
+        File[] sessionFiles = subjectFolder.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return name.endsWith("_sessions.tsv");
+            }
+        });
+        if (sessionFiles == null || sessionFiles.length != 1 || sessionFiles[0].length() == 0) {
+            return examDates;
+        }
+        File sessionFile = sessionFiles[0];
+        CsvMapper mapper = new CsvMapper();
+        mapper.enable(CsvParser.Feature.WRAP_AS_ARRAY);
+        try (MappingIterator<String[]> it = mapper.readerFor(String[].class).readValues(sessionFile)) {
+            if (!it.hasNext()) {
+                return examDates;
+            }
+            List<String> columns = parseHeaderColumns(it.next()[0]);
+            int sessionIdIndex = indexOfColumn(columns, "session_id");
+            int dateIndex = indexOfColumn(columns, "acq_time");
+            if (dateIndex == -1) {
+                LOG.warn("No acq_time column in sessions file [{}]", sessionFile.getName());
+                return examDates;
+            }
+            while (it.hasNext()) {
+                String[] row = splitRow(it.next()[0], columns.size());
+                if (row.length <= dateIndex) {
+                    continue;
+                }
+                String sessionId = sessionIdIndex >= 0 && row.length > sessionIdIndex ? row[sessionIdIndex].trim() : "";
+                Optional<LocalDate> parsed = parseAcqTime(row[dateIndex]);
+                if (parsed.isEmpty()) {
+                    LOG.warn("Could not parse acq_time [{}] in sessions file [{}] for session [{}]",
+                            row[dateIndex], sessionFile.getName(), sessionId);
+                    continue;
+                }
+                putSessionDate(examDates, sessionId, parsed.get());
+            }
+        }
+        return examDates;
+    }
+
+    /**
+     * Reads the earliest valid {@code acq_time} from {@code *_scans.tsv} in the given folder.
+     */
+    public static Optional<LocalDate> readEarliestAcqTimeFromScansFolder(File parentFolder) throws IOException {
+        File[] scansFiles = parentFolder.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return name.endsWith("_scans.tsv");
+            }
+        });
+        if (scansFiles == null || scansFiles.length != 1 || scansFiles[0].length() == 0) {
+            return Optional.empty();
+        }
+        File scanFile = scansFiles[0];
+        CsvMapper mapper = new CsvMapper();
+        mapper.enable(CsvParser.Feature.WRAP_AS_ARRAY);
+        try (MappingIterator<String[]> it = mapper.readerFor(String[].class).readValues(scanFile)) {
+            if (!it.hasNext()) {
+                return Optional.empty();
+            }
+            List<String> columns = parseHeaderColumns(it.next()[0]);
+            int dateIndex = indexOfColumn(columns, "acq_time");
+            if (dateIndex == -1) {
+                LOG.warn("No acq_time column in scans file [{}]", scanFile.getName());
+                return Optional.empty();
+            }
+            List<LocalDate> dates = new ArrayList<>();
+            while (it.hasNext()) {
+                String[] row = splitRow(it.next()[0], columns.size());
+                if (row.length <= dateIndex) {
+                    continue;
+                }
+                parseAcqTime(row[dateIndex]).ifPresent(dates::add);
+            }
+            if (dates.isEmpty()) {
+                LOG.warn("No parseable acq_time values in scans file [{}]", scanFile.getName());
+                return Optional.empty();
+            }
+            return dates.stream().min(Comparator.naturalOrder());
+        }
+    }
+
+    /**
+     * Looks up a session date using folder label ({@code t0}) or BIDS id ({@code ses-t0}).
+     */
+    public static LocalDate lookupSessionDate(Map<String, LocalDate> sessionDates, String sessionLabel) {
+        if (sessionDates == null || sessionLabel == null) {
+            return null;
+        }
+        LocalDate date = sessionDates.get(sessionLabel);
+        if (date != null) {
+            return date;
+        }
+        return sessionDates.get("ses-" + sessionLabel);
+    }
+
+    static List<String> parseHeaderColumns(String headerLine) {
+        return Arrays.stream(headerLine.split(CSV_SEPARATOR, -1))
+                .map(String::trim)
+                .collect(Collectors.toList());
+    }
+
+    static int indexOfColumn(List<String> columns, String name) {
+        for (int i = 0; i < columns.size(); i++) {
+            if (name.equalsIgnoreCase(columns.get(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    static String[] splitRow(String rowLine, int expectedColumns) {
+        String[] parts = rowLine.split(CSV_SEPARATOR, -1);
+        if (expectedColumns > 0 && parts.length < expectedColumns) {
+            String[] padded = new String[expectedColumns];
+            System.arraycopy(parts, 0, padded, 0, parts.length);
+            for (int i = parts.length; i < expectedColumns; i++) {
+                padded[i] = "";
+            }
+            return padded;
+        }
+        return parts;
+    }
+
+    private static void putSessionDate(Map<String, LocalDate> examDates, String sessionIdFromTsv, LocalDate date) {
+        if (sessionIdFromTsv == null || sessionIdFromTsv.isEmpty()) {
+            return;
+        }
+        String trimmed = sessionIdFromTsv.trim();
+        examDates.put(trimmed, date);
+        if (trimmed.startsWith("ses-")) {
+            examDates.put(trimmed.substring("ses-".length()), date);
+        } else {
+            examDates.put("ses-" + trimmed, date);
+        }
+    }
+}

--- a/shanoir-ng-import/src/test/java/org/shanoir/ng/importer/bids/BidsExaminationDateResolutionTest.java
+++ b/shanoir-ng-import/src/test/java/org/shanoir/ng/importer/bids/BidsExaminationDateResolutionTest.java
@@ -1,0 +1,78 @@
+/**
+ * Shanoir NG - Import, manage and share neuroimaging data
+ * Copyright (C) 2009-2019 Inria - https://www.inria.fr/
+ * Contact us on https://project.inria.fr/shanoir/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+package org.shanoir.ng.importer.bids;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class BidsExaminationDateResolutionTest {
+
+    @Test
+    void resolvePrefersSessionsTsv(@TempDir Path tempDir) throws IOException {
+        Path sessionDir = Files.createDirectory(tempDir.resolve("ses-t0"));
+        Map<String, LocalDate> sessions = Map.of("t0", LocalDate.of(2024, 6, 1));
+        FileTime folderTime = FileTime.from(Instant.parse("2026-05-29T12:00:00Z"));
+
+        BidsExaminationDateResolution resolution = BidsExaminationDateResolution.resolve(
+                sessionDir.toFile(), "t0", sessions, folderTime, ZoneId.systemDefault());
+
+        assertFalse(resolution.isFallback());
+        assertEquals(LocalDate.of(2024, 6, 1), resolution.getDate());
+        assertTrue(resolution.getSourceDescription().contains("sessions.tsv"));
+    }
+
+    @Test
+    void resolveUsesScansTsvWhenNoSessionDate(@TempDir Path tempDir) throws IOException {
+        Path sessionDir = tempDir.resolve("ses-t0");
+        Files.createDirectories(sessionDir);
+        Files.writeString(sessionDir.resolve("sub-117_ses-t0_scans.tsv"),
+                "filename\tacq_time\nscan.nii.gz\t2024-12-13T17:48:00\n");
+        FileTime folderTime = FileTime.from(Instant.parse("2026-05-29T12:00:00Z"));
+
+        BidsExaminationDateResolution resolution = BidsExaminationDateResolution.resolve(
+                sessionDir.toFile(), "t0", Collections.emptyMap(), folderTime, ZoneId.systemDefault());
+
+        assertFalse(resolution.isFallback());
+        assertEquals(LocalDate.of(2024, 12, 13), resolution.getDate());
+        assertTrue(resolution.getSourceDescription().contains("scans.tsv"));
+    }
+
+    @Test
+    void resolveFallbackToFolderTime(@TempDir Path tempDir) throws IOException {
+        Path sessionDir = Files.createDirectory(tempDir.resolve("ses-t0"));
+        FileTime folderTime = FileTime.from(Instant.parse("2026-05-29T12:00:00Z"));
+
+        BidsExaminationDateResolution resolution = BidsExaminationDateResolution.resolve(
+                sessionDir.toFile(), "t0", Collections.emptyMap(), folderTime, ZoneId.of("UTC"));
+
+        assertTrue(resolution.isFallback());
+        assertEquals(LocalDate.of(2026, 5, 29), resolution.getDate());
+        assertTrue(resolution.formatEventMessage().startsWith("Warning:"));
+    }
+}

--- a/shanoir-ng-import/src/test/java/org/shanoir/ng/importer/bids/BidsTsvDateParserTest.java
+++ b/shanoir-ng-import/src/test/java/org/shanoir/ng/importer/bids/BidsTsvDateParserTest.java
@@ -1,0 +1,106 @@
+/**
+ * Shanoir NG - Import, manage and share neuroimaging data
+ * Copyright (C) 2009-2019 Inria - https://www.inria.fr/
+ * Contact us on https://project.inria.fr/shanoir/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+package org.shanoir.ng.importer.bids;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class BidsTsvDateParserTest {
+
+    @Test
+    void parseAcqTimeIsoDateTime() {
+        assertEquals(LocalDate.of(2024, 12, 13),
+                BidsTsvDateParser.parseAcqTime("2024-12-13T17:48:00").get());
+    }
+
+    @Test
+    void parseAcqTimeWithFractionalSeconds() {
+        assertEquals(LocalDate.of(2024, 12, 13),
+                BidsTsvDateParser.parseAcqTime("2024-12-13T17:48:00.123456").get());
+    }
+
+    @Test
+    void parseAcqTimeWithZuluOffset() {
+        assertEquals(LocalDate.of(2024, 12, 13),
+                BidsTsvDateParser.parseAcqTime("2024-12-13T17:48:00Z").get());
+    }
+
+    @Test
+    void parseAcqTimeDateOnly() {
+        assertEquals(LocalDate.of(2024, 12, 13),
+                BidsTsvDateParser.parseAcqTime("2024-12-13").get());
+    }
+
+    @Test
+    void parseAcqTimeInvalidReturnsEmpty() {
+        assertFalse(BidsTsvDateParser.parseAcqTime("not-a-date").isPresent());
+        assertFalse(BidsTsvDateParser.parseAcqTime("").isPresent());
+        assertFalse(BidsTsvDateParser.parseAcqTime(null).isPresent());
+    }
+
+    @Test
+    void readEarliestAcqTimeFromScansFolder(@TempDir Path tempDir) throws IOException {
+        Path sessionDir = tempDir.resolve("ses-t0");
+        Files.createDirectories(sessionDir);
+        String tsv = "filename\tacq_time\n"
+                + "anat/sub-117_ses-t0_run-02_T1w.nii.gz\t2024-12-14T10:00:00\n"
+                + "anat/sub-117_ses-t0_run-01_T1w.nii.gz\t2024-12-13T17:48:00\n";
+        Files.writeString(sessionDir.resolve("sub-117_ses-t0_scans.tsv"), tsv);
+
+        Optional<LocalDate> date = BidsTsvDateParser.readEarliestAcqTimeFromScansFolder(sessionDir.toFile());
+        assertTrue(date.isPresent());
+        assertEquals(LocalDate.of(2024, 12, 13), date.get());
+    }
+
+    @Test
+    void readDatesFromSessionsFileNormalizesSessionId(@TempDir Path tempDir) throws IOException {
+        Path subjectDir = tempDir.resolve("sub-117");
+        Files.createDirectories(subjectDir);
+        String tsv = "session_id\tacq_time\n"
+                + "ses-t0\t2024-12-13T08:00:00\n";
+        Files.writeString(subjectDir.resolve("sub-117_sessions.tsv"), tsv);
+
+        Map<String, LocalDate> dates = BidsTsvDateParser.readDatesFromSessionsFile(subjectDir.toFile());
+        assertEquals(LocalDate.of(2024, 12, 13), dates.get("t0"));
+        assertEquals(LocalDate.of(2024, 12, 13), dates.get("ses-t0"));
+        assertEquals(LocalDate.of(2024, 12, 13), BidsTsvDateParser.lookupSessionDate(dates, "t0"));
+    }
+
+    @Test
+    void readEarliestAcqTimeMissingAcqTimeColumn(@TempDir Path tempDir) throws IOException {
+        Path sessionDir = tempDir.resolve("ses-t0");
+        Files.createDirectories(sessionDir);
+        Files.writeString(sessionDir.resolve("sub-117_ses-t0_scans.tsv"), "filename\tsize\nscan.nii.gz\t1\n");
+
+        assertFalse(BidsTsvDateParser.readEarliestAcqTimeFromScansFolder(sessionDir.toFile()).isPresent());
+    }
+
+    @Test
+    void parseHeaderColumnsTrimsNames() {
+        assertEquals(2, BidsTsvDateParser.parseHeaderColumns(" filename \t acq_time ").size());
+        assertEquals("acq_time", BidsTsvDateParser.parseHeaderColumns(" filename \t acq_time ").get(1));
+    }
+}


### PR DESCRIPTION
## Problem:
BIDS upload often fails to get acq_time and thus goes to fallback (today)

## Solution
- Parse BIDS `acq_time` from `*_scans.tsv` and `*_sessions.tsv` with flexible ISO formats
- Use the **earliest** valid `acq_time` in scans.tsv for the examination date (visit date)
- Match session labels with or without `ses-` prefix
- Log and surface a **warning** when falling back to folder creation time

