### PR TITLE
hotfix/dataset-user-id: PR #3673 fixes

### DIFF
--- a/docker-compose/database-migrations/db-changes/datasets/0078_add_user_id_to_dataset.sql
+++ b/docker-compose/database-migrations/db-changes/datasets/0078_add_user_id_to_dataset.sql
@@ -10,4 +10,4 @@
 -- You should have received a copy of the GNU General Public License
 -- along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 
-ALTER TABLE dataset ADD COLUMN is_active BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE dataset ADD COLUMN user_id BIGINT DEFAULT NULL;

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/model/Dataset.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/model/Dataset.java
@@ -104,8 +104,8 @@ public abstract class Dataset extends AbstractEntity {
     @LocalDateAnnotations
     private LocalDate creationDate;
 
-    /** Name of the user who imported the dataset. */
-    private String username;
+    /** Id of the user who imported the dataset. */
+    private Long userId;
 
     /**
      * Dataset Acquisition.
@@ -213,7 +213,7 @@ public abstract class Dataset extends AbstractEntity {
 
     public Dataset(Dataset d) {
         this.creationDate = d.getCreationDate();
-        this.username = d.getUsername();
+        this.userId = d.getUserId();
         this.datasetAcquisition = d.getDatasetAcquisition();
         this.datasetExpressions = new ArrayList<>(d.getDatasetExpressions().size());
         for (DatasetExpression ds : d.getDatasetExpressions()) {
@@ -259,17 +259,17 @@ public abstract class Dataset extends AbstractEntity {
     }
 
     /**
-     * @return the username of the user who imported the dataset
+     * @return the id of the user who imported the dataset
      */
-    public String getUsername() {
-        return username;
+    public Long getUserId() {
+        return userId;
     }
 
     /**
-     * @param username the username to set
+     * @param userId the userId to set
      */
-    public void setUsername(String username) {
-        this.username = username;
+    public void setUserId(Long userId) {
+        this.userId = userId;
     }
 
     /**

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/security/DatasetSecurityService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/dataset/security/DatasetSecurityService.java
@@ -158,12 +158,12 @@ public class DatasetSecurityService {
         if (dataset == null) {
             return false;
         }
-        String owner = dataset.getUsername();
+        Long owner = dataset.getUserId();
         if (owner == null) {
             return true;
         }
         Long studyId = dataset.getStudyId();
-        if (owner.equals(KeycloakUtil.getTokenUserName())
+        if (owner.equals(KeycloakUtil.getTokenUserId())
                 && hasRightOnStudy(studyId, StudyUserRight.CAN_ANNOTATE.name())) {
             return true;
         }
@@ -859,16 +859,16 @@ public class DatasetSecurityService {
         if (KeycloakUtil.isAdmin()) {
             return true;
         }
-        String userName = KeycloakUtil.getTokenUserName();
+        Long userId = KeycloakUtil.getTokenUserId();
         UserRights userRights = studyRightsService.getUserRights();
         Set<Dataset> toRemove = new HashSet<>();
         list.forEach((Dataset ds) -> {
-            String owner = ds.getUsername();
+            Long owner = ds.getUserId();
             if (owner != null) {
                 Long studyId = ds.getStudyId();
                 boolean canSeeAllAnnotations = userRights.hasStudyRights(studyId, StudyUserRight.CAN_ANNOTATE_REVIEW.name())
                         || userRights.hasStudyRights(studyId, StudyUserRight.CAN_ADMINISTRATE.name());
-                boolean ownAnnotator = owner.equals(userName)
+                boolean ownAnnotator = owner.equals(userId)
                         && userRights.hasStudyRights(studyId, StudyUserRight.CAN_ANNOTATE.name());
                 if (!canSeeAllAnnotations && !ownAnnotator) {
                     toRemove.add(ds);

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/DicomSEGAndSRImporterService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/DicomSEGAndSRImporterService.java
@@ -118,8 +118,7 @@ public class DicomSEGAndSRImporterService {
             LOG.error("Error: importDicomSEGAndSR: examination not found for StudyInstanceUID: {}", studyInstanceUID);
             return false;
         }
-        boolean canAnnotate = datasetSecurityService.hasRightOnStudy(examination.getStudyId(), StudyUserRight.CAN_ANNOTATE.name())
-                || datasetSecurityService.hasRightOnStudy(examination.getStudyId(), StudyUserRight.CAN_ANNOTATE_REVIEW.name());
+        boolean canAnnotate = datasetSecurityService.hasRightOnStudy(examination.getStudyId(), StudyUserRight.CAN_ANNOTATE.name());
         boolean canImport = datasetSecurityService.hasRightOnStudy(examination.getStudyId(), StudyUserRight.CAN_IMPORT.name());
         boolean canAdministrate = datasetSecurityService.hasRightOnStudy(examination.getStudyId(), StudyUserRight.CAN_ADMINISTRATE.name());
         if (!canAnnotate && !canImport && !canAdministrate) {
@@ -347,7 +346,7 @@ public class DicomSEGAndSRImporterService {
      * @param examination
      * @param dataset
      * @param datasetAttributes
-     * @param canAnnotate whether the importing user holds the CAN_ANNOTATE or CAN_ANNOTATE_REVIEW right
+     * @param canAnnotate whether the importing user holds the CAN_ANNOTATE right
      * @throws MalformedURLException
      * @throws ShanoirException
      */

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/DicomSEGAndSRImporterService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/DicomSEGAndSRImporterService.java
@@ -365,7 +365,7 @@ public class DicomSEGAndSRImporterService {
         newMsOrSegDataset.setCreationDate(LocalDate.now());
         // record the annotator as owner, but only when imported with the CAN_ANNOTATE right
         if (canAnnotate) {
-            newMsOrSegDataset.setUsername(KeycloakUtil.getTokenUserName());
+            newMsOrSegDataset.setUserId(KeycloakUtil.getTokenUserId());
         }
         // for rights check: keep link to original acquisition
         newMsOrSegDataset.setDatasetAcquisition(dataset.getDatasetAcquisition());

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/dataset/security/DatasetSecurityServiceTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/dataset/security/DatasetSecurityServiceTest.java
@@ -54,9 +54,9 @@ public class DatasetSecurityServiceTest {
 
     private static final Long STUDY_ID = 1L;
 
-    private static final String OWNER = "annotatorUser";
+    private static final Long OWNER = 11L;
 
-    private static final String OTHER_USER = "otherUser";
+    private static final Long OTHER_USER = 22L;
 
     private static final String DATASET_UID = "1.4.9.12.34.1.8527.0.100";
 
@@ -77,21 +77,21 @@ public class DatasetSecurityServiceTest {
     private Dataset ownedDataset() {
         Dataset dataset = new MrDataset();
         dataset.setStudyId(STUDY_ID);
-        dataset.setUsername(OWNER);
+        dataset.setUserId(OWNER);
         return dataset;
     }
 
     private Dataset unownedDataset() {
         Dataset dataset = new MrDataset();
         dataset.setStudyId(STUDY_ID);
-        dataset.setUsername(null);
+        dataset.setUserId(null);
         return dataset;
     }
 
-    private Dataset datasetOwnedBy(String owner) {
+    private Dataset datasetOwnedBy(Long owner) {
         Dataset dataset = new MrDataset();
         dataset.setStudyId(STUDY_ID);
-        dataset.setUsername(owner);
+        dataset.setUserId(owner);
         return dataset;
     }
 
@@ -132,7 +132,7 @@ public class DatasetSecurityServiceTest {
         when(studyRightsService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE.name())).thenReturn(true);
         try (MockedStatic<KeycloakUtil> keycloakUtilMock = Mockito.mockStatic(KeycloakUtil.class)) {
             keycloakUtilMock.when(KeycloakUtil::isAdmin).thenReturn(false);
-            keycloakUtilMock.when(KeycloakUtil::getTokenUserName).thenReturn(OWNER);
+            keycloakUtilMock.when(KeycloakUtil::getTokenUserId).thenReturn(OWNER);
             assertTrue(datasetSecurityService.hasRightToVisualizeDataset(DATASET_ID));
         }
     }
@@ -144,7 +144,7 @@ public class DatasetSecurityServiceTest {
         when(studyRightsService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE_REVIEW.name())).thenReturn(true);
         try (MockedStatic<KeycloakUtil> keycloakUtilMock = Mockito.mockStatic(KeycloakUtil.class)) {
             keycloakUtilMock.when(KeycloakUtil::isAdmin).thenReturn(false);
-            keycloakUtilMock.when(KeycloakUtil::getTokenUserName).thenReturn(OWNER);
+            keycloakUtilMock.when(KeycloakUtil::getTokenUserId).thenReturn(OWNER);
             assertTrue(datasetSecurityService.hasRightToVisualizeDataset(DATASET_ID));
         }
     }
@@ -156,7 +156,7 @@ public class DatasetSecurityServiceTest {
         when(studyRightsService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE_REVIEW.name())).thenReturn(false);
         try (MockedStatic<KeycloakUtil> keycloakUtilMock = Mockito.mockStatic(KeycloakUtil.class)) {
             keycloakUtilMock.when(KeycloakUtil::isAdmin).thenReturn(false);
-            keycloakUtilMock.when(KeycloakUtil::getTokenUserName).thenReturn(OWNER);
+            keycloakUtilMock.when(KeycloakUtil::getTokenUserId).thenReturn(OWNER);
             assertFalse(datasetSecurityService.hasRightToVisualizeDataset(DATASET_ID));
         }
     }
@@ -167,7 +167,7 @@ public class DatasetSecurityServiceTest {
         when(studyRightsService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE_REVIEW.name())).thenReturn(true);
         try (MockedStatic<KeycloakUtil> keycloakUtilMock = Mockito.mockStatic(KeycloakUtil.class)) {
             keycloakUtilMock.when(KeycloakUtil::isAdmin).thenReturn(false);
-            keycloakUtilMock.when(KeycloakUtil::getTokenUserName).thenReturn(OTHER_USER);
+            keycloakUtilMock.when(KeycloakUtil::getTokenUserId).thenReturn(OTHER_USER);
             assertTrue(datasetSecurityService.hasRightToVisualizeDataset(DATASET_ID));
         }
     }
@@ -179,7 +179,7 @@ public class DatasetSecurityServiceTest {
         when(studyRightsService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ADMINISTRATE.name())).thenReturn(true);
         try (MockedStatic<KeycloakUtil> keycloakUtilMock = Mockito.mockStatic(KeycloakUtil.class)) {
             keycloakUtilMock.when(KeycloakUtil::isAdmin).thenReturn(false);
-            keycloakUtilMock.when(KeycloakUtil::getTokenUserName).thenReturn(OTHER_USER);
+            keycloakUtilMock.when(KeycloakUtil::getTokenUserId).thenReturn(OTHER_USER);
             assertTrue(datasetSecurityService.hasRightToVisualizeDataset(DATASET_ID));
         }
     }
@@ -190,7 +190,7 @@ public class DatasetSecurityServiceTest {
         when(studyRightsService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE_REVIEW.name())).thenReturn(false);
         try (MockedStatic<KeycloakUtil> keycloakUtilMock = Mockito.mockStatic(KeycloakUtil.class)) {
             keycloakUtilMock.when(KeycloakUtil::isAdmin).thenReturn(false);
-            keycloakUtilMock.when(KeycloakUtil::getTokenUserName).thenReturn(OTHER_USER);
+            keycloakUtilMock.when(KeycloakUtil::getTokenUserId).thenReturn(OTHER_USER);
             assertFalse(datasetSecurityService.hasRightToVisualizeDataset(DATASET_ID));
         }
     }
@@ -239,7 +239,7 @@ public class DatasetSecurityServiceTest {
         when(studyRightsService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE_REVIEW.name())).thenReturn(false);
         try (MockedStatic<KeycloakUtil> keycloakUtilMock = Mockito.mockStatic(KeycloakUtil.class)) {
             keycloakUtilMock.when(KeycloakUtil::isAdmin).thenReturn(false);
-            keycloakUtilMock.when(KeycloakUtil::getTokenUserName).thenReturn(OTHER_USER);
+            keycloakUtilMock.when(KeycloakUtil::getTokenUserId).thenReturn(OTHER_USER);
             assertFalse(datasetSecurityService.hasRightToVisualizeSeries(DATASET_UID));
         }
     }
@@ -262,7 +262,7 @@ public class DatasetSecurityServiceTest {
         List<Dataset> datasets = new ArrayList<>(List.of(unownedDataset(), unownedDataset()));
         try (MockedStatic<KeycloakUtil> keycloakUtilMock = Mockito.mockStatic(KeycloakUtil.class)) {
             keycloakUtilMock.when(KeycloakUtil::isAdmin).thenReturn(false);
-            keycloakUtilMock.when(KeycloakUtil::getTokenUserName).thenReturn(OWNER);
+            keycloakUtilMock.when(KeycloakUtil::getTokenUserId).thenReturn(OWNER);
             assertTrue(datasetSecurityService.filterAnnotationDatasetList(datasets));
         }
         // no owner: the per-study rights are never consulted
@@ -277,7 +277,7 @@ public class DatasetSecurityServiceTest {
         List<Dataset> datasets = new ArrayList<>(List.of(datasetOwnedBy(OWNER), datasetOwnedBy(OTHER_USER)));
         try (MockedStatic<KeycloakUtil> keycloakUtilMock = Mockito.mockStatic(KeycloakUtil.class)) {
             keycloakUtilMock.when(KeycloakUtil::isAdmin).thenReturn(false);
-            keycloakUtilMock.when(KeycloakUtil::getTokenUserName).thenReturn(OTHER_USER);
+            keycloakUtilMock.when(KeycloakUtil::getTokenUserId).thenReturn(OTHER_USER);
             assertTrue(datasetSecurityService.filterAnnotationDatasetList(datasets));
         }
         assertEquals(2, datasets.size());
@@ -292,7 +292,7 @@ public class DatasetSecurityServiceTest {
         List<Dataset> datasets = new ArrayList<>(List.of(datasetOwnedBy(OWNER), datasetOwnedBy(OTHER_USER)));
         try (MockedStatic<KeycloakUtil> keycloakUtilMock = Mockito.mockStatic(KeycloakUtil.class)) {
             keycloakUtilMock.when(KeycloakUtil::isAdmin).thenReturn(false);
-            keycloakUtilMock.when(KeycloakUtil::getTokenUserName).thenReturn(OTHER_USER);
+            keycloakUtilMock.when(KeycloakUtil::getTokenUserId).thenReturn(OTHER_USER);
             assertTrue(datasetSecurityService.filterAnnotationDatasetList(datasets));
         }
         assertEquals(2, datasets.size());
@@ -311,7 +311,7 @@ public class DatasetSecurityServiceTest {
         List<Dataset> datasets = new ArrayList<>(List.of(own, other, unowned));
         try (MockedStatic<KeycloakUtil> keycloakUtilMock = Mockito.mockStatic(KeycloakUtil.class)) {
             keycloakUtilMock.when(KeycloakUtil::isAdmin).thenReturn(false);
-            keycloakUtilMock.when(KeycloakUtil::getTokenUserName).thenReturn(OWNER);
+            keycloakUtilMock.when(KeycloakUtil::getTokenUserId).thenReturn(OWNER);
             assertTrue(datasetSecurityService.filterAnnotationDatasetList(datasets));
         }
         // the annotator keeps his own annotation and the unowned one, loses the other's
@@ -333,7 +333,7 @@ public class DatasetSecurityServiceTest {
         List<Dataset> datasets = new ArrayList<>(List.of(own, unowned));
         try (MockedStatic<KeycloakUtil> keycloakUtilMock = Mockito.mockStatic(KeycloakUtil.class)) {
             keycloakUtilMock.when(KeycloakUtil::isAdmin).thenReturn(false);
-            keycloakUtilMock.when(KeycloakUtil::getTokenUserName).thenReturn(OWNER);
+            keycloakUtilMock.when(KeycloakUtil::getTokenUserId).thenReturn(OWNER);
             assertTrue(datasetSecurityService.filterAnnotationDatasetList(datasets));
         }
         // even his own annotation is removed without the CAN_ANNOTATE right; unowned stays

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/importer/service/DicomSEGAndSRImporterServiceTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/importer/service/DicomSEGAndSRImporterServiceTest.java
@@ -63,7 +63,7 @@ import org.shanoir.ng.utils.KeycloakUtil;
 import org.springframework.http.HttpStatus;
 
 /**
- * Tests for the CAN_ANNOTATE / CAN_ANNOTATE_REVIEW rights check on study level in DicomSEGAndSRImporterService.
+ * Tests for the CAN_ANNOTATE rights check on study level in DicomSEGAndSRImporterService.
  *
  * @author Adam Fragkiadakis
  */
@@ -133,7 +133,6 @@ public class DicomSEGAndSRImporterServiceTest {
     @Test
     public void importDicomSEGAndSRRefusedWithoutCanAnnotateOrCanImportRight() {
         when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE.name())).thenReturn(false);
-        when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE_REVIEW.name())).thenReturn(false);
         when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_IMPORT.name())).thenReturn(false);
         when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ADMINISTRATE.name())).thenReturn(false);
         try (MockedStatic<KeycloakUtil> keycloakUtilMock = Mockito.mockStatic(KeycloakUtil.class)) {
@@ -159,24 +158,9 @@ public class DicomSEGAndSRImporterServiceTest {
     }
 
     @Test
-    public void importDicomSEGAndSRProceedsWithCanAnnotateReviewRight() throws Exception {
-        // CAN_ANNOTATE_REVIEW grants the annotation rights of CAN_ANNOTATE
-        when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE.name())).thenReturn(false);
-        when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE_REVIEW.name())).thenReturn(true);
-        // No ReferencedSeriesSequence in the SEG: the import continues past the rights
-        // check and only stops later, when the source dataset cannot be found (returns false)
-        boolean result = dicomSEGAndSRImporterService.importDicomSEGAndSR(metaInformationAttributes, datasetAttributes, "SEG", true);
-        assertFalse(result);
-        verify(datasetSecurityService).hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE_REVIEW.name());
-        // The source dataset was not found, so nothing is persisted
-        verifyNoInteractions(datasetService);
-    }
-
-    @Test
     public void importDicomSEGAndSRProceedsWithCanImportRightOnly() throws Exception {
         // A user with CAN_IMPORT but not CAN_ANNOTATE is also allowed to import annotations
         when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE.name())).thenReturn(false);
-        when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE_REVIEW.name())).thenReturn(false);
         when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_IMPORT.name())).thenReturn(true);
         // No ReferencedSeriesSequence in the SEG: the import continues past the rights
         // check and only stops later, when the source dataset cannot be found (returns false)
@@ -191,7 +175,6 @@ public class DicomSEGAndSRImporterServiceTest {
     public void importDicomSEGAndSRProceedsWithCanAdministrateRightOnly() throws Exception {
         // a study administrator (study-scoped admin) is also allowed to import annotations
         when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE.name())).thenReturn(false);
-        when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE_REVIEW.name())).thenReturn(false);
         when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_IMPORT.name())).thenReturn(false);
         when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ADMINISTRATE.name())).thenReturn(true);
         // No ReferencedSeriesSequence in the SEG: the import continues past the rights
@@ -221,28 +204,9 @@ public class DicomSEGAndSRImporterServiceTest {
     }
 
     @Test
-    public void importDicomSEGAndSRAssignsUserIdWithCanAnnotateReviewRight() throws Exception {
-        wireSourceDatasetAndSegReferences();
-        when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE.name())).thenReturn(false);
-        when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE_REVIEW.name())).thenReturn(true);
-        when(datasetService.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
-        ArgumentCaptor<Dataset> datasetCaptor = ArgumentCaptor.forClass(Dataset.class);
-        try (MockedStatic<KeycloakUtil> keycloakUtilMock = Mockito.mockStatic(KeycloakUtil.class)) {
-            keycloakUtilMock.when(KeycloakUtil::getTokenUserName).thenReturn(USER_NAME);
-            keycloakUtilMock.when(KeycloakUtil::getTokenUserId).thenReturn(USER_ID);
-            boolean result = dicomSEGAndSRImporterService.importDicomSEGAndSR(metaInformationAttributes, datasetAttributes, "SEG", true);
-            assertTrue(result);
-        }
-        verify(datasetService).create(datasetCaptor.capture());
-        // The reviewer-annotator is recorded as the owner of the created annotation dataset
-        assertEquals(USER_ID, datasetCaptor.getValue().getUserId());
-    }
-
-    @Test
     public void importDicomSEGAndSRDoesNotAssignUserIdWithCanImportRightOnly() throws Exception {
         wireSourceDatasetAndSegReferences();
         when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE.name())).thenReturn(false);
-        when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE_REVIEW.name())).thenReturn(false);
         when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_IMPORT.name())).thenReturn(true);
         when(datasetService.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
         ArgumentCaptor<Dataset> datasetCaptor = ArgumentCaptor.forClass(Dataset.class);
@@ -257,7 +221,6 @@ public class DicomSEGAndSRImporterServiceTest {
     public void importDicomSEGAndSRDoesNotAssignUserIdWithCanAdministrateRightOnly() throws Exception {
         wireSourceDatasetAndSegReferences();
         when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE.name())).thenReturn(false);
-        when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE_REVIEW.name())).thenReturn(false);
         when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_IMPORT.name())).thenReturn(false);
         when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ADMINISTRATE.name())).thenReturn(true);
         when(datasetService.create(any())).thenAnswer(invocation -> invocation.getArgument(0));

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/importer/service/DicomSEGAndSRImporterServiceTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/importer/service/DicomSEGAndSRImporterServiceTest.java
@@ -74,6 +74,8 @@ public class DicomSEGAndSRImporterServiceTest {
 
     private static final String USER_NAME = "testUser";
 
+    private static final Long USER_ID = 42L;
+
     private static final String STUDY_INSTANCE_UID = "1.2.840.113619.2.1.1";
 
     private static final String SERIES_INSTANCE_UID = "1.2.840.113619.2.1.2";
@@ -202,23 +204,24 @@ public class DicomSEGAndSRImporterServiceTest {
     }
 
     @Test
-    public void importDicomSEGAndSRAssignsUsernameWithCanAnnotateRight() throws Exception {
+    public void importDicomSEGAndSRAssignsUserIdWithCanAnnotateRight() throws Exception {
         wireSourceDatasetAndSegReferences();
         when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE.name())).thenReturn(true);
         when(datasetService.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
         ArgumentCaptor<Dataset> datasetCaptor = ArgumentCaptor.forClass(Dataset.class);
         try (MockedStatic<KeycloakUtil> keycloakUtilMock = Mockito.mockStatic(KeycloakUtil.class)) {
             keycloakUtilMock.when(KeycloakUtil::getTokenUserName).thenReturn(USER_NAME);
+            keycloakUtilMock.when(KeycloakUtil::getTokenUserId).thenReturn(USER_ID);
             boolean result = dicomSEGAndSRImporterService.importDicomSEGAndSR(metaInformationAttributes, datasetAttributes, "SEG", true);
             assertTrue(result);
         }
         verify(datasetService).create(datasetCaptor.capture());
         // The annotator is recorded as the owner of the created annotation dataset
-        assertEquals(USER_NAME, datasetCaptor.getValue().getUsername());
+        assertEquals(USER_ID, datasetCaptor.getValue().getUserId());
     }
 
     @Test
-    public void importDicomSEGAndSRAssignsUsernameWithCanAnnotateReviewRight() throws Exception {
+    public void importDicomSEGAndSRAssignsUserIdWithCanAnnotateReviewRight() throws Exception {
         wireSourceDatasetAndSegReferences();
         when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE.name())).thenReturn(false);
         when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE_REVIEW.name())).thenReturn(true);
@@ -226,16 +229,17 @@ public class DicomSEGAndSRImporterServiceTest {
         ArgumentCaptor<Dataset> datasetCaptor = ArgumentCaptor.forClass(Dataset.class);
         try (MockedStatic<KeycloakUtil> keycloakUtilMock = Mockito.mockStatic(KeycloakUtil.class)) {
             keycloakUtilMock.when(KeycloakUtil::getTokenUserName).thenReturn(USER_NAME);
+            keycloakUtilMock.when(KeycloakUtil::getTokenUserId).thenReturn(USER_ID);
             boolean result = dicomSEGAndSRImporterService.importDicomSEGAndSR(metaInformationAttributes, datasetAttributes, "SEG", true);
             assertTrue(result);
         }
         verify(datasetService).create(datasetCaptor.capture());
         // The reviewer-annotator is recorded as the owner of the created annotation dataset
-        assertEquals(USER_NAME, datasetCaptor.getValue().getUsername());
+        assertEquals(USER_ID, datasetCaptor.getValue().getUserId());
     }
 
     @Test
-    public void importDicomSEGAndSRDoesNotAssignUsernameWithCanImportRightOnly() throws Exception {
+    public void importDicomSEGAndSRDoesNotAssignUserIdWithCanImportRightOnly() throws Exception {
         wireSourceDatasetAndSegReferences();
         when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE.name())).thenReturn(false);
         when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE_REVIEW.name())).thenReturn(false);
@@ -246,11 +250,11 @@ public class DicomSEGAndSRImporterServiceTest {
         assertTrue(result);
         verify(datasetService).create(datasetCaptor.capture());
         // A CAN_IMPORT-only import does not record an annotator
-        assertNull(datasetCaptor.getValue().getUsername());
+        assertNull(datasetCaptor.getValue().getUserId());
     }
 
     @Test
-    public void importDicomSEGAndSRDoesNotAssignUsernameWithCanAdministrateRightOnly() throws Exception {
+    public void importDicomSEGAndSRDoesNotAssignUserIdWithCanAdministrateRightOnly() throws Exception {
         wireSourceDatasetAndSegReferences();
         when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE.name())).thenReturn(false);
         when(datasetSecurityService.hasRightOnStudy(STUDY_ID, StudyUserRight.CAN_ANNOTATE_REVIEW.name())).thenReturn(false);
@@ -262,7 +266,7 @@ public class DicomSEGAndSRImporterServiceTest {
         assertTrue(result);
         verify(datasetService).create(datasetCaptor.capture());
         // A study-administrator import behaves like CAN_IMPORT: no annotator is recorded
-        assertNull(datasetCaptor.getValue().getUsername());
+        assertNull(datasetCaptor.getValue().getUserId());
     }
 
     /**


### PR DESCRIPTION
This PR provides some small URGENT fixes for the PR #3673 

1) The database keeps the user_id in the dataset table for the datasets imported by users with CAN_ANNOTATE right.
2) Revert the right of SEG and SR importation for users with only CAN_ANNOTATE_REVIEW right.