### PR TITLE
feat(studies): make study extra-details fields optional

### DIFF
--- a/docker-compose/database-migrations/db-changes/studies/0031_study_extra_details_optional_fields.sql
+++ b/docker-compose/database-migrations/db-changes/studies/0031_study_extra_details_optional_fields.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `study_extra_details`
+  MODIFY `expected_nb_of_subjects` bigint(20) DEFAULT NULL,
+  MODIFY `expected_nb_of_centers` bigint(20) DEFAULT NULL,
+  MODIFY `sponsor` varchar(255) DEFAULT NULL,
+  MODIFY `principal_investigator` varchar(255) DEFAULT NULL;

--- a/shanoir-ng-front/src/app/studies/study/study.component.html
+++ b/shanoir-ng-front/src/app/studies/study/study.component.html
@@ -398,15 +398,6 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
                                     }
                                     @default {
                                         <input type="number" formControlName="expectedNbOfSubjects" />
-                                        @if (hasError('expectedNbOfSubjects', ['required'])) {
-                                            <label
-                                                animate.enter="slide-down-error"
-                                                animate.leave="slide-up-error"
-                                                class="form-validation-alert"
-                                                i18n="Edit study|Expected number of subjects required error@@studyDetailExpectedNbOfSubjectsRequiredError">
-                                                Expected number of subjects is required!
-                                            </label>
-                                        }
                                         @if (hasError('expectedNbOfSubjects', ['min'])) {
                                             <label
                                                 animate.enter="slide-down-error"
@@ -479,15 +470,6 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
                                     }
                                     @default {
                                         <input type="number" formControlName="expectedNbOfCenters" />
-                                        @if (hasError('expectedNbOfCenters', ['required'])) {
-                                            <label
-                                                animate.enter="slide-down-error"
-                                                animate.leave="slide-up-error"
-                                                class="form-validation-alert"
-                                                i18n="Edit study|Expected number of centers required error@@studyDetailExpectedNbOfCentersRequiredError">
-                                                Expected number of centers is required!
-                                            </label>
-                                        }
                                         @if (hasError('expectedNbOfCenters', ['min'])) {
                                             <label
                                                 animate.enter="slide-down-error"
@@ -558,15 +540,6 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
                                     }
                                     @default {
                                         <input type="text" formControlName="sponsor" />
-                                        @if (hasError('sponsor', ['required'])) {
-                                            <label
-                                                animate.enter="slide-down-error"
-                                                animate.leave="slide-up-error"
-                                                class="form-validation-alert"
-                                                i18n="Edit study|Sponsor required error@@studyDetailSponsorRequiredError">
-                                                Sponsor is required!
-                                            </label>
-                                        }
                                         @if (hasError('sponsor', ['minlength', 'maxlength'])) {
                                             <label
                                                 animate.enter="slide-down-error"
@@ -591,15 +564,6 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
                                     }
                                     @default {
                                         <input type="text" formControlName="principalInvestigator" />
-                                        @if (hasError('principalInvestigator', ['required'])) {
-                                            <label
-                                                animate.enter="slide-down-error"
-                                                animate.leave="slide-up-error"
-                                                class="form-validation-alert"
-                                                i18n="Edit study|Principal investigator required error@@studyDetailPrincipalInvestigatorRequiredError">
-                                                Principal investigator is required!
-                                            </label>
-                                        }
                                         @if (hasError('principalInvestigator', ['minlength', 'maxlength'])) {
                                             <label
                                                 animate.enter="slide-down-error"

--- a/shanoir-ng-front/src/app/studies/study/study.component.ts
+++ b/shanoir-ng-front/src/app/studies/study/study.component.ts
@@ -290,14 +290,14 @@ export class StudyComponent extends EntityComponent<Study> {
             'protocolFile': [],
             'dataUserAgreement': [],
             'studyUserList': [this.study.studyUserList],
-            'expectedNbOfSubjects': [this.study.expectedNbOfSubjects, [Validators.required, Validators.min(1)]],
+            'expectedNbOfSubjects': [this.study.expectedNbOfSubjects, [Validators.min(1)]],
             'averageExaminationSize': [this.study.averageExaminationSize, [Validators.min(1)]],
             'estimatedTotalVolume': [this.study.estimatedTotalVolume, [Validators.min(1)]],
-            'expectedNbOfCenters': [this.study.expectedNbOfCenters, [Validators.required, Validators.min(1)]],
+            'expectedNbOfCenters': [this.study.expectedNbOfCenters, [Validators.min(1)]],
             'inclusionRate': [this.study.inclusionRate, [Validators.min(1)]],
             'inclusionRateUnit': [this.study.inclusionRateUnit],
-            'sponsor': [this.study.sponsor, [Validators.required, Validators.minLength(2), Validators.maxLength(200)]],
-            'principalInvestigator': [this.study.principalInvestigator, [Validators.required, Validators.minLength(2), Validators.maxLength(200)]],
+            'sponsor': [this.study.sponsor, [Validators.minLength(2), Validators.maxLength(200)]],
+            'principalInvestigator': [this.study.principalInvestigator, [Validators.minLength(2), Validators.maxLength(200)]],
             'scientificAdvisor': [this.study.scientificAdvisor, [Validators.minLength(2), Validators.maxLength(200)]]
         });
 

--- a/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/model/StudyExtraDetails.java
+++ b/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/model/StudyExtraDetails.java
@@ -23,7 +23,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotNull;
 
 /**
  * Study Extra Details.
@@ -46,7 +45,6 @@ public class StudyExtraDetails extends HalEntity {
     private Study study;
 
     /** Expected number of subjects. */
-    @NotNull
     @Column(name = "expected_nb_of_subjects")
     private Long expectedNbOfSubjects;
 
@@ -59,7 +57,6 @@ public class StudyExtraDetails extends HalEntity {
     private Float estimatedTotalVolume;
 
     /** Expected number of centers. */
-    @NotNull
     @Column(name = "expected_nb_of_centers")
     private Long expectedNbOfCenters;
 
@@ -72,12 +69,10 @@ public class StudyExtraDetails extends HalEntity {
     private Integer inclusionRateUnit;
 
     /** Sponsor ID. */
-    @NotNull
     @Column(name = "sponsor")
     private String sponsor;
 
     /** Principal investigator ID. */
-    @NotNull
     @Column(name = "principal_investigator")
     private String principalInvestigator;
 


### PR DESCRIPTION
## Summary
Turns four previously **required** study fields into **optional** across the full stack:

- Number of subjects (`expectedNbOfSubjects`)
- Number of centers (`expectedNbOfCenters`)
- Sponsor (`sponsor`)
- Principal investigator (`principalInvestigator`)

These belong to the `StudyExtraDetails` entity / `study_extra_details` table.

## Testing
- [ ] Create/edit a study leaving these four fields empty — save succeeds.

Closes #3606 