### PR TITLE
feature#3582: Update OHIF viewer version to v3.12.5

### DIFF
--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -315,7 +315,7 @@ CMD []
 
 ################ nginx #####################################################
 
-FROM ohif/app:v3.11.0 AS nginx-viewer
+FROM ohif/app:v3.12.5 AS nginx-viewer
 
 FROM nginx AS nginx
 

--- a/docker-compose/nginx/viewer/app-config.js
+++ b/docker-compose/nginx/viewer/app-config.js
@@ -12,6 +12,13 @@
  * along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
  */
 
+// Shim Node-only globals that leak into a lazily loaded OHIF 3.12 browser
+// chunk (ReferenceError: __filename is not defined -> black screen on the first
+// load). Defining them on the global object lets the bare references resolved.
+// Safe to remove if the upstream ohif/app image stops referencing them.
+window.__filename = window.__filename || '';
+window.__dirname = window.__dirname || '/';
+
 window.config = {
 	routerBasename: null,
 	extensions: [],


### PR DESCRIPTION
Bumps the OHIF viewer base image used by the nginx stage from ohif/app:v3.11.0 to ohif/app:v3.12.5 in docker-compose/Dockerfile.

Closes #3582