### PR TITLE
issue/3640: Fix study deletion

### DIFF
--- a/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/controler/StudyApiController.java
+++ b/shanoir-ng-studies/src/main/java/org/shanoir/ng/study/controler/StudyApiController.java
@@ -132,13 +132,16 @@ public class StudyApiController implements StudyApi {
             if (!CollectionUtils.isEmpty(duas)) {
                 this.dataUserAgreementService.deleteAll(duas);
             }
+            studyService.deleteById(studyId);
             storageService.deleteDirectoryStudyData(studyId);
             eventService.publishEvent(new ShanoirEvent(ShanoirEventType.DELETE_STUDY_EVENT, studyId.toString(),
                     KeycloakUtil.getTokenUserId(), "", ShanoirEvent.SUCCESS, studyId));
             return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        } catch (EntityNotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } catch (Exception e) {
-            LOG.error("Error while deleting protocol file {}", e);
-            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+            LOG.error("Error while deleting study {}", studyId, e);
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 


### PR DESCRIPTION
Deleting a study returned success but left the study in the database, with no error shown.

The deleteStudy endpoint ran its guard checks, cleaned up DUAs/storage and published DELETE_STUDY_EVENT, but never called studyService.deleteById ? so the row was never removed. The catch block also returned 204 No Content for any failure, masking the problem.

Fix
- Call studyService.deleteById(studyId) before storage cleanup, so a DB failure rolls back cleanly.
- Return 404 on not-found and 500 on error instead of a silent 204.

Closes #3640