### PR TITLE
Keycloak fix

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@
 #
 # Possible schemes are 'https' (default) and 'http' (not recommended)
 SHANOIR_URL_SCHEME=https
-SHANOIR_URL_HOST=localhost
+SHANOIR_URL_HOST=shanoir-ng-nginx
 
 # URL where the OHIF-Viewer is reachable (SHANOIR_VIEWER_OHIF_URL_SCHEME://SHANOIR_VIEWER_OHIF_URL_HOST)
 SHANOIR_VIEWER_OHIF_URL_SCHEME=https

--- a/docker-compose/nginx/shanoir.template.dev.conf
+++ b/docker-compose/nginx/shanoir.template.dev.conf
@@ -17,6 +17,14 @@ location @redirect_root {
     return 301 /shanoir-ng/welcome;
 }
 
+location = /shanoir-ng/assets/env.js {
+  alias /etc/nginx/html/assets/env.js;
+}
+
+location = /assets/env.js {
+  alias /etc/nginx/html/assets/env.js;
+}
+
 # Front dev Angular via esbuild / Vite HMR
 location /shanoir-ng/ {
     proxy_pass http://front-dev:4200/;


### PR DESCRIPTION
Hi @a-ba, here is a tiny fix for the local dev mode. 

My issue was due to the use of docker-compsoe-dev-front.yml which set the SHANOIR-DEV env var to true, which leads to the use of shanoir.template.dev.conf which does not manage correctly the env.js in the browser (I'm not really sure about the details). The PR fix that to have the right env.js loaded in the browser.