### PR TITLE
issue/3813: Fix VIP execution monitoring reporting to the wrong user

### DIFF
--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/vip/executionMonitoring/service/ExecutionMonitoringServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/vip/executionMonitoring/service/ExecutionMonitoringServiceImpl.java
@@ -61,9 +61,11 @@ public class ExecutionMonitoringServiceImpl implements ExecutionMonitoringServic
     public static final float DEFAULT_PROGRESS = 0.5f;
     @Value("${vip.sleep-time}")
     private long sleepTime;
+    /** Pause observed after each polled execution, so a full queue does not hammer the VIP API. In ms. */
+    private long jobPollDelay = 10000;
     private static final Logger LOG = LoggerFactory.getLogger(ExecutionMonitoringServiceImpl.class);
     private static final String RIGHT_STR = "CAN_SEE_ALL";
-    private final ConcurrentLinkedQueue<Map<String, Object>> monitoringQueue = new ConcurrentLinkedQueue<>();
+    private final ConcurrentLinkedQueue<MonitoringJob> monitoringQueue = new ConcurrentLinkedQueue<>();
     private volatile boolean isRunning = false;
 
     @Autowired
@@ -125,12 +127,7 @@ public class ExecutionMonitoringServiceImpl implements ExecutionMonitoringServic
 
 
     public void startMonitoringJob(ExecutionMonitoring createdMonitoring, ShanoirEvent event, Integer jobsNumber) {
-        Map<String, Object> monitoringMap = new HashMap<>();
-        monitoringMap.put("monitoring", createdMonitoring);
-        monitoringMap.put("event", event);
-        monitoringMap.put("attempt", 1);
-        monitoringMap.put("jobsNumber", jobsNumber);
-        monitoringQueue.add(monitoringMap);
+        monitoringQueue.add(new MonitoringJob(createdMonitoring, event, jobsNumber));
 
         if (!isRunning) { //If we remove this line, each calling thread needs to wait the old ones to finish the synchronized block below before resuming the code execution. It's only for code performance.
             synchronized (this) { //Allow the synchronized block to be executed only by one thread at a time. It avoids concurrency
@@ -143,67 +140,13 @@ public class ExecutionMonitoringServiceImpl implements ExecutionMonitoringServic
     }
 
 
-    @Async //We keep that method async, because the startMonitoringJob ensure that only one thread of this method can exist at a time, and it doesn't block the 1st calling method
+    @Async // We keep that method async, because the startMonitoringJob ensure that only one thread of this method can exist at a time, and it doesn't block the 1st calling method
     protected void monitoringLoop() {
         while (!monitoringQueue.isEmpty()) {
             long startTime = System.currentTimeMillis();
 
-            for (Map<String, Object> emMap : monitoringQueue) {
-                ExecutionMonitoring monitoring = (ExecutionMonitoring) emMap.get("monitoring");
-                ShanoirEvent event = (ShanoirEvent) emMap.get("event");
-                Integer attempt = (Integer) emMap.get("attempt");
-                Integer jobsNumber = (Integer) emMap.get("jobsNumber");
-                String execLabel = getExecLabel(monitoring);
-
-
-                if (Objects.isNull(event) || !Objects.equals(event.getStatus(), ShanoirEvent.IN_PROGRESS)) {
-                    event = initShanoirEvent(monitoring, event, execLabel, jobsNumber);
-                    emMap.put("event", event);
-                    LOG.info("Monitoring of execution id: " + monitoring.getId() + ", identifier: " + monitoring.getPipelineIdentifier() + ", name: " + monitoring.getName() + " started");
-                }
-
-                try {
-                    VipExecutionDTO dto = executionService.getExecutionAsServiceAccount(attempt, monitoring.getIdentifier()).block();
-                    if (dto == null) {
-                        emMap.put("attempt", (Integer) emMap.get("attempt") + 1);
-                        continue;
-                    } else {
-                        emMap.put("attempt", 1);
-                    }
-
-                    switch (dto.getStatus()) {
-                        case FINISHED -> {
-                            monitoring.setJobs(dto.getJobs());
-                            monitoring.setStatus(dto.getStatus());
-                            LOG.info("Monitoring of execution id: " + monitoring.getId() + ", status: " + monitoring.getStatus());
-                            emProxyService.processFinishedJob(monitoring, event, dto.getEndDate());
-                        }
-                        case UNKNOWN, EXECUTION_FAILED, KILLED -> {
-                            monitoring.setJobs(dto.getJobs());
-                            monitoring.setStatus(dto.getStatus());
-                            LOG.info("Monitoring of execution id: " + monitoring.getId() + ", status: " + monitoring.getStatus());
-                            emProxyService.processKilledJob(monitoring, event, dto);
-                        }
-                        default -> {
-                            if (!(Objects.isNull(dto.getJobs()) || Objects.equals(dto.getJobs().size(), 0))) {
-                                Integer doneJobs = dto.getJobs().values().stream().mapToInt(e -> (ExecutionStatus.RUNNING.getRestLabel().toUpperCase().equals(e.get("status")) || ExecutionStatus.QUEUED.getRestLabel().toUpperCase().equals(e.get("status"))) ? 0 : 1).sum();
-                                updateShanoirEvent(event, doneJobs, jobsNumber, execLabel);
-                            }
-                        }
-                    }
-                    if (!Objects.equals(dto.getStatus(), ExecutionStatus.RUNNING)) {
-                        monitoringQueue.remove(emMap);
-                    }
-                    Thread.sleep(10000);
-                } catch (Exception e) {
-                    // Unwrap ReactiveException thrown from async method
-                    Throwable ex = Exceptions.unwrap(e);
-                    LOG.error("Error while monitoring processing {}. Stopping the monitoring ...", monitoring.getId(), ex.getCause());
-                    if (Objects.nonNull(event)) {
-                        setEventInError(event, execLabel + " : " + ex.getMessage());
-                    }
-                    monitoringQueue.remove(emMap);
-                }
+            for (MonitoringJob job : monitoringQueue) {
+                processMonitoringJob(job);
             }
             while (System.currentTimeMillis() - startTime < sleepTime) {
                 try {
@@ -214,6 +157,63 @@ public class ExecutionMonitoringServiceImpl implements ExecutionMonitoringServic
             }
         }
         isRunning = false;
+    }
+
+    /**
+     * Poll VIP for the state of a single queued execution and handle its outcome. The job is dropped from the
+     * monitoring queue as soon as its execution is no longer running, or if the polling itself failed.
+     */
+    private void processMonitoringJob(MonitoringJob job) {
+        ExecutionMonitoring monitoring = job.monitoring;
+        String execLabel = getExecLabel(monitoring);
+
+        if (Objects.isNull(job.event) || !Objects.equals(job.event.getStatus(), ShanoirEvent.IN_PROGRESS)) {
+            job.event = initShanoirEvent(monitoring, job.event, execLabel, job.jobsNumber);
+            LOG.info("Monitoring of execution id: " + monitoring.getId() + ", identifier: " + monitoring.getPipelineIdentifier() + ", name: " + monitoring.getName() + " started");
+        }
+
+        try {
+            VipExecutionDTO dto = executionService.getExecutionAsServiceAccount(job.attempt, monitoring.getIdentifier()).block();
+            if (dto == null) {
+                job.attempt++;
+                return;
+            } else {
+                job.attempt = 1;
+            }
+
+            switch (dto.getStatus()) {
+                case FINISHED -> {
+                    monitoring.setJobs(dto.getJobs());
+                    monitoring.setStatus(dto.getStatus());
+                    LOG.info("Monitoring of execution id: " + monitoring.getId() + ", status: " + monitoring.getStatus());
+                    emProxyService.processFinishedJob(monitoring, job.event, dto.getEndDate());
+                }
+                case UNKNOWN, EXECUTION_FAILED, KILLED -> {
+                    monitoring.setJobs(dto.getJobs());
+                    monitoring.setStatus(dto.getStatus());
+                    LOG.info("Monitoring of execution id: " + monitoring.getId() + ", status: " + monitoring.getStatus());
+                    emProxyService.processKilledJob(monitoring, job.event, dto);
+                }
+                default -> {
+                    if (!(Objects.isNull(dto.getJobs()) || Objects.equals(dto.getJobs().size(), 0))) {
+                        Integer doneJobs = dto.getJobs().values().stream().mapToInt(e -> (ExecutionStatus.RUNNING.getRestLabel().toUpperCase().equals(e.get("status")) || ExecutionStatus.QUEUED.getRestLabel().toUpperCase().equals(e.get("status"))) ? 0 : 1).sum();
+                        updateShanoirEvent(job.event, doneJobs, job.jobsNumber, execLabel);
+                    }
+                }
+            }
+            if (!Objects.equals(dto.getStatus(), ExecutionStatus.RUNNING)) {
+                monitoringQueue.remove(job);
+            }
+            Thread.sleep(jobPollDelay);
+        } catch (Exception e) {
+            // Unwrap ReactiveException thrown from async method
+            Throwable ex = Exceptions.unwrap(e);
+            LOG.error("Error while monitoring processing {}. Stopping the monitoring ...", monitoring.getId(), ex.getCause());
+            if (Objects.nonNull(job.event)) {
+                setEventInError(job.event, execLabel + " : " + ex.getMessage());
+            }
+            monitoringQueue.remove(job);
+        }
     }
 
     public String getVipIdentifierFromMonitoringId(Long id) {
@@ -331,5 +331,27 @@ public class ExecutionMonitoringServiceImpl implements ExecutionMonitoringServic
         event.setStatus(ShanoirEvent.ERROR);
         event.setProgress(1f);
         eventService.publishEvent(event);
+    }
+
+    /**
+     * A VIP execution awaiting monitoring, as held in {@link #monitoringQueue}.
+     */
+    private static final class MonitoringJob {
+
+        private final ExecutionMonitoring monitoring;
+
+        private final Integer jobsNumber;
+
+        /** Shanoir event reporting this execution to its owner, created on the first poll if not resumed from one. */
+        private ShanoirEvent event;
+
+        /** Consecutive failed attempts to read this execution from VIP, reset as soon as one succeeds. */
+        private int attempt = 1;
+
+        MonitoringJob(ExecutionMonitoring monitoring, ShanoirEvent event, Integer jobsNumber) {
+            this.monitoring = monitoring;
+            this.event = event;
+            this.jobsNumber = jobsNumber;
+        }
     }
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/vip/executionMonitoring/service/ExecutionMonitoringServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/vip/executionMonitoring/service/ExecutionMonitoringServiceImpl.java
@@ -130,7 +130,15 @@ public class ExecutionMonitoringServiceImpl implements ExecutionMonitoringServic
 
 
     public void startMonitoringJob(ExecutionMonitoring createdMonitoring, ShanoirEvent event, Integer jobsNumber) {
-        MonitoringJob job = new MonitoringJob(createdMonitoring, event, jobsNumber, KeycloakUtil.getTokenUserId());
+        if (event == null) {
+            // Report the execution to its owner right now, on their own thread. Creating the event on the first
+            // poll instead would delay it by one poll round, so a user queuing an execution while others are
+            // already being monitored would not see their task appear for several seconds. It also guarantees the
+            // event is addressed to the user who queued the execution rather than to whoever runs the loop.
+            event = createShanoirEvent(createdMonitoring, jobsNumber);
+        }
+        MonitoringJob job = new MonitoringJob(createdMonitoring, event, jobsNumber);
+        LOG.info("Monitoring of execution id: " + createdMonitoring.getId() + ", identifier: " + createdMonitoring.getPipelineIdentifier() + ", name: " + createdMonitoring.getName() + " started");
 
         // Queuing the job and starting a loop for it must be atomic with respect to the loop's own exit check, see
         // hasJobsToPoll(). The guarded section is a queue add, a boolean read and an async submit that returns at
@@ -201,9 +209,9 @@ public class ExecutionMonitoringServiceImpl implements ExecutionMonitoringServic
      * that user's rights.
      *
      * So each job is polled under a system context instead, exactly as the resumption runner already does on
-     * startup, and the owner of the execution is carried explicitly by {@link MonitoringJob#ownerId} for the sole
-     * purpose of addressing its Shanoir event. The previous context is restored afterwards so nothing leaks from
-     * one job to the next.
+     * startup, and the event addressing the execution to its owner is built upfront by {@link #startMonitoringJob}
+     * on the owner's own thread. The previous context is restored afterwards so nothing leaks from one job to the
+     * next.
      */
     private void processMonitoringJob(MonitoringJob job) {
         SecurityContext previousContext = SecurityContextHolder.getContext();
@@ -224,9 +232,9 @@ public class ExecutionMonitoringServiceImpl implements ExecutionMonitoringServic
         ExecutionMonitoring monitoring = job.monitoring;
         String execLabel = getExecLabel(monitoring);
 
-        if (Objects.isNull(job.event) || !Objects.equals(job.event.getStatus(), ShanoirEvent.IN_PROGRESS)) {
-            job.event = initShanoirEvent(monitoring, job.event, execLabel, job.jobsNumber, job.ownerId);
-            LOG.info("Monitoring of execution id: " + monitoring.getId() + ", identifier: " + monitoring.getPipelineIdentifier() + ", name: " + monitoring.getName() + " started");
+        if (!Objects.equals(job.event.getStatus(), ShanoirEvent.IN_PROGRESS)) {
+            resumeShanoirEvent(job.event, monitoring, job.jobsNumber);
+            LOG.info("Monitoring of execution id: " + monitoring.getId() + ", identifier: " + monitoring.getPipelineIdentifier() + ", name: " + monitoring.getName() + " resumed");
         }
 
         try {
@@ -299,26 +307,40 @@ public class ExecutionMonitoringServiceImpl implements ExecutionMonitoringServic
     }
 
     /**
-     * Create or update Shanoir event relative to an execution monitoring
+     * Create and publish the Shanoir event reporting an execution monitoring to its owner.
+     *
+     * Called on the thread that queues the execution, so the event is addressed to the user who launched it. The
+     * monitoring loop must never create it: it is a background task running under a system context, and it would
+     * only get to this execution once it is done polling the ones already queued.
      */
-    private ShanoirEvent initShanoirEvent(ExecutionMonitoring processing, ShanoirEvent event, String execLabel, Integer jobsNumber, Long ownerId) {
-        String startMsg = execLabel + " : " + ExecutionStatus.RUNNING.getRestLabel() + " (0/" + jobsNumber + " jobs done)";
-
-        if (event == null) {
-            event = new ShanoirEvent(
-                    ShanoirEventType.EXECUTION_MONITORING_EVENT,
-                    processing.getId().toString(),
-                    ownerId,
-                    startMsg,
-                    ShanoirEvent.IN_PROGRESS,
-                    DEFAULT_PROGRESS);
-        } else {
-            event.setMessage(startMsg);
-            event.setStatus(ShanoirEvent.IN_PROGRESS);
-            event.setProgress(DEFAULT_PROGRESS);
-        }
+    private ShanoirEvent createShanoirEvent(ExecutionMonitoring processing, Integer jobsNumber) {
+        ShanoirEvent event = new ShanoirEvent(
+                ShanoirEventType.EXECUTION_MONITORING_EVENT,
+                processing.getId().toString(),
+                KeycloakUtil.getTokenUserId(),
+                startMessage(processing, jobsNumber),
+                ShanoirEvent.IN_PROGRESS,
+                DEFAULT_PROGRESS);
         eventService.publishEvent(event);
         return event;
+    }
+
+    /**
+     * Put back in progress the event of an execution whose monitoring is resumed, typically after a restart. The
+     * event already belongs to the user who launched the execution, so its owner is left untouched.
+     */
+    private void resumeShanoirEvent(ShanoirEvent event, ExecutionMonitoring processing, Integer jobsNumber) {
+        event.setMessage(startMessage(processing, jobsNumber));
+        event.setStatus(ShanoirEvent.IN_PROGRESS);
+        event.setProgress(DEFAULT_PROGRESS);
+        eventService.publishEvent(event);
+    }
+
+    /**
+     * Message reporting an execution monitoring that has yet to complete a single job
+     */
+    private String startMessage(ExecutionMonitoring processing, Integer jobsNumber) {
+        return getExecLabel(processing) + " : " + ExecutionStatus.RUNNING.getRestLabel() + " (0/" + jobsNumber + " jobs done)";
     }
 
     /**
@@ -399,23 +421,16 @@ public class ExecutionMonitoringServiceImpl implements ExecutionMonitoringServic
 
         private final Integer jobsNumber;
 
-        /**
-         * Id of the user who queued this execution. Captured on the calling thread, because the monitoring loop
-         * that later polls this job runs under an unrelated user's context.
-         */
-        private final Long ownerId;
-
-        /** Shanoir event reporting this execution to its owner, created on the first poll if not resumed from one. */
+        /** Shanoir event reporting this execution to its owner. Never null: built when the job is queued. */
         private ShanoirEvent event;
 
         /** Consecutive failed attempts to read this execution from VIP, reset as soon as one succeeds. */
         private int attempt = 1;
 
-        MonitoringJob(ExecutionMonitoring monitoring, ShanoirEvent event, Integer jobsNumber, Long ownerId) {
+        MonitoringJob(ExecutionMonitoring monitoring, ShanoirEvent event, Integer jobsNumber) {
             this.monitoring = monitoring;
             this.event = event;
             this.jobsNumber = jobsNumber;
-            this.ownerId = ownerId;
         }
     }
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/vip/executionMonitoring/service/ExecutionMonitoringServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/vip/executionMonitoring/service/ExecutionMonitoringServiceImpl.java
@@ -21,6 +21,7 @@ import org.shanoir.ng.shared.event.ShanoirEventService;
 import org.shanoir.ng.shared.event.ShanoirEventType;
 import org.shanoir.ng.shared.exception.RestServiceException;
 import org.shanoir.ng.utils.KeycloakUtil;
+import org.shanoir.ng.utils.SecurityContextUtil;
 import org.shanoir.ng.vip.execution.dto.ExecutionCandidateDTO;
 import org.shanoir.ng.vip.execution.dto.VipExecutionDTO;
 import org.shanoir.ng.vip.execution.service.ExecutionServiceImpl;
@@ -39,6 +40,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import reactor.core.Exceptions;
@@ -127,7 +130,7 @@ public class ExecutionMonitoringServiceImpl implements ExecutionMonitoringServic
 
 
     public void startMonitoringJob(ExecutionMonitoring createdMonitoring, ShanoirEvent event, Integer jobsNumber) {
-        monitoringQueue.add(new MonitoringJob(createdMonitoring, event, jobsNumber));
+        monitoringQueue.add(new MonitoringJob(createdMonitoring, event, jobsNumber, KeycloakUtil.getTokenUserId()));
 
         if (!isRunning) { //If we remove this line, each calling thread needs to wait the old ones to finish the synchronized block below before resuming the code execution. It's only for code performance.
             synchronized (this) { //Allow the synchronized block to be executed only by one thread at a time. It avoids concurrency
@@ -160,15 +163,40 @@ public class ExecutionMonitoringServiceImpl implements ExecutionMonitoringServic
     }
 
     /**
+     * Poll one queued execution under its own, self-contained security context.
+     *
+     * The monitoring loop is a background system task shared by every user: it is started by whoever happened to
+     * queue the first execution, and the async executor pins that user's security context to the loop thread for
+     * its whole lifetime. Reading the connected user from the thread here therefore yields an arbitrary user, which
+     * is what made executions be reported to the wrong person (issue #3813). It also made result import depend on
+     * that user's rights.
+     *
+     * So each job is polled under a system context instead, exactly as the resumption runner already does on
+     * startup, and the owner of the execution is carried explicitly by {@link MonitoringJob#ownerId} for the sole
+     * purpose of addressing its Shanoir event. The previous context is restored afterwards so nothing leaks from
+     * one job to the next.
+     */
+    private void processMonitoringJob(MonitoringJob job) {
+        SecurityContext previousContext = SecurityContextHolder.getContext();
+        SecurityContextHolder.setContext(SecurityContextHolder.createEmptyContext());
+        SecurityContextUtil.initAuthenticationContext(KeycloakUtil.ROLE_ADMIN);
+        try {
+            pollMonitoringJob(job);
+        } finally {
+            SecurityContextHolder.setContext(previousContext);
+        }
+    }
+
+    /**
      * Poll VIP for the state of a single queued execution and handle its outcome. The job is dropped from the
      * monitoring queue as soon as its execution is no longer running, or if the polling itself failed.
      */
-    private void processMonitoringJob(MonitoringJob job) {
+    private void pollMonitoringJob(MonitoringJob job) {
         ExecutionMonitoring monitoring = job.monitoring;
         String execLabel = getExecLabel(monitoring);
 
         if (Objects.isNull(job.event) || !Objects.equals(job.event.getStatus(), ShanoirEvent.IN_PROGRESS)) {
-            job.event = initShanoirEvent(monitoring, job.event, execLabel, job.jobsNumber);
+            job.event = initShanoirEvent(monitoring, job.event, execLabel, job.jobsNumber, job.ownerId);
             LOG.info("Monitoring of execution id: " + monitoring.getId() + ", identifier: " + monitoring.getPipelineIdentifier() + ", name: " + monitoring.getName() + " started");
         }
 
@@ -244,14 +272,14 @@ public class ExecutionMonitoringServiceImpl implements ExecutionMonitoringServic
     /**
      * Create or update Shanoir event relative to an execution monitoring
      */
-    private ShanoirEvent initShanoirEvent(ExecutionMonitoring processing, ShanoirEvent event, String execLabel, Integer jobsNumber) {
+    private ShanoirEvent initShanoirEvent(ExecutionMonitoring processing, ShanoirEvent event, String execLabel, Integer jobsNumber, Long ownerId) {
         String startMsg = execLabel + " : " + ExecutionStatus.RUNNING.getRestLabel() + " (0/" + jobsNumber + " jobs done)";
 
         if (event == null) {
             event = new ShanoirEvent(
                     ShanoirEventType.EXECUTION_MONITORING_EVENT,
                     processing.getId().toString(),
-                    KeycloakUtil.getTokenUserId(),
+                    ownerId,
                     startMsg,
                     ShanoirEvent.IN_PROGRESS,
                     DEFAULT_PROGRESS);
@@ -342,16 +370,23 @@ public class ExecutionMonitoringServiceImpl implements ExecutionMonitoringServic
 
         private final Integer jobsNumber;
 
+        /**
+         * Id of the user who queued this execution. Captured on the calling thread, because the monitoring loop
+         * that later polls this job runs under an unrelated user's context.
+         */
+        private final Long ownerId;
+
         /** Shanoir event reporting this execution to its owner, created on the first poll if not resumed from one. */
         private ShanoirEvent event;
 
         /** Consecutive failed attempts to read this execution from VIP, reset as soon as one succeeds. */
         private int attempt = 1;
 
-        MonitoringJob(ExecutionMonitoring monitoring, ShanoirEvent event, Integer jobsNumber) {
+        MonitoringJob(ExecutionMonitoring monitoring, ShanoirEvent event, Integer jobsNumber, Long ownerId) {
             this.monitoring = monitoring;
             this.event = event;
             this.jobsNumber = jobsNumber;
+            this.ownerId = ownerId;
         }
     }
 }

--- a/shanoir-ng-datasets/src/main/java/org/shanoir/ng/vip/executionMonitoring/service/ExecutionMonitoringServiceImpl.java
+++ b/shanoir-ng-datasets/src/main/java/org/shanoir/ng/vip/executionMonitoring/service/ExecutionMonitoringServiceImpl.java
@@ -130,14 +130,16 @@ public class ExecutionMonitoringServiceImpl implements ExecutionMonitoringServic
 
 
     public void startMonitoringJob(ExecutionMonitoring createdMonitoring, ShanoirEvent event, Integer jobsNumber) {
-        monitoringQueue.add(new MonitoringJob(createdMonitoring, event, jobsNumber, KeycloakUtil.getTokenUserId()));
+        MonitoringJob job = new MonitoringJob(createdMonitoring, event, jobsNumber, KeycloakUtil.getTokenUserId());
 
-        if (!isRunning) { //If we remove this line, each calling thread needs to wait the old ones to finish the synchronized block below before resuming the code execution. It's only for code performance.
-            synchronized (this) { //Allow the synchronized block to be executed only by one thread at a time. It avoids concurrency
-                if (!isRunning) {  //In case of two calling threads hitting the 1st !isRunning check condition at the same time, it may leads to 2 distinct monitoring loop if we remove this second !isRunning check, what we want to avoid
-                    isRunning = true;
-                    emProxyService.monitoringLoop();
-                }
+        // Queuing the job and starting a loop for it must be atomic with respect to the loop's own exit check, see
+        // hasJobsToPoll(). The guarded section is a queue add, a boolean read and an async submit that returns at
+        // once, never a monitoring round, so concurrent callers are not made to wait on each other in practice.
+        synchronized (this) {
+            monitoringQueue.add(job);
+            if (!isRunning) {
+                isRunning = true;
+                emProxyService.monitoringLoop();
             }
         }
     }
@@ -145,20 +147,47 @@ public class ExecutionMonitoringServiceImpl implements ExecutionMonitoringServic
 
     @Async // We keep that method async, because the startMonitoringJob ensure that only one thread of this method can exist at a time, and it doesn't block the 1st calling method
     protected void monitoringLoop() {
-        while (!monitoringQueue.isEmpty()) {
-            long startTime = System.currentTimeMillis();
+        try {
+            while (hasJobsToPoll()) {
+                long startTime = System.currentTimeMillis();
 
-            for (MonitoringJob job : monitoringQueue) {
-                processMonitoringJob(job);
-            }
-            while (System.currentTimeMillis() - startTime < sleepTime) {
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                    LOG.error("Error in the monitoring loop", e);
+                for (MonitoringJob job : monitoringQueue) {
+                    processMonitoringJob(job);
+                }
+                while (System.currentTimeMillis() - startTime < sleepTime) {
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException e) {
+                        LOG.error("Error in the monitoring loop", e);
+                    }
                 }
             }
+        } finally {
+            releaseLoop();
         }
+    }
+
+    /**
+     * Tell whether the monitoring loop has another round to run, and release it if the queue has been drained.
+     *
+     * Reading the queue and clearing the running flag has to be atomic with respect to {@link #startMonitoringJob}:
+     * otherwise an execution queued in between is left in the queue while the loop stops believing it is empty, and
+     * nothing ever polls it again. Its owner then never hears about their execution, and its results are never
+     * imported (issue #3813).
+     */
+    private synchronized boolean hasJobsToPoll() {
+        if (monitoringQueue.isEmpty()) {
+            isRunning = false;
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Release the monitoring loop, so that the next queued execution starts a new one. Called on every exit path,
+     * as an unexpected error leaving the flag set would silently stop all VIP monitoring until the next restart.
+     */
+    private synchronized void releaseLoop() {
         isRunning = false;
     }
 

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/vip/executionMonitoring/service/ExecutionMonitoringServiceImplTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/vip/executionMonitoring/service/ExecutionMonitoringServiceImplTest.java
@@ -1,0 +1,171 @@
+/**
+ * Shanoir NG - Import, manage and share neuroimaging data
+ * Copyright (C) 2009-2019 Inria - https://www.inria.fr/
+ * Contact us on https://project.inria.fr/shanoir/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+package org.shanoir.ng.vip.executionMonitoring.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.shanoir.ng.shared.event.ShanoirEvent;
+import org.shanoir.ng.shared.event.ShanoirEventService;
+import org.shanoir.ng.utils.KeycloakUtil;
+import org.shanoir.ng.utils.SecurityContextUtil;
+import org.shanoir.ng.vip.execution.dto.VipExecutionDTO;
+import org.shanoir.ng.vip.execution.service.ExecutionServiceImpl;
+import org.shanoir.ng.vip.executionMonitoring.model.ExecutionMonitoring;
+import org.shanoir.ng.vip.executionMonitoring.model.ExecutionStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Tests that the shared VIP monitoring loop reports each execution to the user who launched it, whoever happens
+ * to be running the loop at that moment.
+ *
+ * See issue #3813: the loop is started by the first user to queue an execution and its thread keeps that user's
+ * security context, so every execution queued afterwards used to be reported to that first user.
+ */
+@ExtendWith(MockitoExtension.class)
+public class ExecutionMonitoringServiceImplTest {
+
+    private static final Long USER_A = 11L;
+
+    private static final Long USER_B = 22L;
+
+    private static final Long LOOP_RUNNER = 99L;
+
+    @Mock
+    private ShanoirEventService eventService;
+
+    @Mock
+    private ExecutionServiceImpl executionService;
+
+    @Mock
+    private ExecutionMonitoringServiceImpl emProxyService;
+
+    private ExecutionMonitoringServiceImpl service;
+
+    @BeforeEach
+    public void setUp() {
+        service = new ExecutionMonitoringServiceImpl();
+        ReflectionTestUtils.setField(service, "eventService", eventService);
+        ReflectionTestUtils.setField(service, "executionService", executionService);
+        ReflectionTestUtils.setField(service, "emProxyService", emProxyService);
+        ReflectionTestUtils.setField(service, "sleepTime", 0L);
+        ReflectionTestUtils.setField(service, "jobPollDelay", 0L);
+    }
+
+    @AfterEach
+    public void clearAuthentication() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    public void shouldReportEachExecutionToItsOwnOwner() throws Exception {
+        ExecutionMonitoring executionOfA = executionMonitoring(1L, "exec-of-a");
+        ExecutionMonitoring executionOfB = executionMonitoring(2L, "exec-of-b");
+
+        given(executionService.getExecutionAsServiceAccount(anyInt(), anyString()))
+                .willReturn(Mono.just(finishedExecution()));
+
+        queueAs(USER_A, executionOfA);
+        queueAs(USER_B, executionOfB);
+
+        runLoopAs(LOOP_RUNNER);
+
+        assertEquals(USER_A, publishedEventFor(executionOfA).getUserId());
+        assertEquals(USER_B, publishedEventFor(executionOfB).getUserId());
+    }
+
+    @Test
+    public void shouldRestoreTheCallingContextAfterEachPolledExecution() throws Exception {
+        given(executionService.getExecutionAsServiceAccount(anyInt(), anyString()))
+                .willReturn(Mono.just(finishedExecution()));
+
+        queueAs(USER_A, executionMonitoring(1L, "exec-of-a"));
+
+        runLoopAs(LOOP_RUNNER);
+
+        assertEquals(LOOP_RUNNER, KeycloakUtil.getTokenUserId());
+    }
+
+    @Test
+    public void shouldStartANewLoopOnceTheQueueHasBeenDrained() throws Exception {
+        given(executionService.getExecutionAsServiceAccount(anyInt(), anyString()))
+                .willReturn(Mono.just(finishedExecution()));
+
+        queueAs(USER_A, executionMonitoring(1L, "exec-of-a"));
+        runLoopAs(LOOP_RUNNER);
+
+        queueAs(USER_B, executionMonitoring(2L, "exec-of-b"));
+
+        verify(emProxyService, times(2)).monitoringLoop();
+    }
+
+    private void queueAs(Long userId, ExecutionMonitoring monitoring) throws Exception {
+        SecurityContextUtil.initAuthenticationContext(KeycloakUtil.ROLE_EXPERT, userId);
+        service.startMonitoringJob(monitoring, null, 1);
+    }
+
+    /**
+     * Run the monitoring loop synchronously, under a user unrelated to the queued executions. In production this
+     * is the user who queued the very first execution, kept on the loop thread by the async executor.
+     */
+    private void runLoopAs(Long userId) {
+        SecurityContextUtil.initAuthenticationContext(KeycloakUtil.ROLE_EXPERT, userId);
+        service.monitoringLoop();
+    }
+
+    private ShanoirEvent publishedEventFor(ExecutionMonitoring monitoring) {
+        ArgumentCaptor<ShanoirEvent> captor = ArgumentCaptor.forClass(ShanoirEvent.class);
+        verify(eventService, atLeastOnce()).publishEvent(captor.capture());
+
+        List<ShanoirEvent> events = captor.getAllValues().stream()
+                .filter(event -> monitoring.getId().toString().equals(event.getObjectId()))
+                .toList();
+        assertEquals(1, events.size(), "expected exactly one event for execution " + monitoring.getName());
+        return events.getFirst();
+    }
+
+    private ExecutionMonitoring executionMonitoring(Long id, String name) {
+        ExecutionMonitoring monitoring = new ExecutionMonitoring();
+        monitoring.setId(id);
+        monitoring.setName(name);
+        monitoring.setIdentifier("vip-" + id);
+        monitoring.setPipelineIdentifier("pipeline/1.0");
+        monitoring.setStatus(ExecutionStatus.RUNNING);
+        return monitoring;
+    }
+
+    private VipExecutionDTO finishedExecution() {
+        VipExecutionDTO dto = new VipExecutionDTO();
+        dto.setStatus(ExecutionStatus.FINISHED);
+        return dto;
+    }
+}

--- a/shanoir-ng-datasets/src/test/java/org/shanoir/ng/vip/executionMonitoring/service/ExecutionMonitoringServiceImplTest.java
+++ b/shanoir-ng-datasets/src/test/java/org/shanoir/ng/vip/executionMonitoring/service/ExecutionMonitoringServiceImplTest.java
@@ -21,6 +21,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.util.List;
 
@@ -101,6 +102,22 @@ public class ExecutionMonitoringServiceImplTest {
 
         assertEquals(USER_A, publishedEventFor(executionOfA).getUserId());
         assertEquals(USER_B, publishedEventFor(executionOfB).getUserId());
+    }
+
+    /**
+     * The monitoring loop reaches a newly queued execution only once it is done polling the ones queued before it,
+     * several seconds later. Its owner must be told about it as soon as it is submitted, not that late.
+     */
+    @Test
+    public void shouldReportTheExecutionBeforeItIsEverPolled() throws Exception {
+        ExecutionMonitoring executionOfB = executionMonitoring(2L, "exec-of-b");
+
+        queueAs(USER_A, executionMonitoring(1L, "exec-of-a"));
+        queueAs(USER_B, executionOfB);
+
+        // no monitoring round has run at this point
+        assertEquals(USER_B, publishedEventFor(executionOfB).getUserId());
+        verifyNoInteractions(executionService);
     }
 
     @Test


### PR DESCRIPTION
The VIP monitoring loop is shared by all users, but it is started by whoever queues the first execution and the async executor pins *that* user's security context to the loop thread for its whole life. Every execution queued afterwards had its ShanoirEvent created under that foreign identity -- so user B saw nothing and user A saw executions that were not theirs.                                                                                                                                                              

Each job is now polled under a system context, with the owner's id carried explicitly on the queue entry for the sole purpose of addressing its event. Also fixes a race where an execution queued exactly as the loop exited was left in the queue, never polled at all.

Fixes #3813 