### PR TITLE
task/pre-3788: Bump keycloak from version 26.2.5 -> 26.6.4

### DIFF
--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -266,7 +266,7 @@ CMD ["-jar", "/shanoir-ng-users.jar"]
 
 ################ keycloak ##################################################
 
-FROM quay.io/keycloak/keycloak:26.2.5 AS keycloak-base
+FROM quay.io/keycloak/keycloak:26.6.4 AS keycloak-base
 
 # keycloak options (https://www.keycloak.org/server/all-config)
 #

--- a/shanoir-ng-back/pom.xml
+++ b/shanoir-ng-back/pom.xml
@@ -50,7 +50,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <mapstruct.version>1.5.3.Final</mapstruct.version>
-        <keycloak.version>26.2.5</keycloak.version>
+        <keycloak.version>26.6.4</keycloak.version>
         <dcm4che.version>5.31.1</dcm4che.version>
         <checkstyle.header.file>${project.basedir}/../shanoir-ng-back/java-header</checkstyle.header.file>
         <checkstyle.config.file>${project.basedir}/../shanoir-ng-back/checkstyle.xml</checkstyle.config.file>

--- a/shanoir-ng-keycloak-auth/pom.xml
+++ b/shanoir-ng-keycloak-auth/pom.xml
@@ -28,7 +28,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>11</java.version>
 		<jboss.logging.version>3.4.1.Final</jboss.logging.version>
-		<keycloak.version>26.2.5</keycloak.version>
+		<keycloak.version>26.6.4</keycloak.version>
 	</properties>
 
 	<dependencies>

--- a/shanoir-uploader/pom.xml
+++ b/shanoir-uploader/pom.xml
@@ -33,7 +33,7 @@ along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 		<logback.version>1.5.3</logback.version>
 		<lombok.version>1.18.26</lombok.version>
 		<dcm4che.version>5.31.1</dcm4che.version>
-		<keycloak.version>26.2.5</keycloak.version>
+		<keycloak.version>26.6.4</keycloak.version>
 		<jackson.version>2.13.4</jackson.version>
 		<json.version>20231013</json.version>
 		<junit.jupiter.version>5.8.2</junit.jupiter.version>


### PR DESCRIPTION
Bump keycloak to 26.6.4

IMPORTANT NOTE: MERGE AND DEPLOY THIS BRANCH BEFORE #3789 - reason is explained in #3789