### PR TITLE
feat/allowing-papaya-on-bids-dataset

### DIFF
--- a/shanoir-ng-front/src/app/datasets/dataset/dataset.component.html
+++ b/shanoir-ng-front/src/app/datasets/dataset/dataset.component.html
@@ -45,7 +45,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 
 			<!-- TODO : other types -->
 
-			<fieldset *ngIf="mode=='view' && !isMRS && hasDownloadRight && dataset.type != 'Eeg' && dataset.type != 'BIDS' && dataset.type != 'Measurement'">
+			<fieldset *ngIf="mode=='view' && !isMRS && hasDownloadRight && dataset.type != 'Eeg' && dataset.type != 'Measurement'">
 				<legend>Preview</legend>
 				<papaya [loadingCallback]="papayaLoadCallback"></papaya>
 			</fieldset>


### PR DESCRIPTION
Following discussion at: https://github.com/fli-iam/shanoir-ng/discussions/3549

Allowing Papaya Viewer for BIDS dataset so that we can visualize NIfTI files following BIDS structure. e.g. here it works with a NIfTI returned by VIP because Modality Type is not BIDS.

<img width="1057" height="810" alt="image" src="https://github.com/user-attachments/assets/ff9c07ea-edc9-448a-932c-24629df344f1" />
