### PR TITLE
Fix quality tags severity order

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/ImporterService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/importer/service/ImporterService.java
@@ -165,6 +165,12 @@ public class ImporterService {
             event.setMessage("[" + importJob.getStudyName() + " (n°" + importJob.getStudyId() + ")]"
                     + " Successfully created " + createdDatasetIds.size() + " dataset(s) for subject [" + importJob.getSubjectName()
                     + "] in examination [" + examination.getId() + "]");
+            // Some (but not all) series may have been excluded because a quality card tagged them ERROR:
+            // we set the report so the user knows which acquisitions were skipped and why (all-excluded
+            // is already reported via the QualityException branch below).
+            if (acquisitionsResult.qualityResult().hasError()) {
+                event.setReport(acquisitionsResult.qualityResult().toString());
+            }
             eventService.publishEvent(event);
 
             datasetsImportStatusService.markFinished(importJob.getExaminationId(), createdDatasetIds);

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/controler/QualityCardApi.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/controler/QualityCardApi.java
@@ -134,8 +134,10 @@ public interface QualityCardApi {
         @ApiResponse(responseCode = "422", description = "bad parameters"),
         @ApiResponse(responseCode = "500", description = "unexpected error")
     })
-    @RequestMapping(value = "/test/{qualityCardId}", method = RequestMethod.GET)
+    @RequestMapping(value = { "/test/{qualityCardId}", "/test/{qualityCardId}/{from}/{to}" }, method = RequestMethod.GET)
     @PreAuthorize("hasRole('ADMIN') or (hasRole('EXPERT') and @datasetSecurityService.hasRightOnQualityCard(#qualityCardId, 'CAN_ADMINISTRATE'))")
     ResponseEntity<QualityCardResult> testQualityCardOnStudy(
-            @Parameter(description = "id of the quality card", required = true) @PathVariable("qualityCardId") Long qualityCardId) throws RestServiceException, MicroServiceCommunicationException, PacsException;
+            @Parameter(description = "id of the quality card", required = true) @PathVariable("qualityCardId") Long qualityCardId,
+            @Parameter(description = "index of the first examination to test, when testing a sample") @PathVariable(value = "from", required = false) Integer from,
+            @Parameter(description = "index of the last examination to test, when testing a sample") @PathVariable(value = "to", required = false) Integer to) throws RestServiceException, MicroServiceCommunicationException, PacsException;
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/controler/QualityCardApiController.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/controler/QualityCardApiController.java
@@ -109,7 +109,7 @@ public class QualityCardApiController implements QualityCardApi {
         return new ResponseEntity<>(results, HttpStatus.OK);
     }
 
-    public ResponseEntity<QualityCardResult> testQualityCardOnStudy(Long qualityCardId) throws RestServiceException {
+    public ResponseEntity<QualityCardResult> testQualityCardOnStudy(Long qualityCardId, Integer from, Integer to) throws RestServiceException {
         QualityCard qualityCard = repository.findById(qualityCardId).orElse(null);
         if (qualityCard == null) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
@@ -117,7 +117,7 @@ public class QualityCardApiController implements QualityCardApi {
         QualityCardResult results = null;
         LOG.info("test quality card: name:" + qualityCard.getName() + ", studyId: " + qualityCard.getStudyId());
         try {
-            results = service.applyQualityCardOnStudy(qualityCard, false);
+            results = service.applyQualityCardOnStudy(qualityCard, false, from, to);
         } catch (PacsException e) {
             LOG.error(PACS_COMMUNICATION_ERROR, e);
             throw new RestServiceException(

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/model/condition/AcqMetadataCondOnAcq.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/model/condition/AcqMetadataCondOnAcq.java
@@ -74,23 +74,31 @@ public class AcqMetadataCondOnAcq extends StudyCardMetadataCondition<DatasetAcqu
     }
 
     /**
-     * Check if the condition is fulfilled for the given acquisition and append a message if not
-     * Used in QualityCardRule to check the condition and set the msg in quality report
+     * Check if the condition is fulfilled for the given acquisition and append a message describing
+     * the outcome (fulfilled or not) - the caller (QualityCardServiceImpl.conditionsfulfilled()) relies
+     * on this message being non-empty in both cases to build the quality card report.
      * @param acquisition the acquisition to check
-     * @param msg the message to append if the condition is not fulfilled
+     * @param report the message to append, describing whether/why the condition was fulfilled
      * @return true if the condition is fulfilled, false otherwise
      * @throws CheckedIllegalClassException
      */
     public boolean fulfilled(DatasetAcquisition acquisition, StringBuffer report) {
         boolean fulfilled = fulfilled(acquisition);
-        if (!fulfilled) {
-            try {
-                report.append("Condition not fulfilled for acquisition ").append(acquisition.getId()).append(" : ");
-                report.append("field ").append(this.getShanoirField().get(acquisition)).append(" value is not in ").append(this.getValues());
-            } catch (CheckedIllegalClassException e) {
-                report.append("Error occurred while checking condition for acquisition ").append(acquisition.getId());
-                LOG.error("Error occurred while checking condition for acquisition {}", acquisition.getId(), e);
+        try {
+            String fieldValue = this.getShanoirField().get(acquisition);
+            if (fulfilled) {
+                report.append("field ").append(this.getShanoirField().name()).append(", the found value ").append(fieldValue)
+                        .append(" satisfies operator ").append(this.getOperation())
+                        .append(" against the expected value(s) ").append(this.getValues());
+            } else {
+                report.append("Condition not fulfilled for acquisition id ").append(acquisition.getId()).append(" : ");
+                report.append("field ").append(this.getShanoirField().name()).append(", the found value ").append(fieldValue)
+                        .append(" does not satisfy operator ").append(this.getOperation())
+                        .append(" against the expected value(s) ").append(this.getValues());
             }
+        } catch (CheckedIllegalClassException e) {
+            report.append("Error occurred while checking condition for acquisition ").append(acquisition.getId());
+            LOG.error("Error occurred while checking condition for acquisition {}", acquisition.getId(), e);
         }
         return fulfilled;
     }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/model/condition/DICOMConditionOnDatasets.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/model/condition/DICOMConditionOnDatasets.java
@@ -57,7 +57,12 @@ public abstract class DICOMConditionOnDatasets extends CardCondition {
         this.getValues().stream().forEach(s -> LOG.debug(s));
 
         if (dicomAttributes == null) {
-            throw new IllegalArgumentException("dicomAttributes can't be null");
+            // No DICOM attributes could be retrieved for this dataset (e.g. no PACS url, dataset not
+            // found in PACS). Treated as "unknown" rather than failing the whole quality check: this
+            // dataset is excluded from cardinality counting instead of crashing the study-wide run.
+            if (report != null) report.append("\nThe condition [" + toString()
+                    + "] could not be checked on one dataset because no DICOM attributes could be retrieved for it.");
+            return null;
         }
         VR tagVr = StandardElementDictionary.INSTANCE.vrOf(dicomTag);
         VM tagVm = VM.of(dicomTag);

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/service/QualityCardService.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/service/QualityCardService.java
@@ -14,14 +14,17 @@
 
 package org.shanoir.ng.studycard.service;
 
+import java.util.List;
+
 import org.shanoir.ng.datasetacquisition.model.DatasetAcquisition;
 import org.shanoir.ng.download.AcquisitionAttributes;
-import org.shanoir.ng.shared.exception.*;
+import org.shanoir.ng.shared.exception.EntityNotFoundException;
+import org.shanoir.ng.shared.exception.PacsException;
+import org.shanoir.ng.shared.exception.RestServiceException;
+import org.shanoir.ng.shared.exception.ShanoirException;
 import org.shanoir.ng.studycard.dto.QualityCardResult;
 import org.shanoir.ng.studycard.model.QualityCard;
 import org.springframework.validation.BindingResult;
-
-import java.util.List;
 
 public interface QualityCardService {
 
@@ -57,6 +60,17 @@ public interface QualityCardService {
      * @param updateTags for testing or for real apply
      */
     QualityCardResult applyQualityCardOnStudy(QualityCard qualityCard, boolean updateTags) throws PacsException;
+
+    /**
+     * Quality cards for quality control: apply on a sample of the study's examinations only
+     * (used by the "test on sample" option for studies with too many examinations to test in full).
+     *
+     * @param qualityCard
+     * @param updateTags for testing or for real apply
+     * @param from index of the first examination to process, or null to process all
+     * @param to index of the last examination to process, or null to process all
+     */
+    QualityCardResult applyQualityCardOnStudy(QualityCard qualityCard, boolean updateTags, Integer from, Integer to) throws PacsException;
 
     QualityCardResult checkQuality(DatasetAcquisition datasetAcquisition, AcquisitionAttributes<?> acquisitionAttributes, List<QualityCard> qualityCards) throws ShanoirException;
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/service/QualityCardServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/service/QualityCardServiceImpl.java
@@ -239,6 +239,11 @@ public class QualityCardServiceImpl implements QualityCardService {
     }
 
     public QualityCardResult applyQualityCardOnStudy(QualityCard qualityCard, boolean updateTags) throws PacsException {
+        return applyQualityCardOnStudy(qualityCard, updateTags, null, null);
+    }
+
+    @Override
+    public QualityCardResult applyQualityCardOnStudy(QualityCard qualityCard, boolean updateTags, Integer from, Integer to) throws PacsException {
         long startTs = new Date().getTime();
         if (qualityCard == null)
             throw new IllegalArgumentException("qualityCard can't be null");
@@ -263,6 +268,11 @@ public class QualityCardServiceImpl implements QualityCardService {
         loadRulesLazyCollections(qualityCard.getRules(), event);
 
         List<Examination> examinations = study.getExaminations();
+        if (from != null && to != null) {
+            int start = Math.max(0, from);
+            int end = Math.min(to, examinations.size());
+            examinations = start < end ? examinations.subList(start, end) : Collections.emptyList();
+        }
 
         QualityCardResult result = new QualityCardResult();
         AtomicInteger examinationIndex = new AtomicInteger(0);

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/service/QualityCardServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/studycard/service/QualityCardServiceImpl.java
@@ -343,16 +343,25 @@ public class QualityCardServiceImpl implements QualityCardService {
 
         // In case a rule was added without condition (= set as Always in gui)
         if (rule.getConditions() == null || rule.getConditions().isEmpty()) {
+            // Several concurrently applicable rules must never let evaluation order decide the
+            // final tag: only apply this rule's tag if it's at least as severe as whatever is
+            // already set (ERROR > WARNING > VALID wins regardless of rule order).
+            boolean applied = rule.getQualityTag().isMoreSevereThan(datasetAcquisition.getQualityTag());
             QualityCardResultEntry resultEntry = initResult(datasetAcquisition);
             resultEntry.setTagSet(rule.getQualityTag());
-            resultEntry.setMessage("Tag " + rule.getQualityTag().name() + " was set by the quality card rule without any condition.");
+            if (applied) {
+                resultEntry.setMessage("Tag " + rule.getQualityTag().name() + " was set by the quality card rule without any condition.");
+                datasetAcquisition.setQualityTag(rule.getQualityTag());
+                result.addUpdatedDatasetAcquisition(datasetAcquisition);
+            } else {
+                resultEntry.setMessage("Tag " + rule.getQualityTag().name() + " was not set by the quality card rule without any condition, "
+                        + "because the more severe tag " + datasetAcquisition.getQualityTag().name() + " already applies.");
+            }
             result.add(resultEntry);
-
-            datasetAcquisition.setQualityTag(rule.getQualityTag());
-            result.addUpdatedDatasetAcquisition(datasetAcquisition);
         } else {
             ConditionResult conditionResult = conditionsfulfilled(rule, acquisitionDicomAttributes, datasetAcquisition);
-            if (conditionResult.isFulfilled()) {
+            boolean applied = conditionResult.isFulfilled() && rule.getQualityTag().isMoreSevereThan(datasetAcquisition.getQualityTag());
+            if (applied) {
                 datasetAcquisition.setQualityTag(rule.getQualityTag());
                 result.addUpdatedDatasetAcquisition(datasetAcquisition);
             }
@@ -366,9 +375,13 @@ public class QualityCardServiceImpl implements QualityCardService {
                 resultEntry.setTagSet(rule.getQualityTag());
                 // Here we use the seriesDescription attribute or the dataset acquisition ID to clearly identify the dataset acquisition concerned by the quality card result message.
                 String seriesDescription = acquisitionDicomAttributes.getFirstDatasetAttributes() != null ? acquisitionDicomAttributes.getFirstDatasetAttributes().getString(Tag.SeriesDescription) : datasetAcquisition.getId().toString();
-                if (conditionResult.isFulfilled()) {
+                if (conditionResult.isFulfilled() && applied) {
                     resultEntry.setMessage("Tag " + rule.getQualityTag().name() + " was set on acquisition " + seriesDescription
                             + " because those conditions were fulfilled : " + StringUtils.join(conditionResult.getFulfilledConditionsMsgList(), ", "));
+                } else if (conditionResult.isFulfilled()) {
+                    resultEntry.setMessage("Tag " + rule.getQualityTag().name() + " conditions were fulfilled on acquisition " + seriesDescription
+                            + " but the more severe tag " + datasetAcquisition.getQualityTag().name() + " already applies : "
+                            + StringUtils.join(conditionResult.getFulfilledConditionsMsgList(), ", "));
                 } else {
                     resultEntry.setMessage("Tag " + rule.getQualityTag().name() + " could not be set on acquisition " + seriesDescription
                             + " because those conditions failed : " + StringUtils.join(conditionResult.getUnfulfilledConditionsMsgList(), ", "));

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/studycard/QualityCardServiceTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/studycard/QualityCardServiceTest.java
@@ -36,6 +36,7 @@ import org.shanoir.ng.studycard.model.QualityCard;
 import org.shanoir.ng.studycard.model.rule.QualityCardRule;
 import org.shanoir.ng.studycard.repository.QualityCardRepository;
 import org.shanoir.ng.studycard.service.QualityCardServiceImpl;
+import org.shanoir.ng.utils.SecurityContextUtil;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
@@ -82,6 +83,10 @@ public class QualityCardServiceTest {
 
     @BeforeEach
     public void setup() throws Exception {
+        // applyQualityCardOnStudy() reads the authenticated user via KeycloakUtil.getTokenUserId() to
+        // build its ShanoirEvent; in production this comes from the request's JWT, but here there's no
+        // real HTTP request, so the security context needs to be seeded manually.
+        SecurityContextUtil.initAuthenticationContext("ROLE_ADMIN");
         given(qualityCardRepository.findAll()).willReturn(Arrays.asList(createQualityCard()));
         given(qualityCardRepository.findById(QUALITY_CARD_ID)).willReturn(Optional.of(createQualityCard()));
         given(qualityCardRepository.findByStudyId(STUDY_ID)).willReturn(Arrays.asList(createQualityCard()));

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/studycard/QualityCardServiceTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/studycard/QualityCardServiceTest.java
@@ -20,8 +20,18 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.shanoir.ng.datasetacquisition.model.DatasetAcquisition;
+import org.shanoir.ng.datasetacquisition.model.GenericDatasetAcquisition;
+import org.shanoir.ng.datasetacquisition.service.DatasetAcquisitionService;
 import org.shanoir.ng.dicom.web.StudyInstanceUIDAndSubjectNameHandler;
+import org.shanoir.ng.download.AcquisitionAttributes;
+import org.shanoir.ng.download.WADODownloaderService;
+import org.shanoir.ng.examination.model.Examination;
+import org.shanoir.ng.shared.event.ShanoirEventService;
 import org.shanoir.ng.shared.exception.EntityNotFoundException;
+import org.shanoir.ng.shared.model.Study;
+import org.shanoir.ng.shared.quality.QualityTag;
+import org.shanoir.ng.shared.repository.StudyRepository;
 import org.shanoir.ng.studycard.model.QualityCard;
 import org.shanoir.ng.studycard.model.rule.QualityCardRule;
 import org.shanoir.ng.studycard.repository.QualityCardRepository;
@@ -52,6 +62,18 @@ public class QualityCardServiceTest {
     @Mock
     private QualityCardRepository qualityCardRepository;
 
+    @Mock
+    private StudyRepository studyRepository;
+
+    @Mock
+    private WADODownloaderService downloader;
+
+    @Mock
+    private ShanoirEventService eventService;
+
+    @Mock
+    private DatasetAcquisitionService datasetAcquisitionService;
+
     @MockBean
     private StudyInstanceUIDAndSubjectNameHandler studyInstanceUIDHandler;
 
@@ -59,7 +81,7 @@ public class QualityCardServiceTest {
     private QualityCardServiceImpl qualityCardService;
 
     @BeforeEach
-    public void setup() {
+    public void setup() throws Exception {
         given(qualityCardRepository.findAll()).willReturn(Arrays.asList(createQualityCard()));
         given(qualityCardRepository.findById(QUALITY_CARD_ID)).willReturn(Optional.of(createQualityCard()));
         given(qualityCardRepository.findByStudyId(STUDY_ID)).willReturn(Arrays.asList(createQualityCard()));
@@ -67,6 +89,7 @@ public class QualityCardServiceTest {
                 .willReturn(Arrays.asList(createQualityCard()));
         given(qualityCardRepository.findByName(QUALITY_CARD_NAME)).willReturn(createQualityCard());
         given(qualityCardRepository.save(Mockito.any(QualityCard.class))).willReturn(createQualityCard());
+        given(downloader.getDicomAttributesForAcquisition(Mockito.any())).willReturn(new AcquisitionAttributes<>());
     }
 
     @Test
@@ -87,6 +110,41 @@ public class QualityCardServiceTest {
         Mockito.verify(qualityCardRepository, Mockito.never()).save(Mockito.any(QualityCard.class));
     }
 
+    /**
+     * When two rules of a quality card are both applicable to the same dataset acquisition, the
+     * resulting quality tag must be the most severe one (ERROR > WARNING > VALID), regardless of
+     * the order in which the rules were evaluated - not just "last rule wins".
+     */
+    @Test
+    public void applyQualityCardOnStudyKeepsMostSevereTagWhenErrorAppliedFirstTest() throws Exception {
+        final DatasetAcquisition acquisition = createAcquisition();
+        final QualityCard qualityCard = createQualityCard();
+        qualityCard.setRules(Arrays.asList(
+                createRuleWithoutCondition(QualityTag.ERROR),
+                createRuleWithoutCondition(QualityTag.WARNING)));
+        given(studyRepository.findByIdWithDatasetsAndDatasetFilePaths(STUDY_ID))
+                .willReturn(Optional.of(createStudyWithAcquisition(acquisition)));
+
+        qualityCardService.applyQualityCardOnStudy(qualityCard, false);
+
+        Assertions.assertEquals(QualityTag.ERROR, acquisition.getQualityTag());
+    }
+
+    @Test
+    public void applyQualityCardOnStudyKeepsMostSevereTagWhenErrorAppliedLastTest() throws Exception {
+        final DatasetAcquisition acquisition = createAcquisition();
+        final QualityCard qualityCard = createQualityCard();
+        qualityCard.setRules(Arrays.asList(
+                createRuleWithoutCondition(QualityTag.WARNING),
+                createRuleWithoutCondition(QualityTag.ERROR)));
+        given(studyRepository.findByIdWithDatasetsAndDatasetFilePaths(STUDY_ID))
+                .willReturn(Optional.of(createStudyWithAcquisition(acquisition)));
+
+        qualityCardService.applyQualityCardOnStudy(qualityCard, false);
+
+        Assertions.assertEquals(QualityTag.ERROR, acquisition.getQualityTag());
+    }
+
     private QualityCard createQualityCard() {
         final QualityCard qualityCard = new QualityCard();
         qualityCard.setId(QUALITY_CARD_ID);
@@ -95,6 +153,27 @@ public class QualityCardServiceTest {
         qualityCard.setToCheckAtImport(true);
         qualityCard.setRules(new ArrayList<QualityCardRule>());
         return qualityCard;
+    }
+
+    private DatasetAcquisition createAcquisition() {
+        final DatasetAcquisition acquisition = new GenericDatasetAcquisition();
+        acquisition.setId(1L);
+        acquisition.setExamination(new Examination());
+        return acquisition;
+    }
+
+    private QualityCardRule createRuleWithoutCondition(QualityTag tag) {
+        final QualityCardRule rule = new QualityCardRule();
+        rule.setQualityTag(tag);
+        return rule;
+    }
+
+    private Study createStudyWithAcquisition(DatasetAcquisition acquisition) {
+        final Study study = new Study();
+        study.setId(STUDY_ID);
+        acquisition.getExamination().setDatasetAcquisitions(Collections.singletonList(acquisition));
+        study.setExaminations(Collections.singletonList(acquisition.getExamination()));
+        return study;
     }
 
 }

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/studycard/QualityCardServiceTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/studycard/QualityCardServiceTest.java
@@ -44,6 +44,7 @@ import org.springframework.test.context.ActiveProfiles;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.BDDMockito.given;
@@ -176,8 +177,8 @@ public class QualityCardServiceTest {
     private Study createStudyWithAcquisition(DatasetAcquisition acquisition) {
         final Study study = new Study();
         study.setId(STUDY_ID);
-        acquisition.getExamination().setDatasetAcquisitions(Collections.singletonList(acquisition));
-        study.setExaminations(Collections.singletonList(acquisition.getExamination()));
+        acquisition.getExamination().setDatasetAcquisitions(new ArrayList<>(List.of(acquisition)));
+        study.setExaminations(new ArrayList<>(List.of(acquisition.getExamination())));
         return study;
     }
 

--- a/shanoir-ng-front/src/app/async-tasks/status/task-status.component.ts
+++ b/shanoir-ng-front/src/app/async-tasks/status/task-status.component.ts
@@ -66,27 +66,59 @@ export class TaskStatusComponent implements OnDestroy, OnChanges {
         private consoleService: ConsoleService
     ) {}
 
+    private reportFetchInFlight: boolean = false;
+
     ngOnChanges(changes: SimpleChanges): void {
         if (changes.task && this.task) {
-            this.report = null;
-            if (this.task) {
-                let reportArray: [];
-                try {
-                    reportArray = JSON.parse(this.task.report);
-                } catch {
-                    reportArray = null;
-                }
-                if (reportArray && Array.isArray(reportArray)) {
-                    this.report = new BrowserPaging(reportArray, this.reportColumns);
-                    if (this.tableRefresh) this.tableRefresh();
-                }
-            }
+            this.updateReport();
+            this.fetchReportIfNeeded();
 
             this.subscriptions.push(
                 this.notificationsService.getNotifications().subscribe(tasks => {
-                    this.task = tasks.find(task => task.id == this.task.id);
+                    // Live SSE updates only ever carry a "light" task (hasReport flag, never the
+                    // actual report content - cf. ShanoirEvent.toLightEvent()). 
+                    // Merge in place via updateWith() rather than replacing the reference : it
+                    // only overwrites report when the incoming value is truthy, so it can never
+                    // erase a report already fetched below via taskService.get().
+                    const liveTask = tasks.find(task => task.id == this.task.id);
+                    if (liveTask) this.task.updateWith(liveTask);
+                    this.updateReport();
+                    this.fetchReportIfNeeded();
                 })
             );
+        }
+    }
+
+    /**
+     * The task's report becomes available only once the job is done, but the live SSE stream
+     * never carries its actual content (only the hasReport flag) - so as soon as that flag turns
+     * true, fetch the full task once to get the real report, instead of waiting for a page reload.
+     */
+    private fetchReportIfNeeded(): void {
+        if (this.task?.hasReport && !this.task.report && !this.reportFetchInFlight) {
+            this.reportFetchInFlight = true;
+            this.taskService.get(this.task.completeId)
+                .then(fullTask => {
+                    this.task.updateWith(fullTask);
+                    this.updateReport();
+                })
+                .finally(() => this.reportFetchInFlight = false);
+        }
+    }
+
+    private updateReport(): void {
+        this.report = null;
+        if (this.task) {
+            let reportArray: [];
+            try {
+                reportArray = JSON.parse(this.task.report);
+            } catch {
+                reportArray = null;
+            }
+            if (reportArray && Array.isArray(reportArray)) {
+                this.report = new BrowserPaging(reportArray, this.reportColumns);
+                if (this.tableRefresh) this.tableRefresh();
+            }
         }
     }
 

--- a/shanoir-ng-front/src/app/async-tasks/status/task-status.component.ts
+++ b/shanoir-ng-front/src/app/async-tasks/status/task-status.component.ts
@@ -75,7 +75,7 @@ export class TaskStatusComponent implements OnDestroy, OnChanges {
 
             this.subscriptions.push(
                 this.notificationsService.getNotifications().subscribe(tasks => {
-                    // Live SSE updates only ever carry a "light" task (hasReport flag, never the
+                    // Live updates only ever carry a "light" task (hasReport flag, never the
                     // actual report content - cf. ShanoirEvent.toLightEvent()). 
                     // Merge in place via updateWith() rather than replacing the reference : it
                     // only overwrites report when the incoming value is truthy, so it can never

--- a/shanoir-ng-front/src/app/study-cards/quality-card/quality-card.component.ts
+++ b/shanoir-ng-front/src/app/study-cards/quality-card/quality-card.component.ts
@@ -198,10 +198,15 @@ export class QualityCardComponent extends EntityComponent<QualityCard> {
         });
     }
 
-    addConditionForm(form: FormGroup): FormGroup {
+    addConditionForm(form: FormGroup, previousForm?: FormGroup): FormGroup {
         if (this.mode != 'view') {
             setTimeout(() => { // prevent "changed after check" error
-                (this.form.get('conditions') as FormArray).push(form);
+                const conditions = this.form.get('conditions') as FormArray;
+                if (previousForm) {
+                    const previousIndex = conditions.controls.indexOf(previousForm);
+                    if (previousIndex > -1) conditions.removeAt(previousIndex);
+                }
+                if (form) conditions.push(form);
             });
         }
         return this.form;

--- a/shanoir-ng-front/src/app/study-cards/study-card-rules/condition/condition.component.html
+++ b/shanoir-ng-front/src/app/study-cards/study-card-rules/condition/condition.component.html
@@ -218,7 +218,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
                             }
                         </span>
                     }
-                    @if (!(condition.values[condition.values.length - 1]?.toString().length == 0)) {
+                    @if (allowsMultipleValues && !(condition.values[condition.values.length - 1]?.toString().length == 0)) {
                         <div class="add-cond-value-frame">
                             <span class="add-cond-value" (click)="onTextValueAdd()">
                                 <i class="fa-solid fa-circle-plus"></i>
@@ -242,7 +242,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
                             placeholder="select value"
                             (focusout)="valueTouched = true"></select-box>
                     }
-                    @if (condition.values[condition.values.length - 1] && condition.values.length < shanoirFieldOptions.length) {
+                    @if (allowsMultipleValues && condition.values[condition.values.length - 1] && condition.values.length < shanoirFieldOptions.length) {
                         <div class="add-cond-value-frame">
                             <span class="add-cond-value" (click)="condition.values?.push(null)">
                                 <i class="fa-solid fa-plus"></i>

--- a/shanoir-ng-front/src/app/study-cards/study-card-rules/condition/condition.component.ts
+++ b/shanoir-ng-front/src/app/study-cards/study-card-rules/condition/condition.component.ts
@@ -459,7 +459,13 @@ export class StudyCardConditionComponent implements OnInit, OnDestroy, OnChanges
         } else if (this.condition.values.length == 0) {
             this.resetValues();
         }
-        this.onConditionChange(); 
+        this.onConditionChange();
+    }
+
+    // SMALLER_THAN/BIGGER_THAN compare against a single threshold value, so offering to add
+    // several (OR-combined) values would be misleading.
+    get allowsMultipleValues(): boolean {
+        return this.condition?.operation != 'SMALLER_THAN' && this.condition?.operation != 'BIGGER_THAN';
     }
 
     private computeConditionOptions() {

--- a/shanoir-ng-front/src/app/study-cards/study-card-rules/condition/condition.component.ts
+++ b/shanoir-ng-front/src/app/study-cards/study-card-rules/condition/condition.component.ts
@@ -77,8 +77,13 @@ export class StudyCardConditionComponent implements OnInit, OnDestroy, OnChanges
     shanoirFieldTouched: boolean = false;
     private computeConditionOptionsSubscription: Subscription;
     private conditionChangeSubscription: Subscription;
-    @Input() addSubForm: (subForm: FormGroup) => FormGroup;
+    @Input() addSubForm: (subForm: FormGroup, previousForm?: FormGroup) => FormGroup;
     private parentForm: FormGroup;
+    // The form currently registered in the parent's "conditions" FormArray via addSubForm(),
+    // so it can be swapped out (not just added to) whenever this.form is rebuilt from scratch
+    // (buildForm()) - otherwise the old, now-orphaned FormGroup stays in the array forever,
+    // permanently polluting the parent form's validity with whatever state it was frozen in.
+    private registeredForm: FormGroup;
 
     constructor(
             private dicomService: DicomService,
@@ -152,6 +157,7 @@ export class StudyCardConditionComponent implements OnInit, OnDestroy, OnChanges
             });
         }
         this.parentForm = this.addSubForm(this.form);
+        this.registeredForm = this.form;
         setTimeout(() => this.init = true);
     }
 
@@ -174,6 +180,7 @@ export class StudyCardConditionComponent implements OnInit, OnDestroy, OnChanges
     ngOnDestroy(): void {
         this.computeConditionOptionsSubscription?.unsubscribe();
         this.conditionChangeSubscription?.unsubscribe();
+        this.addSubForm(null, this.registeredForm);
         setTimeout(() => {
             (this.form?.get('values') as FormArray)?.clear();
         });
@@ -250,8 +257,12 @@ export class StudyCardConditionComponent implements OnInit, OnDestroy, OnChanges
                     this.shanoirFieldOptions = null;
                 }
                 this.form = this.buildForm();
+                if (this.registeredForm) {
+                    this.parentForm = this.addSubForm(this.form, this.registeredForm);
+                    this.registeredForm = this.form;
+                }
                 this.filterOperations();
-                this.previousField = this.condition.dicomTag; 
+                this.previousField = this.condition.dicomTag;
             }
         }
     }
@@ -427,6 +438,10 @@ export class StudyCardConditionComponent implements OnInit, OnDestroy, OnChanges
             this.filterOperations();
             this.resetValues();
             this.form = this.buildForm();
+            if (this.registeredForm) {
+                this.parentForm = this.addSubForm(this.form, this.registeredForm);
+                this.registeredForm = this.form;
+            }
             this.onConditionChange();
             if (value.endsWith('OnDataset') || value.endsWith('OnDatasets')) {
                 this.fieldOptions.forEach(opt => opt.disabled = opt.section != 'Dataset');

--- a/shanoir-ng-front/src/app/study-cards/study-card-rules/quality-card-rule.component.ts
+++ b/shanoir-ng-front/src/app/study-cards/study-card-rules/quality-card-rule.component.ts
@@ -49,7 +49,7 @@ export class QualityCardRuleComponent implements OnChanges {
             new Option('WARNING', 'Warning', undefined, 'chocolate', 'fa-solid fa-triangle-exclamation'), 
             new Option('ERROR', 'Error', undefined, 'red', 'fa-solid fa-times-circle')];
     conditionFieldOptions: Option<string>[];
-    @Input() addSubForm: (subForm: FormGroup) => FormGroup;
+    @Input() addSubForm: (subForm: FormGroup, previousForm?: FormGroup) => FormGroup;
 
     constructor(public elementRef: ElementRef) { }
 

--- a/shanoir-ng-front/src/app/study-cards/study-card-rules/study-card-rule.component.ts
+++ b/shanoir-ng-front/src/app/study-cards/study-card-rules/study-card-rule.component.ts
@@ -59,7 +59,7 @@ export class StudyCardRuleComponent implements OnChanges {
     touched: boolean = false;
     assignmentFieldOptions: Option<string>[];
     conditionFieldOptions: Option<string>[];
-    @Input() addSubForm: (subForm: FormGroup) => FormGroup;
+    @Input() addSubForm: (subForm: FormGroup, previousForm?: FormGroup) => FormGroup;
 
     constructor(public elementRef: ElementRef) { }
 

--- a/shanoir-ng-front/src/app/study-cards/study-card-rules/study-card-rules.component.ts
+++ b/shanoir-ng-front/src/app/study-cards/study-card-rules/study-card-rules.component.ts
@@ -86,7 +86,7 @@ export class StudyCardRulesComponent implements OnChanges, ControlValueAccessor 
     @Output() selectedRulesChange: EventEmitter<(StudyCardRule | QualityCardRule)[]> = new EventEmitter();
     selectedRules: Map<number, (StudyCardRule | QualityCardRule)> = new Map();
     rulesToAnimate: Set<number> = new Set();
-    @Input() addSubForm: (subForm: FormGroup) => FormGroup;
+    @Input() addSubForm: (subForm: FormGroup, previousForm?: FormGroup) => FormGroup;
 
 
     constructor(

--- a/shanoir-ng-front/src/app/study-cards/study-card/study-card.component.ts
+++ b/shanoir-ng-front/src/app/study-cards/study-card/study-card.component.ts
@@ -227,10 +227,15 @@ export class StudyCardComponent extends EntityComponent<StudyCard> implements On
         });
     }
 
-    addConditionForm(form: FormGroup): FormGroup {
+    addConditionForm(form: FormGroup, previousForm?: FormGroup): FormGroup {
         if (this.mode != 'view') {
             setTimeout(() => { // prevent "changed after check" error
-                (this.form.get('conditions') as FormArray).push(form);
+                const conditions = this.form.get('conditions') as FormArray;
+                if (previousForm) {
+                    const previousIndex = conditions.controls.indexOf(previousForm);
+                    if (previousIndex > -1) conditions.removeAt(previousIndex);
+                }
+                if (form) conditions.push(form);
             });
         }
         return this.form;

--- a/shanoir-ng-ms-common/src/main/java/org/shanoir/ng/shared/quality/QualityTag.java
+++ b/shanoir-ng-ms-common/src/main/java/org/shanoir/ng/shared/quality/QualityTag.java
@@ -46,4 +46,12 @@ public enum QualityTag {
         throw new IllegalArgumentException("No matching calibration dataset type for id " + id);
     }
 
+    /**
+     * @param other the tag currently applied, may be null (no tag applied yet).
+     * @return true if this tag is worse (ERROR > WARNING > VALID) than other, or other is null.
+     */
+    public boolean isMoreSevereThan(QualityTag other) {
+        return other == null || this.id > other.id;
+    }
+
 }


### PR DESCRIPTION
This fixes 2 bugs identified with Angular 22 and OSIV testing : 

- Quality card rules were overwriting each others so only ordering them in the frontend could alter the quality tag applied in case of concurrent conditions. 
Now the more severe tag is applied if the condition is fulfilled.

- There was a bug due to Angular 22 migration where the quality card condition subForm if changed or deleted stayed in the parent FormGroup as invalid instead of being replaced. The result is that quality cards were impossible to modify and the update button was always greyed out without any error being visible.