### PR TITLE
feature#3570: Let admins activate/deactivate a user in Keycloak from the user form

### DIFF
--- a/shanoir-ng-front/src/app/users/shared/user.model.ts
+++ b/shanoir-ng-front/src/app/users/shared/user.model.ts
@@ -25,6 +25,7 @@ export class User extends Entity {
     @Field() accountRequestInfo: AccountRequestInfo;
     @Field() canAccessToDicomAssociation: boolean;
     @Field() twoFactorEnabled: boolean;
+    @Field() keycloakEnabled: boolean;
     @Field() creationDate: Date;
     @Field() email: string;
     @Field() expirationDate: Date;

--- a/shanoir-ng-front/src/app/users/user/user.component.html
+++ b/shanoir-ng-front/src/app/users/user/user.component.html
@@ -225,6 +225,22 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
             </fieldset>
             <fieldset>
                 <ol>
+                    @if (mode != 'create' || !isUserAdmin()) {
+                        <li>
+                            <label i18n="Edit user|Account activated label@@editUserKeycloakEnabled">Account activated</label>
+                            <span class="right-col">
+                                @if (mode == 'view') {
+                                    @if (user.keycloakEnabled) {
+                                        <span class="bool-true"><i class="fas fa-check"></i></span>
+                                    } @else {
+                                        <span class="bool-false"><i class="fas fa-times"></i></span>
+                                    }
+                                } @else {
+                                    <checkbox formControlName="keycloakEnabled"></checkbox>
+                                }
+                            </span>
+                        </li>
+                    }
                     <li>
                         <label i18n="Edit user|Expiration date label@@editUserExpirationDate">Expiration Date</label>
                         <span class="right-col">
@@ -295,18 +311,20 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
                         </span>
                     </li>
                     @if (isUserAdmin()) {
-                        <label i18n="Edit user|Two-factor authentication label@@editUserTwoFactor">Two-factor authentication</label>
-                        <span class="right-col">
-                            @if (mode == 'view') {
-                                @if (user.twoFactorEnabled) {
-                                    <span class="bool-true"><i class="fas fa-check"></i></span>
+                        <li>
+                            <label i18n="Edit user|Two-factor authentication label@@editUserTwoFactor">Two-factor authentication</label>
+                            <span class="right-col">
+                                @if (mode == 'view') {
+                                    @if (user.twoFactorEnabled) {
+                                        <span class="bool-true"><i class="fas fa-check"></i></span>
+                                    } @else {
+                                        <span class="bool-false"><i class="fas fa-times"></i></span>
+                                    }
                                 } @else {
-                                    <span class="bool-false"><i class="fas fa-times"></i></span>
+                                    <checkbox formControlName="twoFactorEnabled"></checkbox>
                                 }
-                            } @else {
-                                <checkbox formControlName="twoFactorEnabled"></checkbox>
-                            }
-                        </span>
+                            </span>
+                        </li>
                     }
                 </ol>
             </fieldset>

--- a/shanoir-ng-front/src/app/users/user/user.component.ts
+++ b/shanoir-ng-front/src/app/users/user/user.component.ts
@@ -165,6 +165,7 @@ export class UserComponent extends EntityComponent<User> {
             'role': [this.user.role, [Validators.required]],
             'canAccessToDicomAssociation': new UntypedFormControl('false'),
             'twoFactorEnabled': new UntypedFormControl(this.user.twoFactorEnabled),
+            'keycloakEnabled': new UntypedFormControl(this.user.keycloakEnabled),
             'accountRequestInfo': [this.user.accountRequestInfo]
         });
         if (this.user.extensionRequestDemand) {

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/user/model/User.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/user/model/User.java
@@ -77,6 +77,14 @@ public class User extends HalEntity implements UserDetails {
     @Transient
     private Boolean twoFactorEnabled;
 
+    /**
+     * Keycloak account enabled (activated) flag. Not persisted in database:
+     * the state lives in Keycloak and is read/applied through it. Only meaningful for admins.
+     */
+    @VisibleOnlyBy(roles = { "ROLE_ADMIN" })
+    @Transient
+    private Boolean keycloakEnabled;
+
     @VisibleOnlyBy(roles = { "ROLE_ADMIN" })
     @LocalDateAnnotations
     private LocalDate creationDate;
@@ -198,6 +206,21 @@ public class User extends HalEntity implements UserDetails {
      */
     public void setTwoFactorEnabled(final Boolean twoFactorEnabled) {
         this.twoFactorEnabled = twoFactorEnabled;
+    }
+
+    /**
+     * @return whether the user is enabled (activated) in Keycloak
+     */
+    public Boolean getKeycloakEnabled() {
+        return keycloakEnabled;
+    }
+
+    /**
+     * @param keycloakEnabled
+     *            the Keycloak enabled (activated) flag to set
+     */
+    public void setKeycloakEnabled(final Boolean keycloakEnabled) {
+        this.keycloakEnabled = keycloakEnabled;
     }
 
     /**

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/user/service/UserServiceImpl.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/user/service/UserServiceImpl.java
@@ -216,12 +216,17 @@ public class UserServiceImpl implements UserService {
     @Override
     public User findById(final Long id) {
         final User user = userRepository.findById(id).orElse(null);
-        // Two-factor state lives in Keycloak; expose it to admins so the form can display it.
+        // Two-factor and enabled state live in Keycloak; expose them to admins so the form can display them.
         if (user != null && KeycloakUtil.isAdmin()) {
             try {
                 user.setTwoFactorEnabled(keycloakClient.isTotpEnabled(user.getKeycloakId()));
             } catch (SecurityException e) {
                 LOG.error("Could not read two-factor authentication status for user {}", id, e);
+            }
+            try {
+                user.setKeycloakEnabled(keycloakClient.isUserEnabled(user.getKeycloakId()));
+            } catch (SecurityException e) {
+                LOG.error("Could not read the enabled status for user {}", id, e);
             }
         }
         return user;
@@ -373,7 +378,19 @@ public class UserServiceImpl implements UserService {
             }
         }
 
-        return updateUserOnAllSystems(userDb, user);
+        final User updatedUser = updateUserOnAllSystems(userDb, user);
+
+        // The Keycloak enabled flag is rewritten by updateUserOnAllSystems, so apply the admin's
+        // activation choice afterwards to make it the final state. Only admins may change it.
+        if (KeycloakUtil.isAdmin() && user.getKeycloakEnabled() != null) {
+            try {
+                keycloakClient.setUserEnabled(userDb.getKeycloakId(), user.getKeycloakEnabled());
+            } catch (SecurityException e) {
+                LOG.error("Could not update the enabled status for user {}", user.getId(), e);
+            }
+        }
+
+        return updatedUser;
     }
 
     @Override

--- a/shanoir-ng-users/src/main/java/org/shanoir/ng/user/utils/KeycloakClient.java
+++ b/shanoir-ng-users/src/main/java/org/shanoir/ng/user/utils/KeycloakClient.java
@@ -244,6 +244,43 @@ public class KeycloakClient {
         }
     }
 
+    /**
+     * Enable or disable a user in Keycloak (the account {@code enabled} flag).
+     *
+     * @param keycloakId
+     *            the keycloak id of the user.
+     * @param enabled
+     *            {@code true} to activate the user, {@code false} to deactivate it.
+     * @throws SecurityException
+     */
+    public void setUserEnabled(final String keycloakId, final boolean enabled) throws SecurityException {
+        try {
+            final UserResource userResource = getKeycloak().realm(keycloakRealm).users().get(keycloakId);
+            final UserRepresentation userRepresentation = userResource.toRepresentation();
+            userRepresentation.setEnabled(enabled);
+            userResource.update(userRepresentation);
+        } catch (Exception e) {
+            throw new SecurityException("Could not update the enabled status for user with keycloak id " + keycloakId, e);
+        }
+    }
+
+    /**
+     * Tell whether a user is enabled (activated) in Keycloak.
+     *
+     * @param keycloakId
+     *            the keycloak id of the user.
+     * @return {@code true} if the user is enabled in Keycloak, {@code false} otherwise.
+     * @throws SecurityException
+     */
+    public boolean isUserEnabled(final String keycloakId) throws SecurityException {
+        try {
+            final UserResource userResource = getKeycloak().realm(keycloakRealm).users().get(keycloakId);
+            return Boolean.TRUE.equals(userResource.toRepresentation().isEnabled());
+        } catch (Exception e) {
+            throw new SecurityException("Could not read the enabled status for user with keycloak id " + keycloakId, e);
+        }
+    }
+
 
     /**
      * Delete a user.


### PR DESCRIPTION
## Summary

Adds an **admin-only** way to activate or deactivate a user's Keycloak account (the account
`enabled` flag), integrated into the existing user profile form ? it behaves exactly like the
"Can import from PACS" and "Two-factor authentication" fields (read-only icon in view mode,
checkbox in edit mode, applied on Save). Built with the same approach as the 2FA feature.

## How it works

The activation state lives entirely in **Keycloak** (the `UserRepresentation.enabled` flag),
not in the Shanoir database:

- **Activate** ? sets the Keycloak user `enabled = true`.
- **Deactivate** ? sets the Keycloak user `enabled = false` (the user can no longer log in).
- **Enabled flag** is read live from Keycloak (`UserRepresentation.isEnabled()`).

## Testing

- [x] As an admin, edit another user ? untick "Account activated" ? Save ? the user shows `Enabled = OFF` in the Keycloak admin console and can no longer log in.
- [x] Reopen the user in view mode ? the field shows a red X.
- [x] Edit the user ? tick "Account activated" ? Save ? the user is enabled again in the console and the field shows a green tick.

Close #3570 