### PR TITLE
ShUp - Fixes tmp folder deletion and improve write import-job.json method

### DIFF
--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/nominativeData/NominativeDataImportJobManager.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/nominativeData/NominativeDataImportJobManager.java
@@ -16,8 +16,6 @@ package org.shanoir.uploader.nominativeData;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
@@ -96,22 +94,13 @@ public class NominativeDataImportJobManager {
         }
     }
 
-    /**
-     * Writes the import job to a temp file next to the target, then atomically moves it into place.
-     * Made to avoid parsing failure on the next readImportJob() call if an event (crash, forced kill, sleep/shutdown)
-     * left it truncated/corrupted.
-     */
     public void writeImportJob(ImportJobBase importJob) {
         ReentrantLock lock = getLock();
         lock.lock();
-        File tmpFile = new File(this.nominativeDataJobFile.getParentFile(), this.nominativeDataJobFile.getName() + ".tmp");
         try {
-            objectMapper.writerWithDefaultPrettyPrinter().writeValue(tmpFile, importJob);
-            Files.move(tmpFile.toPath(), this.nominativeDataJobFile.toPath(),
-                    StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            objectMapper.writerWithDefaultPrettyPrinter().writeValue(this.nominativeDataJobFile, importJob);
         } catch (IOException e) {
             LOG.error("Error during import-job.json writing: {}", e.getMessage(), e);
-            tmpFile.delete();
         } finally {
             lock.unlock();
         }

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/nominativeData/NominativeDataImportJobManager.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/nominativeData/NominativeDataImportJobManager.java
@@ -16,6 +16,8 @@ package org.shanoir.uploader.nominativeData;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
@@ -94,13 +96,22 @@ public class NominativeDataImportJobManager {
         }
     }
 
+    /**
+     * Writes the import job to a temp file next to the target, then atomically moves it into place.
+     * Made to avoid parsing failure on the next readImportJob() call if an event (crash, forced kill, sleep/shutdown)
+     * left it truncated/corrupted.
+     */
     public void writeImportJob(ImportJobBase importJob) {
         ReentrantLock lock = getLock();
         lock.lock();
+        File tmpFile = new File(this.nominativeDataJobFile.getParentFile(), this.nominativeDataJobFile.getName() + ".tmp");
         try {
-            objectMapper.writerWithDefaultPrettyPrinter().writeValue(this.nominativeDataJobFile, importJob);
+            objectMapper.writerWithDefaultPrettyPrinter().writeValue(tmpFile, importJob);
+            Files.move(tmpFile.toPath(), this.nominativeDataJobFile.toPath(),
+                    StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
         } catch (IOException e) {
             LOG.error("Error during import-job.json writing: {}", e.getMessage(), e);
+            tmpFile.delete();
         } finally {
             lock.unlock();
         }

--- a/shanoir-uploader/src/main/java/org/shanoir/uploader/utils/FileUtil.java
+++ b/shanoir-uploader/src/main/java/org/shanoir/uploader/utils/FileUtil.java
@@ -124,10 +124,15 @@ public class FileUtil {
     //     }
     // }
 
-    public static void cleanTempFolders(File workFolder, String studyInstanceUID) {
+    public static void cleanTempFolders(File workFolder, String studyInstanceUID) throws IOException {
         File tempStudyInstanceUIDFolder = new File(workFolder, studyInstanceUID);
         if (tempStudyInstanceUIDFolder.exists()) {
-            tempStudyInstanceUIDFolder.delete();
+            // Delete every existing file(s) of folder before deleting it.
+            try (Stream<Path> walk = Files.walk(tempStudyInstanceUIDFolder.toPath())) {
+                walk.sorted(Comparator.reverseOrder())
+                    .map(Path::toFile)
+                    .forEach(File::delete);
+            }
             LOG.info("Temp folder of last download found and cleaned: " + tempStudyInstanceUIDFolder.getAbsolutePath());
         }
     }


### PR DESCRIPTION
Fixes https://github.com/fli-iam/shanoir-ng/issues/3665

This PR fixes the previous use of file.delete() in cleanTempFolders(), this method is not returning an Exception but simply false if executed on a non empty folder. In case of interrupted write of .dcm files (long download that fails like described in issue) the folder is not cleaned and exists in case of reattempt at downloading the same dicom study.

This PR contains also a modification of the writeImportJobJson() method that is now atomic to avoid also corrupted .json files (file is now written as a tmp file in same path and then moved once as import-job.json file)  