### PR TITLE
issue/3666: Check CAN_IMPORT right during DICOM SEG/SR importation

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dicom/web/STOWRSMultipartRequestFilter.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dicom/web/STOWRSMultipartRequestFilter.java
@@ -22,6 +22,7 @@ import org.dcm4che3.data.Tag;
 import org.dcm4che3.io.DicomInputStream;
 import org.shanoir.ng.importer.service.DicomImporterService;
 import org.shanoir.ng.importer.service.DicomSEGAndSRImporterService;
+import org.shanoir.ng.shared.exception.RestServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +39,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * The STOWRSMultipartRequestFilter handles a HTTP-POST request of
@@ -126,6 +128,9 @@ public class STOWRSMultipartRequestFilter extends GenericFilterBean {
                         throw new IOException("STOWRSMultipartRequestFilter: exception sending DICOM file to Shanoir (STOW-RS).");
                     }
                 }
+            } catch (RestServiceException e) {
+                LOG.error(e.getErrorModel().getMessage(), e);
+                ((HttpServletResponse) response).sendError(e.getErrorModel().getCode(), e.getErrorModel().getMessage());
             } catch (Exception e) {
                 LOG.error(e.getMessage(), e);
                 throw new IOException("STOWRSMultipartRequestFilter: exception sending DICOM file to Shanoir (STOW-RS).");

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/DicomImporterService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/DicomImporterService.java
@@ -42,6 +42,7 @@ import org.shanoir.ng.dataset.model.Dataset;
 import org.shanoir.ng.dataset.model.DatasetExpression;
 import org.shanoir.ng.dataset.model.DatasetExpressionFormat;
 import org.shanoir.ng.dataset.repository.DatasetExpressionRepository;
+import org.shanoir.ng.dataset.security.DatasetSecurityService;
 import org.shanoir.ng.dataset.service.DatasetService;
 import org.shanoir.ng.datasetacquisition.model.DatasetAcquisition;
 import org.shanoir.ng.datasetacquisition.model.mr.MrDatasetAcquisition;
@@ -72,6 +73,7 @@ import org.shanoir.ng.shared.model.Subject;
 import org.shanoir.ng.shared.repository.AcquisitionEquipmentRepository;
 import org.shanoir.ng.shared.repository.CenterRepository;
 import org.shanoir.ng.shared.repository.StudyCenterRepository;
+import org.shanoir.ng.shared.security.rights.StudyUserRight;
 import org.shanoir.ng.shared.service.StudyService;
 import org.shanoir.ng.shared.service.SubjectService;
 import org.shanoir.ng.solr.service.SolrService;
@@ -124,6 +126,8 @@ public class DicomImporterService {
 
     private static final String EQUIPMENT_CREATION_ERROR = "An error occured during the equipment creation, please check your rights.";
 
+    private static final String MISSING_CAN_IMPORT_RIGHT_ERROR = "Missing right CAN_IMPORT on study, import refused: ";
+
     private static final String DOUBLE_EQUAL = "==";
 
     private static final String SEMI_COLON = ";";
@@ -135,6 +139,9 @@ public class DicomImporterService {
 
     @Autowired
     private StudyService studyService;
+
+    @Autowired
+    private DatasetSecurityService datasetSecurityService;
 
     @Autowired
     private SubjectService subjectService;
@@ -225,6 +232,12 @@ public class DicomImporterService {
         if (study == null) {
             LOG.error("Shanoir study (research project) not found with ID: {}", studyId);
             return false;
+        }
+        if (!datasetSecurityService.hasRightOnStudy(studyId, StudyUserRight.CAN_IMPORT.name())) {
+            LOG.error("User {} misses the right CAN_IMPORT on study with ID: {}, import refused.",
+                    KeycloakUtil.getTokenUserName(), studyId);
+            throw new RestServiceException(
+                    new ErrorModel(HttpStatus.FORBIDDEN.value(), MISSING_CAN_IMPORT_RIGHT_ERROR + studyId, null));
         }
         Serie serie = new Serie(attributes);
         if (!DicomUtils.checkSerieIsIgnored(attributes)) { // do nothing for files of ignored series

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/importer/service/DicomImporterServiceTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/importer/service/DicomImporterServiceTest.java
@@ -1,0 +1,131 @@
+/**
+ * Shanoir NG - Import, manage and share neuroimaging data
+ * Copyright (C) 2009-2019 Inria - https://www.inria.fr/
+ * Contact us on https://project.inria.fr/shanoir/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+package org.shanoir.ng.importer.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.dcm4che3.data.Attributes;
+import org.dcm4che3.data.Tag;
+import org.dcm4che3.data.VR;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.shanoir.ng.dataset.security.DatasetSecurityService;
+import org.shanoir.ng.shared.exception.RestServiceException;
+import org.shanoir.ng.shared.model.Study;
+import org.shanoir.ng.shared.model.Subject;
+import org.shanoir.ng.shared.repository.CenterRepository;
+import org.shanoir.ng.shared.security.rights.StudyUserRight;
+import org.shanoir.ng.shared.service.StudyService;
+import org.shanoir.ng.shared.service.SubjectService;
+import org.shanoir.ng.utils.KeycloakUtil;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.http.HttpStatus;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Tests for the CAN_IMPORT rights check on study level in DicomImporterService.
+ *
+ * @author afragkia
+ */
+@ExtendWith(MockitoExtension.class)
+public class DicomImporterServiceTest {
+
+    private static final Long STUDY_ID = 1L;
+
+    private static final String USER_NAME = "testUser";
+
+    @Mock
+    private StudyService studyService;
+
+    @Mock
+    private DatasetSecurityService datasetSecurityService;
+
+    @Mock
+    private SubjectService subjectService;
+
+    @Mock
+    private CenterRepository centerRepository;
+
+    @Mock
+    private RabbitTemplate rabbitTemplate;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private DicomImporterService dicomImporterService;
+
+    private Attributes metaInformationAttributes;
+
+    private Attributes attributes;
+
+    private Study study;
+
+    @BeforeEach
+    public void setup() {
+        metaInformationAttributes = new Attributes();
+        attributes = new Attributes();
+        attributes.setString(Tag.DeidentificationMethod, VR.LO, "Karnak");
+        attributes.setString(Tag.ClinicalTrialProtocolID, VR.LO, STUDY_ID.toString());
+        attributes.setString(Tag.Modality, VR.CS, "MR");
+        attributes.setString(Tag.PatientName, VR.PN, "subject01");
+        study = new Study();
+        study.setId(STUDY_ID);
+        when(studyService.findById(STUDY_ID)).thenReturn(study);
+    }
+
+    @Test
+    public void importDicomRefusedWithoutCanImportRight() {
+        when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_IMPORT.name())).thenReturn(false);
+        try (MockedStatic<KeycloakUtil> keycloakUtilMock = Mockito.mockStatic(KeycloakUtil.class)) {
+            keycloakUtilMock.when(KeycloakUtil::getTokenUserName).thenReturn(USER_NAME);
+            RestServiceException exception = assertThrows(RestServiceException.class,
+                    () -> dicomImporterService.importDicom(metaInformationAttributes, attributes, "MR"));
+            assertEquals(HttpStatus.FORBIDDEN.value(), exception.getErrorModel().getCode());
+        }
+        verifyNoInteractions(subjectService);
+    }
+
+    @Test
+    public void importDicomProceedsWithCanImportRight() throws Exception {
+        when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_IMPORT.name())).thenReturn(true);
+        Subject subject = new Subject();
+        subject.setId(10L);
+        when(subjectService.findByNameAndStudyId(anyString(), any())).thenReturn(subject);
+        when(centerRepository.findFirstByNameContainingOrderByIdAsc(any())).thenReturn(Optional.empty());
+        // No center found and RabbitMQ answers null: proves the import continued
+        // after the rights check, until the center creation
+        RestServiceException exception = assertThrows(RestServiceException.class,
+                () -> dicomImporterService.importDicom(metaInformationAttributes, attributes, "MR"));
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY.value(), exception.getErrorModel().getCode());
+        verify(subjectService).findByNameAndStudyId("subject01", STUDY_ID);
+    }
+
+}


### PR DESCRIPTION
Add a `CAN_IMPORT` check via `DatasetSecurityService.hasRightOnStudy()` right after study resolution, and refuse the request with HTTP 403 in `STOWRSMultipartRequestFilter`, as already done for the regular import endpoint (`DatasetApi`).

Closes #3666 