### PR TITLE
change shanoir tutorial link and switch to storage volume TB if needed

### DIFF
--- a/shanoir-ng-front/src/app/app.component.html
+++ b/shanoir-ng-front/src/app/app.component.html
@@ -20,12 +20,12 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
     }
     <div class="main-content" [class.reduce-height]="consoleOpened && consoleDeployed" [class.open]="menuOpen">
         @if (treeService.treeOpened && treeService.treeAvailable) {
-            <div class="tree-close-button" (click)="toggleTree(false)" title="open tree">
+            <div class="tree-close-button" (click)="toggleTree(false)" title="close tree">
                 <i class="fas fa-chevron-left"></i>
             </div>
         }
         @if (!treeService.treeOpened && treeService.treeAvailable) {
-            <div class="tree-close-button" (click)="toggleTree(true)" title="close tree">
+            <div class="tree-close-button" (click)="toggleTree(true)" title="open tree">
                 <i class="fas fa-chevron-right"></i>
             </div>
         }

--- a/shanoir-ng-front/src/app/home/home.component.html
+++ b/shanoir-ng-front/src/app/home/home.component.html
@@ -168,7 +168,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
                     <td>
                         <ul class="pannel">
                             <li>
-                                <a href="https://docs.google.com/document/d/1kfsYJXxm3Ts0_qxCxDIPeSdwZnvjh2qhzb9jQbpobt4/edit?ts=5f745be6#" target="_blank">
+                                <a href="https://github.com/fli-iam/shanoir-ng/wiki/User-Tutorial" target="_blank">
                                     <i class="fas fa-graduation-cap"></i>
                                     Tutoriel Shanoir
                                 </a>

--- a/shanoir-ng-front/src/app/welcome/welcome.component.html
+++ b/shanoir-ng-front/src/app/welcome/welcome.component.html
@@ -64,7 +64,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
         <strong>
             {{ subjectsCount || 'no' }} subject@if (subjectsCount > 1) {s}
         </strong>, for a total of
-        <strong>{{ storageSize }} GB</strong>.
+        <strong>{{ formattedStorageSize }}</strong>.
         <br />
         There
         @if (usersCount < 2) {

--- a/shanoir-ng-front/src/app/welcome/welcome.component.ts
+++ b/shanoir-ng-front/src/app/welcome/welcome.component.ts
@@ -60,6 +60,11 @@ export class WelcomeComponent implements OnInit {
     }
 
     addSchemaToDOM(): void {
+        const isTerabyte = this.storageSize >= 1000;
+        const storageValue = isTerabyte ? (this.storageSize / 1000).toFixed(2) : this.storageSize.toFixed(2);
+        const unitCode = isTerabyte ? 'E33' : 'E34';   // E33 = Terabyte, E34 = Gigabyte (codes UN/CEFACT)
+        const unitText = isTerabyte ? 'Terabyte' : 'Gigabyte';
+
         const script = this._renderer2.createElement('script');
         script.type = `application/ld+json`;
 
@@ -101,7 +106,7 @@ export class WelcomeComponent implements OnInit {
             }
         })
 
-        // schema.org DataCatalog + Datasets
+        // JSON-LD annotation script that describes the Shanoir platform and its content, following the Bioschemas DataCatalog profile
         script.text = `
         {
             "@context": {
@@ -235,11 +240,11 @@ export class WelcomeComponent implements OnInit {
                   "dqv:computedOn": { "@id": "` + shanoirUrl + `" },
                   "dqv:isMeasurementOf": { "@id": "Storage Volume" },
                   "schema:value": {
-                  "@value": "` + this.storageSize + `",
-                  "@type": "xsd:decimal"
+                      "@value": "${storageValue}",
+                      "@type": "xsd:decimal"
                   },
-                  "schema:unitCode": "E34", 
-                  "schema:unitText": "Gigabyte"
+                  "schema:unitCode": "${unitCode}",
+                  "schema:unitText": "${unitText}"
                   },
                 {
                   "@id": "Users",
@@ -365,7 +370,13 @@ export class WelcomeComponent implements OnInit {
             this.fetchEventsCount();
             this.addSchemaToDOM();
         });
+    }
 
+    get formattedStorageSize(): string {
+        if (this.storageSize >= 1000) {
+            return (this.storageSize / 1000).toFixed(2) + ' TB';
+        }
+        return this.storageSize.toFixed(2) + ' GB';
     }
 
 	private fetchPublicStudies() {


### PR DESCRIPTION
This PR is not linked to an issue as it is very small.

it corrects the "open tree/close tree" tooltip of the study tree that was inverted.

it changes the unit of total storage volume to Terabyte when the value is superior to 1000 Gigabyte.

It updated the link to Shanoir Tutorial in the Home Documentation menu.