### PR TITLE
#3524 : fix for auto BIDS export launch when modifying study history grid size

### DIFF
--- a/shanoir-ng-front/src/app/bids/tree/bids-tree.component.html
+++ b/shanoir-ng-front/src/app/bids/tree/bids-tree.component.html
@@ -80,7 +80,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 
 @if (!report && !buildingReport) {
     <div>
-        <button class="right-icon" (click)="callBidsValidator()" [disabled]="task && task.progress < 1">Call BIDS Validator</button>
+        <button type="button" class="right-icon" (click)="callBidsValidator()" [disabled]="task && task.progress < 1">Call BIDS Validator</button>
     </div>
 } @else {
     <div class="json-report">


### PR DESCRIPTION
I do'nt really understand what's going with that ... claude find out a fix, thx claude ! HEre is the explanation : 






● Found it. This is a well-known HTML/Angular footgun, and the button in question matches exactly:                                             
                                                                                                                                               
  - table.component.html:389 — the row-count field is <input type="text" [(ngModel)]="maxResultsField" (change)="updateMaxResults()" />, a     
  plain text input, no Enter-key handling.                                                                                                     
  - The whole tab UI lives inside one single <form> (study.component.html:17).                                                                 
  - bids-tree.component.html:83 — <button class="right-icon" (click)="callBidsValidator()" ...>Call BIDS Validator</button> has no type        
  attribute, so per the HTML spec it defaults to type="submit".                                                                                
                                                                                                                                               
  When a <form> has no explicit submit handling, pressing Enter inside any single-line text input triggers the browser's implicit form         
  submission: it finds the first non-disabled submit-type <button> in the form's DOM tree order and dispatches a genuine, trusted click event  
  at it — exactly what your stack trace shows (addEventListener/listen/decoratePreventDefault, a real DOM click, not a synthetic one).         
  Angular's formGroup directive then intercepts the actual submit event and calls preventDefault() on it (so the page doesn't reload) — but by 
  then the click on the button has already fired and callBidsValidator() has already run.                                                      
                                                                                                                                               
  Since the bids fieldset sits right before history in the DOM (study.component.html:847 then :852), and its "Call BIDS Validator" button is   
  the only untyped <button> in that region (everything else — footer buttons, etc. — explicitly sets type="button"), it becomes the browser's  
  default submit target. So the sequence is:                                                                                                   
                                                                                                                                               
  1. You type a new page size in the "Page size" input.                                                                                        
  2. You press Enter to confirm (instead of clicking away to blur).                                                                            
  3. The browser, seeing Enter in a text field inside a form with no explicit submit button focused, implicitly "clicks" the first             
  submit-defaulting button in the form — the invisible, off-screen "Call BIDS Validator" button.                                               
  4. That fires callBidsValidator() → getBidsStructure() → real HTTP request → first-ever BIDS export for the study gets created (and never    
  again, since exportAsBids() short-circuits once the work folder exists).