### PR TITLE
fix(subject): update `@JsonIgnoreProperties` to fine-tune property handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ server directly:
    `SHANOIR_KEYCLOAK_USER`/`SHANOIR_KEYCLOAK_PASSWORD' (default is `admin`/`&a1A&a1A`)
 3. go to the **shanoir-ng** realm
 4. create/edit the new user and grant the relevant role (eg. `ROLE_ADMIN`). By
-   default, new user accounts are created in Keycloak by the users microservice
+   default, new user accounts are created in Keycloak by the users' microservice
    with temporary passwords, you may reset the password in keycloak's admin
    interface and receive the new password is by e-mail. In development, if you
    do hot have a configured SMTP relay, then you may choose to overide the

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/service/DatasetAcquisitionServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/datasetacquisition/service/DatasetAcquisitionServiceImpl.java
@@ -320,8 +320,10 @@ public class DatasetAcquisitionServiceImpl implements DatasetAcquisitionService 
         if (entity == null) {
             throw new EntityNotFoundException("Cannot find entity with id = " + id);
         }
-        event.setMessage("Delete examination - datasetAcquisition with id : " + id);
-        shanoirEventService.publishEvent(event);
+        if (event != null) {
+            event.setMessage("Delete examination - datasetAcquisition with id : " + id);
+            shanoirEventService.publishEvent(event);
+        }
         delete(entity, event);
 
         repository.deleteById(id);

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dicom/web/service/DICOMWebService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dicom/web/service/DICOMWebService.java
@@ -567,16 +567,14 @@ public class DICOMWebService {
         try (CloseableHttpResponse response = httpClient.execute(post)) {
             if (HttpStatus.OK.value() == response.getCode()) {
                 LOG.debug("Rejected from PACS: " + post);
+            } else if (response.getCode() == 404 && response.getReasonPhrase().startsWith("Not Found")) {
+                // No DICOM instance present in PACS, nothing to reject: we continue with deletion
+                LOG.warn(response.getCode() + ": No instance to reject in PACS for rejectURL: " + url);
             } else {
                 LOG.error(response.getCode() + ": Could not reject instance from PACS: " + response.getReasonPhrase()
                         + " for rejectURL: " + url);
-                // in case one URL is Not Found (no DICOM instance present), we continue with deletion
-                if (response.getCode() == 404 && response.getReasonPhrase().startsWith("Not Found")) {
-                    return;
-                } else {
-                    throw new ShanoirException(response.getCode() + ": Could not reject instance from PACS: " + response.getReasonPhrase()
-                            + " for rejectURL: " + url);
-                }
+                throw new ShanoirException(response.getCode() + ": Could not reject instance from PACS: " + response.getReasonPhrase()
+                        + " for rejectURL: " + url);
             }
         } catch (IOException e) {
             LOG.error("Could not reject instance from PACS: for rejectURL: " + url, e);

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/shared/model/Subject.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/shared/model/Subject.java
@@ -40,7 +40,7 @@ import jakarta.validation.constraints.NotNull;
  */
 @Entity
 @Table(name = "subject")
-@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonIgnoreProperties(value = "study", ignoreUnknown = true, allowGetters = true)
 public class Subject extends IdName {
 
     @Id


### PR DESCRIPTION
## Problem
  
When importing a DICOM dataset, the subject is created in MS Studies but fails
to propagate to MS Datasets, with the import breaking on: 

jakarta.validation.ConstraintViolationException: Validation failed for classes
[org.shanoir.ng.shared.model.Subject] during persist time ...
propertyPath=study, interpolatedMessage='must not be null'

## Root cause

`SubjectMapper.subjectToSubjectDTO` populates `studyId` but leaves the `study`
(`StudyTagsDTO`) field null (`@Mapping(target = "study", ignore = true)`). Jackson
serializes fields in declaration order, so the message sent to MS Datasets looks like:

```json
{ ..., "studyId": 123, ..., "study": null, ... }
```

The MS Datasets Subject entity has both setters. During deserialization they
fire in JSON order:
  
1. setStudyId(123) -> resolves and sets study
2. setStudy(null) -> overwrites it back to null

Fix
  
Ignore the redundant study property on input in the MS Datasets Subject,
making studyId the sole entry path so it can no longer be clobbered:

@JsonIgnoreProperties(value = "study", ignoreUnknown = true, allowGetters = true)

Closes #3608 