### PR TITLE
chore(docker-compose): update images to NG_v2.12.0 across all services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
   #
   keycloak-database:
     container_name: "${SHANOIR_PREFIX}keycloak-database"
-    image: "ghcr.io/fli-iam/shanoir-ng/keycloak-database:NG_v2.10.0"
+    image: "ghcr.io/fli-iam/shanoir-ng/keycloak-database:NG_v2.12.0"
     environment:
       - MARIADB_DATABASE=keycloak
       - MARIADB_ROOT_PASSWORD=password
@@ -57,7 +57,7 @@ services:
       - SHANOIR_SMTP_STARTTLS_ENABLE
       - SHANOIR_SMTP_STARTTLS_REQUIRED
       - SHANOIR_SMTP_FROM
-    image: "ghcr.io/fli-iam/shanoir-ng/keycloak:NG_v2.10.0"
+    image: "ghcr.io/fli-iam/shanoir-ng/keycloak:NG_v2.12.0"
     volumes:
       - "keycloak-logs:/opt/keycloak/data/log"
     networks:
@@ -85,7 +85,7 @@ services:
   #
   database:
     container_name: "${SHANOIR_PREFIX}database"
-    image: "ghcr.io/fli-iam/shanoir-ng/database:NG_v2.10.0"
+    image: "ghcr.io/fli-iam/shanoir-ng/database:NG_v2.12.0"
     command: --max_allowed_packet 20000000
     environment:
       - MARIADB_ROOT_PASSWORD=password
@@ -111,7 +111,7 @@ services:
   #
   database-migrations:
     container_name: "${SHANOIR_PREFIX}database-migrations"
-    image: "ghcr.io/fli-iam/shanoir-ng/database-migrations:NG_v2.10.0"
+    image: "ghcr.io/fli-iam/shanoir-ng/database-migrations:NG_v2.12.0"
     environment:
       - SHANOIR_MIGRATION
     networks:
@@ -125,7 +125,7 @@ services:
   #
   users:
     container_name: "${SHANOIR_PREFIX}users"
-    image: "ghcr.io/fli-iam/shanoir-ng/users:NG_v2.10.0"
+    image: "ghcr.io/fli-iam/shanoir-ng/users:NG_v2.12.0"
     environment:
       - SHANOIR_PREFIX
       - SHANOIR_URL_SCHEME
@@ -161,7 +161,7 @@ services:
   #
   studies:
     container_name: "${SHANOIR_PREFIX}studies"
-    image: "ghcr.io/fli-iam/shanoir-ng/studies:NG_v2.10.0"
+    image: "ghcr.io/fli-iam/shanoir-ng/studies:NG_v2.12.0"
     environment:
       - SHANOIR_PREFIX
       - SHANOIR_URL_SCHEME
@@ -198,7 +198,7 @@ services:
   #
   import:
     container_name: "${SHANOIR_PREFIX}import"
-    image: "ghcr.io/fli-iam/shanoir-ng/import:NG_v2.10.0"
+    image: "ghcr.io/fli-iam/shanoir-ng/import:NG_v2.12.0"
     environment:
       - SHANOIR_PREFIX
       - SHANOIR_URL_SCHEME
@@ -231,7 +231,7 @@ services:
   #
   datasets:
     container_name: "${SHANOIR_PREFIX}datasets"
-    image: "ghcr.io/fli-iam/shanoir-ng/datasets:NG_v2.10.0"
+    image: "ghcr.io/fli-iam/shanoir-ng/datasets:NG_v2.12.0"
     environment:
       - SHANOIR_PREFIX
       - SHANOIR_URL_SCHEME
@@ -277,7 +277,7 @@ services:
   #
   preclinical:
     container_name: "${SHANOIR_PREFIX}preclinical"
-    image: "ghcr.io/fli-iam/shanoir-ng/preclinical:NG_v2.10.0"
+    image: "ghcr.io/fli-iam/shanoir-ng/preclinical:NG_v2.12.0"
     environment:
       - SHANOIR_PREFIX
       - SHANOIR_URL_SCHEME
@@ -313,7 +313,7 @@ services:
   #
   nifti-conversion:
     container_name: "${SHANOIR_PREFIX}nifti-conversion"
-    image: "ghcr.io/fli-iam/shanoir-ng/nifti-conversion:NG_v2.10.0"
+    image: "ghcr.io/fli-iam/shanoir-ng/nifti-conversion:NG_v2.12.0"
     environment:
       - SHANOIR_PREFIX
       - SHANOIR_URL_SCHEME
@@ -333,7 +333,7 @@ services:
   #
   solr:
     container_name: "${SHANOIR_PREFIX}solr"
-    image: "ghcr.io/fli-iam/shanoir-ng/solr:NG_v2.10.0"
+    image: "ghcr.io/fli-iam/shanoir-ng/solr:NG_v2.12.0"
     environment:
       - SOLR_LOG_LEVEL=SEVERE
     volumes:
@@ -406,7 +406,7 @@ services:
   #
   nginx:
     container_name: shanoir-ng-nginx
-    image: "ghcr.io/fli-iam/shanoir-ng/nginx:NG_v2.10.0"
+    image: "ghcr.io/fli-iam/shanoir-ng/nginx:NG_v2.12.0"
     environment:
       - SHANOIR_PREFIX
       - SHANOIR_URL_SCHEME
@@ -440,7 +440,7 @@ services:
 
   bids-validator:
     container_name: "${SHANOIR_PREFIX}bids-validator"
-    image: "ghcr.io/fli-iam/shanoir-ng/bids-validator:NG_v2.10.0"
+    image: "ghcr.io/fli-iam/shanoir-ng/bids-validator:NG_v2.12.0"
     environment:
       - AMQP_URL=amqp://guest:guest@rabbitmq:5672/
       - IN_QUEUE=bids.validate


### PR DESCRIPTION
Updates all Shanoir-NG container images in `docker-compose.yml` from `NG_v2.10.0` to `NG_v2.12.0`, so the production compose stack pulls the latest released images