### PR TITLE
Accept the full DICOM TM range in DateTimeUtils.stringToLocalTime

### DIFF
--- a/shanoir-ng-ms-common/src/main/java/org/shanoir/ng/shared/dateTime/DateTimeUtils.java
+++ b/shanoir-ng-ms-common/src/main/java/org/shanoir/ng/shared/dateTime/DateTimeUtils.java
@@ -23,7 +23,8 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 import java.util.Date;
 
 /**
@@ -47,17 +48,36 @@ public final class DateTimeUtils {
         else return Date.from(localDate.atStartOfDay().atZone(ZoneId.of("UTC")).toInstant());
     }
 
+    /**
+     * The DICOM VR TM is HH[MM[SS[.FFFFFF]]], where the fractional part holds one
+     * to six digits, so HH, HHMM, HHMMSS and HHMMSS.F to HHMMSS.FFFFFF are all
+     * legal. Values are also padded with a trailing space to an even length.
+     *
+     * Only HHMMSS and HHMMSS.FFFFFF used to be accepted, so a legal value such as
+     * 120000.00 raised a DateTimeParseException. The components that are not
+     * present default to 0.
+     */
+    private static final DateTimeFormatter DICOM_TIME_FORMATTER = new DateTimeFormatterBuilder()
+            .appendValue(ChronoField.HOUR_OF_DAY, 2)
+            .optionalStart()
+            .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+            .optionalStart()
+            .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+            .optionalStart()
+            .appendFraction(ChronoField.NANO_OF_SECOND, 1, 6, true)
+            .optionalEnd()
+            .optionalEnd()
+            .optionalEnd()
+            .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+            .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+            .parseDefaulting(ChronoField.NANO_OF_SECOND, 0)
+            .toFormatter();
+
     public static LocalTime stringToLocalTime(String time) {
-        if (time == null || time.isEmpty()) return null;
-
-        DateTimeFormatter fullFormatter = DateTimeFormatter.ofPattern("HHmmss.SSSSSS");
-        DateTimeFormatter shortFormatter = DateTimeFormatter.ofPattern("HHmmss");
-
-        try {
-            return LocalTime.parse(time, fullFormatter);
-        } catch (DateTimeParseException e) {
-            return LocalTime.parse(time, shortFormatter);
-        }
+        if (time == null) return null;
+        String trimmedTime = time.trim();
+        if (trimmedTime.isEmpty()) return null;
+        return LocalTime.parse(trimmedTime, DICOM_TIME_FORMATTER);
     }
 
     public static LocalDateTime dateToLocalDateTime(Date date) {

--- a/shanoir-ng-ms-common/src/test/java/org/shanoir/ng/shared/dateTime/DateTimeUtilsTest.java
+++ b/shanoir-ng-ms-common/src/test/java/org/shanoir/ng/shared/dateTime/DateTimeUtilsTest.java
@@ -1,0 +1,98 @@
+/**
+ * Shanoir NG - Import, manage and share neuroimaging data
+ * Copyright (C) 2009-2019 Inria - https://www.inria.fr/
+ * Contact us on https://project.inria.fr/shanoir/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+package org.shanoir.ng.shared.dateTime;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the parsing of DICOM date and time values.
+ */
+public class DateTimeUtilsTest {
+
+    /**
+     * The DICOM VR TM is HH[MM[SS[.FFFFFF]]]: all these forms are legal and the
+     * missing components default to 0.
+     */
+    @Test
+    public void testStringToLocalTimeAcceptsAllDicomTimeForms() {
+        Assertions.assertEquals(LocalTime.of(12, 0, 0), DateTimeUtils.stringToLocalTime("12"));
+        Assertions.assertEquals(LocalTime.of(12, 21, 0), DateTimeUtils.stringToLocalTime("1221"));
+        Assertions.assertEquals(LocalTime.of(12, 21, 5), DateTimeUtils.stringToLocalTime("122105"));
+    }
+
+    /**
+     * The fractional part holds one to six digits. 120000.00 is a legal value that
+     * used to raise a DateTimeParseException, as only six digits were accepted.
+     */
+    @Test
+    public void testStringToLocalTimeAcceptsOneToSixFractionalDigits() {
+        Assertions.assertEquals(LocalTime.of(12, 0, 0), DateTimeUtils.stringToLocalTime("120000.00"));
+        Assertions.assertEquals(LocalTime.of(12, 0, 0, 500000000), DateTimeUtils.stringToLocalTime("120000.5"));
+        Assertions.assertEquals(LocalTime.of(13, 57, 5, 123456000), DateTimeUtils.stringToLocalTime("135705.123456"));
+    }
+
+    /**
+     * The formats accepted before must keep working.
+     */
+    @Test
+    public void testStringToLocalTimeStillAcceptsPreviousFormats() {
+        Assertions.assertEquals(LocalTime.of(13, 57, 5), DateTimeUtils.stringToLocalTime("135705"));
+        Assertions.assertEquals(LocalTime.of(13, 57, 5, 123456000), DateTimeUtils.stringToLocalTime("135705.123456"));
+    }
+
+    /**
+     * DICOM pads values with a trailing space to reach an even length.
+     */
+    @Test
+    public void testStringToLocalTimeIgnoresPadding() {
+        Assertions.assertEquals(LocalTime.of(12, 21, 0), DateTimeUtils.stringToLocalTime("1221 "));
+    }
+
+    /**
+     * A null, empty or blank value is an absent value, not an error: a DICOM
+     * date/time tag can be present but empty (type 2).
+     */
+    @Test
+    public void testStringToLocalTimeReturnsNullForAbsentValue() {
+        Assertions.assertNull(DateTimeUtils.stringToLocalTime(null));
+        Assertions.assertNull(DateTimeUtils.stringToLocalTime(""));
+        Assertions.assertNull(DateTimeUtils.stringToLocalTime("  "));
+    }
+
+    /**
+     * A value that is not a legal TM must still be reported as a parse error, so
+     * that callers can distinguish it from an absent value.
+     */
+    @Test
+    public void testStringToLocalTimeRejectsInvalidValue() {
+        Assertions.assertThrows(DateTimeParseException.class, () -> DateTimeUtils.stringToLocalTime("not-a-time"));
+        Assertions.assertThrows(DateTimeParseException.class, () -> DateTimeUtils.stringToLocalTime("1200000"));
+        Assertions.assertThrows(DateTimeParseException.class, () -> DateTimeUtils.stringToLocalTime("250000"));
+    }
+
+    /**
+     * The DICOM VR DA is YYYYMMDD, and an empty value means absent.
+     */
+    @Test
+    public void testPacsStringToLocalDate() {
+        Assertions.assertEquals(java.time.LocalDate.of(1995, 10, 31), DateTimeUtils.pacsStringToLocalDate("19951031"));
+        Assertions.assertNull(DateTimeUtils.pacsStringToLocalDate(null));
+        Assertions.assertNull(DateTimeUtils.pacsStringToLocalDate(""));
+    }
+}


### PR DESCRIPTION
## Problem

The DICOM VR TM is `HH[MM[SS[.FFFFFF]]]`, with one to six fractional digits, and values are padded with a trailing space to an even length. `DateTimeUtils.stringToLocalTime` only tried two patterns:

```java
DateTimeFormatter fullFormatter = DateTimeFormatter.ofPattern("HHmmss.SSSSSS");
DateTimeFormatter shortFormatter = DateTimeFormatter.ofPattern("HHmmss");
```

So legal values raise a `DateTimeParseException`:

| Value | Legal TM | Before |
|---|---|---|
| `120000.00` | yes, 2 fractional digits | throws |
| `120000.5` | yes, 1 fractional digit | throws |
| `1221` | yes, HHMM | throws |
| `12` | yes, HH | throws |
| `1221 ` | yes, padded to even length | throws |

The consequences differ by caller. `DicomProcessing.parseAcquisitionStartTime` catches `DateTimeParseException` and returns null, so the MR, CT, PET and XA strategies silently lose the acquisition time on such a value. `GenericDatasetAcquisitionStrategy` inlines the same call with no guard, so the import fails outright.

This came up while investigating RTSTRUCT import failures: `120000.00` is a common value in the wild, and the reporter identified the parser range as the second of the two ways that line can fail.

## Fix

Replace the two patterns with a single formatter built from optional sections covering the whole TM range, defaulting the components that are not present to 0, and trim the padding.

Values that are not legal TM still raise a `DateTimeParseException`, so callers keep being able to tell a malformed value from an absent one. A blank value is now treated like an empty one and returns null, consistent with a type 2 tag being present but empty.

The change is strictly more permissive: everything that parsed before parses identically.

## Scope

`stringToLocalTime` has two production callers, both in `shanoir-ng-datasets`:

- `DicomProcessing.parseAcquisitionStartTime` — catches the exception, unaffected
- `GenericDatasetAcquisitionStrategy` — stops failing the import on a badly formatted time

Neither relies on the exception to detect an absent value.

## Relationship to #3704

Independent and complementary; they touch different files and can merge in either order.

#3704 fixes the case where the acquisition date/time tags are **absent**, which is what makes RTSTRUCT fail 100% of the time. This PR fixes the case where they are **present but in a shape the parser did not accept**. Together they close both ways `GenericDatasetAcquisitionStrategy` could fail on a timestamp.

## Tests

Adds `DateTimeUtilsTest`, covering every TM form, one to six fractional digits, the previously accepted formats, trailing padding, null/empty/blank, and invalid values still raising. It also covers `pacsStringToLocalDate`.

This is the first test in `shanoir-ng-ms-common`. No pom change was needed: `spring-boot-starter-test` is already inherited from the parent.

```
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
```

Checkstyle passes on the module with `includeTestSourceDirectory` (0 violations).