### PR TITLE
task/3788: Bump keycloak from version 26.2.5 -> 26.7.3

### DIFF
--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -266,7 +266,7 @@ CMD ["-jar", "/shanoir-ng-users.jar"]
 
 ################ keycloak ##################################################
 
-FROM quay.io/keycloak/keycloak:26.2.5 AS keycloak-base
+FROM quay.io/keycloak/keycloak:26.7.3 AS keycloak-base
 
 # keycloak options (https://www.keycloak.org/server/all-config)
 #

--- a/shanoir-ng-back/pom.xml
+++ b/shanoir-ng-back/pom.xml
@@ -50,7 +50,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <mapstruct.version>1.5.3.Final</mapstruct.version>
-        <keycloak.version>26.2.5</keycloak.version>
+        <keycloak.version>26.7.3</keycloak.version>
         <dcm4che.version>5.31.1</dcm4che.version>
         <checkstyle.header.file>${project.basedir}/../shanoir-ng-back/java-header</checkstyle.header.file>
         <checkstyle.config.file>${project.basedir}/../shanoir-ng-back/checkstyle.xml</checkstyle.config.file>

--- a/shanoir-ng-keycloak-auth/pom.xml
+++ b/shanoir-ng-keycloak-auth/pom.xml
@@ -28,7 +28,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>11</java.version>
 		<jboss.logging.version>3.4.1.Final</jboss.logging.version>
-		<keycloak.version>26.2.5</keycloak.version>
+		<keycloak.version>26.7.3</keycloak.version>
 	</properties>
 
 	<dependencies>

--- a/shanoir-uploader/pom.xml
+++ b/shanoir-uploader/pom.xml
@@ -33,7 +33,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 		<logback.version>1.5.3</logback.version>
 		<lombok.version>1.18.26</lombok.version>
 		<dcm4che.version>5.31.1</dcm4che.version>
-		<keycloak.version>26.2.5</keycloak.version>
+		<keycloak.version>26.7.3</keycloak.version>
 		<jackson.version>2.13.4</jackson.version>
 		<json.version>20231013</json.version>
 		<junit.jupiter.version>5.8.2</junit.jupiter.version>


### PR DESCRIPTION
This PR upgrades the keycloak version to 26.7.3

**Needs two deploys in one maintenance window.**

@a-ba we need to deploy the PR #3790 first to bump the version to 26.6.4 before bumping to the latest 26.7.3 (this PR).

Going straight from 26.2.5 to 26.7.3 **crashes on startup**:

```
INFO  Migrating older model to 26.7.0
ERROR Failed to start server in (production) mode
ERROR Cannot lazily initialize collection of role 'org.keycloak.models.jpa.entities.RealmEntity.components' with key '<master realm id>' (no session)
```

This is upstream bug [keycloak#51304](https://github.com/keycloak/keycloak/issues/51304) - open and unfixed through 26.7.3. It is not caused by our configuration.

`MigrateTo26_7_0.addOrganizationAdminRoles` iterates `getRealmsStream()` with no `ORDER BY`. When a non-master realm is processed first, the Infinispan realm cache still holds stale entries left by the *earlier migration steps in the same startup*, and the detached `RealmEntity.components` collection throws. Our `shanoir-ng` realm iterates first.

Only relevant when the instance holds more than one realm. Our compose stack has `master` + `shanoir-ng`, so it applies.

## The fix -> two hops

```
26.2.5  ->  26.6.4  ->  26.7.3
```

The intermediate hop advances the DB model past 26.6.2, so the final startup
runs **only** the 26.7.0 step - with no earlier steps to leave stale cache
behind. That removes the precondition for the bug regardless of realm ordering.

### Step 1 - PR1: pin 26.6.4 (#3790)

Deploy, wait for startup, then confirm:

```sql
SELECT VERSION FROM MIGRATION_MODEL;
-- expect a row: 26.6.4
```

### Step 2 - PR2: pin 26.7.3 (this PR)

Deploy immediately after step 1. Confirm:

```sql
SELECT VERSION FROM MIGRATION_MODEL;
-- expect a row: 26.7.3
```

Closes #3788 